### PR TITLE
Fix: Publishing utility module

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("com.materialkolor:material-kolor:1.0.0")
+                implementation("com.materialkolor:material-kolor:1.0.1")
             }
         }
     }
@@ -82,7 +82,7 @@ For an Android only project, add the dependency to app level `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.materialkolor:material-kolor:1.0.0")
+    implementation("com.materialkolor:material-kolor:1.0.1")
 }
 ```
 

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/blend/Blend.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/blend/Blend.kt
@@ -25,7 +25,7 @@ import com.materialkolor.utils.MathUtils.sanitizeDegreesDouble
 import kotlin.math.min
 
 /** Functions for blending in HCT and CAM16.  */
-object Blend {
+internal object Blend {
 
     /**
      * Blend the design color's HCT hue towards the key color's HCT hue, in a way that leaves the

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/common/Function.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/common/Function.kt
@@ -3,16 +3,4 @@ package com.materialkolor.common
 fun interface Function<T, R> {
 
     fun apply(t: T): R
-
-    fun <V> compose(before: Function<in V, out T>): Function<V, R> {
-        return Function { v: V -> apply(before.apply(v)) }
-    }
-
-    fun <V> andThen(after: Function<in R, out V>): Function<T, V> {
-        return Function { t: T -> after.apply(apply(t)) }
-    }
-
-    fun <T> identity(): Function<T, T> {
-        return Function { t: T -> t }
-    }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/Cam16.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/Cam16.kt
@@ -51,7 +51,7 @@ import kotlin.math.sqrt
  * For example, white under the traditional assumption of a midday sun white point is accurately
  * measured as a slightly chromatic blue by CAM16. (roughly, hue 203, chroma 3, lightness 100)
  */
-class Cam16
+internal class Cam16
 /**
  * All of the CAM16 dimensions can be calculated from 3 of the dimensions, in the following
  * combinations: - {j or q} and {c, m, or s} and hue - jstar, astar, bstar Prefer using a static

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/Hct.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/Hct.kt
@@ -112,7 +112,7 @@ class Hct private constructor(argb: Int) {
      *
      * See ViewingConditions.make for parameters affecting color appearance.
      */
-    fun inViewingConditions(vc: ViewingConditions): Hct {
+    internal fun inViewingConditions(vc: ViewingConditions): Hct {
         // 1. Use CAM16 to find XYZ coordinates of color in specified VC.
         val cam16: Cam16 = Cam16.fromInt(toInt())
         val viewedInVc: DoubleArray = cam16.xyzInViewingConditions(vc, null)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/HctSolver.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/HctSolver.kt
@@ -34,7 +34,7 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 
 /** A class that solves the HCT equation.  */
-object HctSolver {
+internal object HctSolver {
 
     val SCALED_DISCOUNT_FROM_LINRGB = arrayOf(doubleArrayOf(
         0.001200833568784504, 0.002389694492170889, 0.0002795742885861124), doubleArrayOf(

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/ViewingConditions.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/ViewingConditions.kt
@@ -39,7 +39,7 @@ import kotlin.math.sqrt
  * This class caches intermediate values of the CAM16 conversion process that depend only on
  * viewing conditions, enabling speed ups.
  */
-class ViewingConditions
+internal class ViewingConditions
 /**
  * Parameters are intermediate values of the CAM16 conversion process. Their names are shorthand
  * for technical color science terminology, this class would not benefit from documenting them

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/PointProvider.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/PointProvider.kt
@@ -16,7 +16,7 @@
 package com.materialkolor.quantize
 
 /** An interface to allow use of different color spaces by quantizers.  */
-interface PointProvider {
+internal interface PointProvider {
 
     /** The four components in the color space of an sRGB color.  */
     fun fromInt(argb: Int): DoubleArray?

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/PointProviderLab.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/PointProviderLab.kt
@@ -22,7 +22,7 @@ import com.materialkolor.utils.ColorUtils.labFromArgb
  * Provides conversions needed for K-Means quantization. Converting input to points, and converting
  * the final state of the K-Means algorithm to colors.
  */
-class PointProviderLab : PointProvider {
+internal class PointProviderLab : PointProvider {
 
     /**
      * Convert a color represented in ARGB to a 3-element array of L*a*b* coordinates of the color.

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerCelebi.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerCelebi.kt
@@ -25,7 +25,7 @@ package com.materialkolor.quantize
  * This algorithm was designed by M. Emre Celebi, and was found in their 2011 paper, Improving
  * the Performance of K-Means for Color Quantization. https://arxiv.org/abs/1101.0395
  */
-object QuantizerCelebi {
+internal object QuantizerCelebi {
 
     /**
      * Reduce the number of colors needed to represented the input, minimizing the difference between

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerMap.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerMap.kt
@@ -16,7 +16,7 @@
 package com.materialkolor.quantize
 
 /** Creates a dictionary with keys of colors, and values of count of the color  */
-class QuantizerMap : Quantizer {
+internal class QuantizerMap : Quantizer {
 
     var colorToCount: Map<Int, Int>? = null
 

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerResult.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerResult.kt
@@ -16,4 +16,4 @@
 package com.materialkolor.quantize
 
 /** Represents result of a quantizer run  */
-class QuantizerResult internal constructor(val colorToCount: Map<Int, Int>)
+internal class QuantizerResult internal constructor(val colorToCount: Map<Int, Int>)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerWsmeans.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerWsmeans.kt
@@ -32,7 +32,7 @@ import kotlin.random.Random
  * This algorithm was designed by M. Emre Celebi, and was found in their 2011 paper, Improving
  * the Performance of K-Means for Color Quantization. https://arxiv.org/abs/1101.0395
  */
-object QuantizerWsmeans {
+internal object QuantizerWsmeans {
 
     private const val MAX_ITERATIONS = 10
     private const val MIN_MOVEMENT_DISTANCE = 3.0

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerWu.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerWu.kt
@@ -26,7 +26,7 @@ import com.materialkolor.utils.ColorUtils.redFromArgb
  *
  * The algorithm was described by Xiaolin Wu in Graphic Gems II, published in 1991.
  */
-class QuantizerWu : Quantizer {
+internal class QuantizerWu : Quantizer {
 
     lateinit var weights: IntArray
     lateinit var momentsR: IntArray

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/Scheme.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/Scheme.kt
@@ -19,7 +19,7 @@ package com.materialkolor.scheme
 import com.materialkolor.palettes.CorePalette
 
 /** Represents a Material color scheme, a mapping of color roles to colors.  */
-class Scheme {
+internal class Scheme {
 
     var primary = 0
     var onPrimary = 0

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/score/Score.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/score/Score.kt
@@ -30,7 +30,7 @@ import kotlin.math.round
  * Enables use of a high cluster count for image quantization, thus ensuring colors aren't
  * muddied, while curating the high cluster count to a much smaller number of appropriate choices.
  */
-object Score {
+internal object Score {
 
     private const val TARGET_CHROMA = 48.0 // A1 Chroma
     private const val WEIGHT_PROPORTION = 0.7

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/temperature/TemperatureCache.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/temperature/TemperatureCache.kt
@@ -33,7 +33,7 @@ import kotlin.math.round
  * Analogous colors, complementary color, and cache to efficiently, lazily, generate data for
  * calculations when needed.
  */
-class TemperatureCache(private val input: Hct) {
+internal class TemperatureCache(private val input: Hct) {
 
     private var precomputedComplement: Hct? = null
     private var precomputedHctsByTemp: List<Hct>? = null

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/ColorUtils.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/ColorUtils.kt
@@ -26,7 +26,7 @@ import kotlin.math.round
  * Utility methods for color science constants and color space conversions that aren't HCT or
  * CAM16.
  */
-object ColorUtils {
+internal object ColorUtils {
 
     val SRGB_TO_XYZ = arrayOf(doubleArrayOf(0.41233895, 0.35762064, 0.18051042), doubleArrayOf(0.2126, 0.7152, 0.0722), doubleArrayOf(0.01932141, 0.11916382, 0.95034478))
     val XYZ_TO_SRGB = arrayOf(doubleArrayOf(

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/MathUtils.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/MathUtils.kt
@@ -19,7 +19,7 @@ package com.materialkolor.utils
 import kotlin.math.abs
 
 /** Utility methods for mathematical operations.  */
-object MathUtils {
+internal object MathUtils {
 
     /**
      * The signum function.

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/pow.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/pow.kt
@@ -2,5 +2,5 @@ package com.materialkolor.utils
 
 import kotlin.math.pow
 
-fun pow(base: Double, exponent: Double): Double = base.pow(exponent)
-fun pow(base: Float, exponent: Float): Float = base.pow(exponent)
+internal fun pow(base: Double, exponent: Double): Double = base.pow(exponent)
+internal fun pow(base: Float, exponent: Float): Float = base.pow(exponent)

--- a/material-kolor/build.gradle.kts
+++ b/material-kolor/build.gradle.kts
@@ -45,7 +45,7 @@ kotlin {
                 implementation(compose.runtime)
                 implementation(compose.ui)
 
-                implementation(project(":material-color-utilities"))
+                api(project(":material-color-utilities"))
             }
         }
 


### PR DESCRIPTION
The `material-color-utilities` was included into the core module via `implementation`. But the artifact wasn't published, so you would fail to sync it. This PR changes it to an `api()` call, and adds `internal` modifiers to some of the library
