### PR TITLE
Feature: Add a CompositionLocalProvider for the current seed color

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("com.materialkolor:material-kolor:1.1.0")
+                implementation("com.materialkolor:material-kolor:1.2.0")
             }
         }
     }
@@ -82,7 +82,7 @@ For an Android only project, add the dependency to app level `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.materialkolor:material-kolor:1.1.0")
+    implementation("com.materialkolor:material-kolor:1.2.0")
 }
 ```
 
@@ -90,7 +90,7 @@ dependencies {
 
 ```toml
 [versions]
-materialKolor = "1.1.0"
+materialKolor = "1.2.0"
 
 [libraries]
 materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }

--- a/demo/composeApp/src/commonMain/kotlin/com/materialkolor/demo/App.kt
+++ b/demo/composeApp/src/commonMain/kotlin/com/materialkolor/demo/App.kt
@@ -136,19 +136,8 @@ internal fun App() {
 
             Spacer(modifier = Modifier.height(8.dp))
 
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text(text = "Seed Color")
-                Spacer(modifier = Modifier.height(4.dp))
-                Box(
-                    modifier = Modifier
-                        .size(height = 32.dp, width = 80.dp)
-                        .clip(MaterialTheme.shapes.small)
-                        .background(seedColor)
-                )
-            }
+            SeedColorRow()
+
             Spacer(modifier = Modifier.height(10.dp))
             FlowRow(
                 verticalAlignment = Alignment.CenterVertically,

--- a/demo/composeApp/src/commonMain/kotlin/com/materialkolor/demo/SeedColorRow.kt
+++ b/demo/composeApp/src/commonMain/kotlin/com/materialkolor/demo/SeedColorRow.kt
@@ -1,0 +1,36 @@
+package com.materialkolor.demo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.materialkolor.LocalDynamicMaterialThemeSeed
+
+@Composable
+fun SeedColorRow() {
+    val seedColor = LocalDynamicMaterialThemeSeed.current
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(text = "Seed Color")
+        Spacer(modifier = Modifier.height(4.dp))
+        Box(
+            modifier = Modifier
+                .size(height = 32.dp, width = 80.dp)
+                .clip(MaterialTheme.shapes.small)
+                .background(seedColor)
+        )
+    }
+}

--- a/material-kolor/api/android/material-kolor.api
+++ b/material-kolor/api/android/material-kolor.api
@@ -8,6 +8,10 @@ public final class com/materialkolor/DynamicMaterialThemeKt {
 	public static final fun DynamicMaterialTheme-yWKOrZg (JZLcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class com/materialkolor/LocalDynamicMaterialThemeSeedKt {
+	public static final fun getLocalDynamicMaterialThemeSeed ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
 public final class com/materialkolor/PaletteStyle : java/lang/Enum {
 	public static final field Content Lcom/materialkolor/PaletteStyle;
 	public static final field Expressive Lcom/materialkolor/PaletteStyle;

--- a/material-kolor/api/jvm/material-kolor.api
+++ b/material-kolor/api/jvm/material-kolor.api
@@ -8,6 +8,10 @@ public final class com/materialkolor/DynamicMaterialThemeKt {
 	public static final fun DynamicMaterialTheme-yWKOrZg (JZLcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class com/materialkolor/LocalDynamicMaterialThemeSeedKt {
+	public static final fun getLocalDynamicMaterialThemeSeed ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
 public final class com/materialkolor/PaletteStyle : java/lang/Enum {
 	public static final field Content Lcom/materialkolor/PaletteStyle;
 	public static final field Expressive Lcom/materialkolor/PaletteStyle;

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -32,7 +33,9 @@ public fun DynamicMaterialTheme(
         }
     }
 
-    MaterialTheme(colorScheme = colorScheme, content = content)
+    CompositionLocalProvider(LocalDynamicMaterialThemeSeed provides seedColor) {
+        MaterialTheme(colorScheme = colorScheme, content = content)
+    }
 }
 
 @Composable
@@ -73,5 +76,7 @@ public fun AnimatedDynamicMaterialTheme(
         onError = animateColorAsState(colors.onError, animationSpec).value,
     )
 
-    MaterialTheme(colorScheme = animatedColorScheme, content = content)
+    CompositionLocalProvider(LocalDynamicMaterialThemeSeed provides seedColor) {
+        MaterialTheme(colorScheme = animatedColorScheme, content = content)
+    }
 }

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/LocalDynamicMaterialThemeSeed.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/LocalDynamicMaterialThemeSeed.kt
@@ -1,0 +1,8 @@
+package com.materialkolor
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+public val LocalDynamicMaterialThemeSeed: ProvidableCompositionLocal<Color> =
+    staticCompositionLocalOf { error("DynamicMaterialTheme not initialized") }


### PR DESCRIPTION
Add a `CompositionLocalProvider` that provides the current seed `Color`.

Usage:

```kotlin
// MyApp.kt

@Composable
fun MyApp() {
    DynamicMaterialTheme(seedColor = Color.Red) {
        // ...
    }
 }
 
 // MyComponent.kt
 
 @Composable
 fun MyComponent() {
     val seedColor = LocalDynamicMaterialThemeSeed.current
     // Do something with color
 }
 ```