### PR TITLE
Chore: Format Kotlin code in material-color-utilities module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.poko) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.dependencies)
     alias(libs.plugins.binaryCompatibility)

--- a/demo/composeApp/build.gradle.kts
+++ b/demo/composeApp/build.gradle.kts
@@ -7,10 +7,9 @@ plugins {
     alias(libs.plugins.android.application)
 }
 
-@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
 kotlin {
-    targetHierarchy.default()
-    android {
+    applyDefaultHierarchyTemplate()
+    androidTarget() {
         compilations.all {
             kotlinOptions {
                 jvmTarget = "1.8"
@@ -93,31 +92,30 @@ kotlin {
             dependencies {
             }
         }
-
     }
 }
 
 android {
     namespace = "com.materialkolor.demo"
-    compileSdk = 34
+    compileSdk = libs.versions.sdk.compile.get().toInt()
 
     defaultConfig {
         minSdk = libs.versions.sdk.min.get().toInt()
-        targetSdk = 34
+        targetSdk = libs.versions.sdk.target.get().toInt()
 
         applicationId = "com.materialkolor.demo.android"
         versionCode = 1
         versionName = "1.0.0"
     }
+
     sourceSets["main"].apply {
         manifest.srcFile("src/androidMain/AndroidManifest.xml")
-        res.srcDirs("src/androidMain/resources")
-        resources.srcDirs("src/commonMain/resources")
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+
+    kotlin {
+        jvmToolchain(jdkVersion = 11)
     }
+
     packaging {
         resources.excludes.add("META-INF/**")
     }

--- a/demo/composeApp/build.gradle.kts
+++ b/demo/composeApp/build.gradle.kts
@@ -9,13 +9,7 @@ plugins {
 
 kotlin {
     applyDefaultHierarchyTemplate()
-    androidTarget() {
-        compilations.all {
-            kotlinOptions {
-                jvmTarget = "1.8"
-            }
-        }
-    }
+    androidTarget()
 
     jvm("desktop")
 

--- a/demo/composeApp/composeApp.podspec
+++ b/demo/composeApp/composeApp.podspec
@@ -11,6 +11,17 @@ Pod::Spec.new do |spec|
     spec.ios.deployment_target = '11.0'
                 
                 
+    if !Dir.exist?('build/cocoapods/framework/ComposeApp.framework') || Dir.empty?('build/cocoapods/framework/ComposeApp.framework')
+        raise "
+
+        Kotlin framework 'ComposeApp' doesn't exist yet, so a proper Xcode project can't be generated.
+        'pod install' should be executed after running ':generateDummyFramework' Gradle task:
+
+            ./gradlew :demo:composeApp:generateDummyFramework
+
+        Alternatively, proper pod installation is performed during Gradle sync in the IDE (if Podfile location is set)"
+    end
+                
     spec.pod_target_xcconfig = {
         'KOTLIN_PROJECT_PATH' => ':demo:composeApp',
         'PRODUCT_MODULE_NAME' => 'ComposeApp',

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ espresso-core = "3.5.1"
 binaryCompatibility = "0.13.2"
 dokka = "1.9.10"
 publish = "0.25.3"
+poko = "0.15.1"
 
 [libraries]
 androidx-core = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core-ktx" }
@@ -40,6 +41,7 @@ dependencies = { id = "com.github.ben-manes.versions", version.ref = "versions" 
 binaryCompatibility = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibility" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 publish = { id = "com.vanniktech.maven.publish", version.ref = "publish" }
+poko = { id = "dev.drewhamilton.poko", version.ref = "poko" }
 
 [bundles]
 androidx = ["androidx-core", "androidx-lifecycle", "androidx-appcompat"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-sdk-target = "33"
-sdk-compile = "33"
+sdk-target = "34"
+sdk-compile = "34"
 sdk-min = "21"
 agp = "8.2.0"
 kotlin = "1.9.21"

--- a/material-color-utilities/build.gradle.kts
+++ b/material-color-utilities/build.gradle.kts
@@ -1,15 +1,14 @@
-@file:Suppress("UNUSED_VARIABLE", "OPT_IN_USAGE")
-
 plugins {
     alias(libs.plugins.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.publish)
+    alias(libs.plugins.poko)
 }
 
 kotlin {
-    targetHierarchy.default()
+    applyDefaultHierarchyTemplate()
 
-    android {
+    androidTarget {
         publishAllLibraryVariants()
     }
 
@@ -61,11 +60,6 @@ android {
         release {
             isMinifyEnabled = false
         }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlin {

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/blend/Blend.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/blend/Blend.kt
@@ -24,15 +24,18 @@ import com.materialkolor.utils.MathUtils.rotationDirection
 import com.materialkolor.utils.MathUtils.sanitizeDegreesDouble
 import kotlin.math.min
 
-/** Functions for blending in HCT and CAM16.  */
+/**
+ * Functions for blending in HCT and CAM16.
+ */
+@Suppress("unused", "MemberVisibilityCanBePrivate")
 internal object Blend {
 
     /**
      * Blend the design color's HCT hue towards the key color's HCT hue, in a way that leaves the
      * original color recognizable and recognizably shifted towards the key color.
      *
-     * @param designColor ARGB representation of an arbitrary color.
-     * @param sourceColor ARGB representation of the main theme color.
+     * @param[designColor] ARGB representation of an arbitrary color.
+     * @param[sourceColor] ARGB representation of the main theme color.
      * @return The design color with a hue shifted towards the system's color, a slightly
      * warmer/cooler variant of the design color's hue.
      */
@@ -50,9 +53,9 @@ internal object Blend {
      * Blends hue from one color into another. The chroma and tone of the original color are
      * maintained.
      *
-     * @param from ARGB representation of color
-     * @param to ARGB representation of color
-     * @param amount how much blending to perform; 0.0 >= and <= 1.0
+     * @param[from] ARGB representation of color
+     * @param[to] ARGB representation of color
+     * @param[amount] how much blending to perform; 0.0 >= and <= 1.0
      * @return from, with a hue blended towards to. Chroma and tone are constant.
      */
     fun hctHue(from: Int, to: Int, amount: Double): Int {
@@ -66,9 +69,9 @@ internal object Blend {
     /**
      * Blend in CAM16-UCS space.
      *
-     * @param from ARGB representation of color
-     * @param to ARGB representation of color
-     * @param amount how much blending to perform; 0.0 >= and <= 1.0
+     * @param[from] ARGB representation of color
+     * @param[to] ARGB representation of color
+     * @param[amount] how much blending to perform; 0.0 >= and <= 1.0
      * @return from, blended towards to. Hue, chroma, and tone will change.
      */
     fun cam16Ucs(from: Int, to: Int, amount: Double): Int {

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/contrast/Contrast.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/contrast/Contrast.kt
@@ -23,14 +23,13 @@ import kotlin.math.max
 /**
  * Color science for contrast utilities.
  *
- *
  * Utility methods for calculating contrast given two colors, or calculating a color given one
  * color and a contrast ratio.
- *
  *
  * Contrast ratio is calculated using XYZ's Y. When linearized to match human perception, Y
  * becomes HCT's tone and L*a*b*'s' L*.
  */
+@Suppress("unused", "MemberVisibilityCanBePrivate")
 object Contrast {
 
     // The minimum contrast ratio of two colors.
@@ -103,12 +102,10 @@ object Contrast {
      * Contrast ratio of two tones. T in HCT, L* in L*a*b*. Also known as luminance or perpectual
      * luminance.
      *
-     *
      * Contrast ratio is defined using Y in XYZ, relative luminance. However, relative luminance is
      * linear to number of photons, not to perception of lightness. Perceptual luminance, L* in
      * L*a*b*, T in HCT, is. Designers prefer color spaces with perceptual luminance since they're
      * accurate to the eye.
-     *
      *
      * Y and L* are pure functions of each other, so it possible to use perceptually accurate color
      * spaces, and measure contrast, and measure contrast in a much more understandable way: instead
@@ -116,16 +113,16 @@ object Contrast {
      * color's lightness to in order to reach their desired contrast, instead of guessing & checking
      * with hex codes.
      */
-    fun ratioOfTones(t1: Double, t2: Double): Double {
-        return ratioOfYs(yFromLstar(t1), yFromLstar(t2))
+    fun ratioOfTones(tone1: Double, tone2: Double): Double {
+        return ratioOfYs(yFromLstar(tone1), yFromLstar(tone2))
     }
 
     /**
      * Returns T in HCT, L* in L*a*b* >= tone parameter that ensures ratio with input T/L*. Returns -1
      * if ratio cannot be achieved.
      *
-     * @param tone Tone return value must contrast with.
-     * @param ratio Desired contrast ratio of return value and tone parameter.
+     * @param[tone] Tone return value must contrast with.
+     * @param[ratio] Desired contrast ratio of return value and tone parameter.
      */
     fun lighter(tone: Double, ratio: Double): Double {
         if (tone < 0.0 || tone > 100.0) {
@@ -156,8 +153,8 @@ object Contrast {
      * This method is unsafe because the returned value is guaranteed to be in bounds, but, the in
      * bounds return value may not reach the desired ratio.
      *
-     * @param tone Tone return value must contrast with.
-     * @param ratio Desired contrast ratio of return value and tone parameter.
+     * @param[tone] Tone return value must contrast with.
+     * @param[ratio] Desired contrast ratio of return value and tone parameter.
      */
     fun lighterUnsafe(tone: Double, ratio: Double): Double {
         val lighterSafe = lighter(tone, ratio)
@@ -168,8 +165,8 @@ object Contrast {
      * Returns T in HCT, L* in L*a*b* <= tone parameter that ensures ratio with input T/L*. Returns -1
      * if ratio cannot be achieved.
      *
-     * @param tone Tone return value must contrast with.
-     * @param ratio Desired contrast ratio of return value and tone parameter.
+     * @param[tone] Tone return value must contrast with.
+     * @param[ratio] Desired contrast ratio of return value and tone parameter.
      */
     fun darker(tone: Double, ratio: Double): Double {
         if (tone < 0.0 || tone > 100.0) {
@@ -190,9 +187,7 @@ object Contrast {
         // For information on 0.4 constant, see comment in lighter(tone, ratio).
         val returnValue = lstarFromY(darkY) - LUMINANCE_GAMUT_MAP_TOLERANCE
         // NOMUTANTS--important validation step; functions it is calling may change implementation.
-        return if (returnValue < 0 || returnValue > 100) {
-            -1.0
-        } else returnValue
+        return if (returnValue < 0 || returnValue > 100) -1.0 else returnValue
     }
 
     /**
@@ -202,8 +197,8 @@ object Contrast {
      * This method is unsafe because the returned value is guaranteed to be in bounds, but, the in
      * bounds return value may not reach the desired ratio.
      *
-     * @param tone Tone return value must contrast with.
-     * @param ratio Desired contrast ratio of return value and tone parameter.
+     * @param[tone] Tone return value must contrast with.
+     * @param[ratio] Desired contrast ratio of return value and tone parameter.
      */
     fun darkerUnsafe(tone: Double, ratio: Double): Double {
         val darkerSafe = darker(tone, ratio)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dislike/DislikeAnalyzer.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dislike/DislikeAnalyzer.kt
@@ -21,40 +21,29 @@ import kotlin.math.round
 /**
  * Check and/or fix universally disliked colors.
  *
- *
  * Color science studies of color preference indicate universal distaste for dark yellow-greens,
  * and also show this is correlated to distate for biological waste and rotting food.
- *
  *
  * See Palmer and Schloss, 2010 or Schloss and Palmer's Chapter 21 in Handbook of Color
  * Psychology (2015).
  */
-class DislikeAnalyzer private constructor() {
+@Suppress("MemberVisibilityCanBePrivate")
+object DislikeAnalyzer {
 
-    init {
-        throw UnsupportedOperationException()
+    /**
+     * Returns true if color is disliked.
+     *
+     * Disliked is defined as a dark yellow-green that is not neutral.
+     */
+    fun isDisliked(hct: Hct): Boolean {
+        val huePasses = round(hct.getHue()) in 90.0..111.0
+        val chromaPasses: Boolean = round(hct.getChroma()) > 16.0
+        val tonePasses: Boolean = round(hct.getTone()) < 65.0
+        return huePasses && chromaPasses && tonePasses
     }
 
-    companion object {
-
-        /**
-         * Returns true if color is disliked.
-         *
-         *
-         * Disliked is defined as a dark yellow-green that is not neutral.
-         */
-        fun isDisliked(hct: Hct): Boolean {
-            val huePasses = round(hct.getHue()) in 90.0..111.0
-            val chromaPasses: Boolean = round(hct.getChroma()) > 16.0
-            val tonePasses: Boolean = round(hct.getTone()) < 65.0
-            return huePasses && chromaPasses && tonePasses
-        }
-
-        /** If color is disliked, lighten it to make it likable.  */
-        fun fixIfDisliked(hct: Hct): Hct {
-            return if (isDisliked(hct)) {
-                Hct.from(hct.getHue(), hct.getChroma(), 70.0)
-            } else hct
-        }
+    /** If color is disliked, lighten it to make it likable.  */
+    fun fixIfDisliked(hct: Hct): Hct {
+        return if (isDisliked(hct)) Hct.from(hct.getHue(), hct.getChroma(), 70.0) else hct
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ContrastCurve.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ContrastCurve.kt
@@ -22,31 +22,24 @@ import com.materialkolor.utils.MathUtils.lerp
  *
  * Usually represents the contrast requirements for a dynamic color on its background. The four
  * values correspond to values for contrast levels -1.0, 0.0, 0.5, and 1.0 respectively.
- */
-class ContrastCurve
-/**
- * Creates a `ContrastCurve` object.
  *
- * @param low Value for contrast level -1.0
- * @param normal Value for contrast level 0.0
- * @param medium Value for contrast level 0.5
- * @param high Value for contrast level 1.0
- */(
-    /** Value for contrast level -1.0  */
+ * @param[low] Value for contrast level -1.0
+ * @param[normal] Value for contrast level 0.0
+ * @param[medium] Value for contrast level 0.5
+ * @param[high] Value for contrast level 1.0
+ */
+class ContrastCurve(
     private val low: Double,
-    /** Value for contrast level 0.0  */
     private val normal: Double,
-    /** Value for contrast level 0.5  */
     private val medium: Double,
-    /** Value for contrast level 1.0  */
     private val high: Double,
 ) {
 
     /**
      * Returns the value at a given contrast level.
      *
-     * @param contrastLevel The contrast ratio. 0.0 is the default (normal); -1.0 is the lowest; 1.0
-     * is the highest.
+     * @param[contrastLevel] The contrast ratio. 0.0 is the default (normal);
+     * -1.0 is the lowest; 1.0 is the highest.
      * @return The value. For contrast ratios, a number between 1.0 and 21.0.
      */
     fun get(contrastLevel: Double): Double = when {

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ContrastCurve.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ContrastCurve.kt
@@ -18,49 +18,42 @@ package com.materialkolor.dynamiccolor
 import com.materialkolor.utils.MathUtils.lerp
 
 /**
- * A class containing the contrast curve for a dynamic color on its background.
+ * A class containing a value that changes with the contrast level.
  *
- *
- * The four values correspond to contrast requirements for contrast levels -1.0, 0.0, 0.5, and
- * 1.0, respectively.
+ * Usually represents the contrast requirements for a dynamic color on its background. The four
+ * values correspond to values for contrast levels -1.0, 0.0, 0.5, and 1.0 respectively.
  */
 class ContrastCurve
 /**
  * Creates a `ContrastCurve` object.
  *
- * @param low Contrast requirement for contrast level -1.0
- * @param normal Contrast requirement for contrast level 0.0
- * @param medium Contrast requirement for contrast level 0.5
- * @param high Contrast requirement for contrast level 1.0
+ * @param low Value for contrast level -1.0
+ * @param normal Value for contrast level 0.0
+ * @param medium Value for contrast level 0.5
+ * @param high Value for contrast level 1.0
  */(
-    /** Contrast requirement for contrast level -1.0  */
+    /** Value for contrast level -1.0  */
     private val low: Double,
-    /** Contrast requirement for contrast level 0.0  */
+    /** Value for contrast level 0.0  */
     private val normal: Double,
-    /** Contrast requirement for contrast level 0.5  */
+    /** Value for contrast level 0.5  */
     private val medium: Double,
-    /** Contrast requirement for contrast level 1.0  */
-    private val high: Double
+    /** Value for contrast level 1.0  */
+    private val high: Double,
 ) {
 
     /**
-     * Returns the contrast ratio at a given contrast level.
+     * Returns the value at a given contrast level.
      *
-     * @param contrastLevel The contrast level. 0.0 is the default (normal); -1.0 is the lowest; 1.0
+     * @param contrastLevel The contrast ratio. 0.0 is the default (normal); -1.0 is the lowest; 1.0
      * is the highest.
-     * @return The contrast ratio, a number between 1.0 and 21.0.
+     * @return The value. For contrast ratios, a number between 1.0 and 21.0.
      */
-    fun getContrast(contrastLevel: Double): Double {
-        return if (contrastLevel <= -1.0) {
-            low
-        } else if (contrastLevel < 0.0) {
-            lerp(low, normal, (contrastLevel - -1) / 1)
-        } else if (contrastLevel < 0.5) {
-            lerp(normal, medium, (contrastLevel - 0) / 0.5)
-        } else if (contrastLevel < 1.0) {
-            lerp(medium, high, (contrastLevel - 0.5) / 0.5)
-        } else {
-            high
-        }
+    fun get(contrastLevel: Double): Double = when {
+        contrastLevel <= -1.0 -> low
+        contrastLevel < 0.0 -> lerp(low, normal, (contrastLevel - -1) / 1)
+        contrastLevel < 0.5 -> lerp(normal, medium, (contrastLevel - 0) / 0.5)
+        contrastLevel < 1.0 -> lerp(medium, high, (contrastLevel - 0.5) / 0.5)
+        else -> high
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/DynamicColor.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/DynamicColor.kt
@@ -240,8 +240,8 @@ class DynamicColor {
             val expansionDir = (if (scheme.isDark) 1 else -1).toDouble()
 
             // 1st round: solve to min, each
-            val nContrast: Double = nearer.contrastCurve!!.getContrast(scheme.contrastLevel)
-            val fContrast: Double = farther.contrastCurve!!.getContrast(scheme.contrastLevel)
+            val nContrast: Double = nearer.contrastCurve!!.get(scheme.contrastLevel)
+            val fContrast: Double = farther.contrastCurve!!.get(scheme.contrastLevel)
 
             // If a color is good enough, it is not adjusted.
             // Initial and adjusted tones for `nearer`
@@ -309,7 +309,7 @@ class DynamicColor {
                 return answer // No adjustment for colors with no background.
             }
             val bgTone: Double = background.apply(scheme).getTone(scheme)
-            val desiredRatio = contrastCurve?.getContrast(scheme.contrastLevel)
+            val desiredRatio = contrastCurve?.get(scheme.contrastLevel)
                 ?: return answer // No adjustment for colors with no contrast curve.
             if (Contrast.ratioOfTones(bgTone, answer) >= desiredRatio) {
                 // Don't "improve" what's good enough.

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/DynamicColor.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/DynamicColor.kt
@@ -29,19 +29,15 @@ import com.materialkolor.common.Function as Function1
 /**
  * A color that adjusts itself based on UI state, represented by DynamicScheme.
  *
- *
  * This color automatically adjusts to accommodate a desired contrast level, or other adjustments
  * such as differing in light mode versus dark mode, or what the theme is, or what the color that
  * produced the theme is, etc.
  *
- *
  * Colors without backgrounds do not change tone when contrast changes. Colors with backgrounds
  * become closer to their background as contrast lowers, and further when contrast increases.
  *
- *
  * Prefer the static constructors. They provide a much more simple interface, such as requiring
  * just a hexcode, or just a hexcode and a background.
- *
  *
  * Ultimately, each component necessary for calculating a color, adjusting it for a desired
  * contrast level, and ensuring it has a certain lightness/tone difference from another color, is

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/DynamicColor.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/DynamicColor.kt
@@ -49,11 +49,7 @@ import com.materialkolor.common.Function as Function1
  * flexibility, any desired behavior of a color for any design system, but it usually unnecessary.
  * See the default constructor for more information.
  */
-// Prevent lint for Function.apply not being available on Android before API level 14 (4.0.1).
-// "AndroidJdkLibsChecker" for Function, "NewApi" for Function.apply().
-// A java_library Bazel rule with an Android constraint cannot skip these warnings without this
-// annotation; another solution would be to create an android_library rule and supply
-// AndroidManifest with an SDK set higher than 14.
+@Suppress("MemberVisibilityCanBePrivate")
 class DynamicColor {
 
     val name: String
@@ -65,38 +61,36 @@ class DynamicColor {
     val contrastCurve: ContrastCurve?
     val toneDeltaPair: Function1<DynamicScheme, ToneDeltaPair>?
     val opacity: Function1<DynamicScheme, Double>?
-    private val hctCache: HashMap<DynamicScheme, Hct> = HashMap<DynamicScheme, Hct>()
+
+    private val hctCache: HashMap<DynamicScheme, Hct> = HashMap()
 
     /**
      * A constructor for DynamicColor.
-     *
      *
      * _Strongly_ prefer using one of the convenience constructors. This class is arguably too
      * flexible to ensure it can support any scenario. Functional arguments allow overriding without
      * risks that come with subclasses.
      *
-     *
      * For example, the default behavior of adjust tone at max contrast to be at a 7.0 ratio with
      * its background is principled and matches accessibility guidance. That does not mean it's the
      * desired approach for _every_ design system, and every color pairing, always, in every case.
      *
-     *
      * For opaque colors (colors with alpha = 100%).
      *
-     * @param name The name of the dynamic color.
-     * @param palette Function that provides a TonalPalette given DynamicScheme. A TonalPalette is
+     * @param[name] The name of the dynamic color.
+     * @param[palette] Function that provides a TonalPalette given DynamicScheme. A TonalPalette is
      * defined by a hue and chroma, so this replaces the need to specify hue/chroma. By providing
      * a tonal palette, when contrast adjustments are made, intended chroma can be preserved.
-     * @param tone Function that provides a tone, given a DynamicScheme.
-     * @param isBackground Whether this dynamic color is a background, with some other color as the
+     * @param[tone] Function that provides a tone, given a DynamicScheme.
+     * @param[isBackground] Whether this dynamic color is a background, with some other color as the
      * foreground.
-     * @param background The background of the dynamic color (as a function of a `DynamicScheme`), if
+     * @param[background] The background of the dynamic color (as a function of a `DynamicScheme`), if
      * it exists.
-     * @param secondBackground A second background of the dynamic color (as a function of a
+     * @param[secondBackground] A second background of the dynamic color (as a function of a
      * `DynamicScheme`), if it exists.
-     * @param contrastCurve A `ContrastCurve` object specifying how its contrast against its
+     * @param[contrastCurve] A `ContrastCurve` object specifying how its contrast against its
      * background should behave in various contrast levels options.
-     * @param toneDeltaPair A `ToneDeltaPair` object specifying a tone delta constraint between two
+     * @param[toneDeltaPair] A `ToneDeltaPair` object specifying a tone delta constraint between two
      * colors. One of them must be the color being constructed.
      */
     constructor(
@@ -123,35 +117,32 @@ class DynamicColor {
     /**
      * A constructor for DynamicColor.
      *
-     *
      * _Strongly_ prefer using one of the convenience constructors. This class is arguably too
      * flexible to ensure it can support any scenario. Functional arguments allow overriding without
      * risks that come with subclasses.
-     *
      *
      * For example, the default behavior of adjust tone at max contrast to be at a 7.0 ratio with
      * its background is principled and matches accessibility guidance. That does not mean it's the
      * desired approach for _every_ design system, and every color pairing, always, in every case.
      *
-     *
      * For opaque colors (colors with alpha = 100%).
      *
-     * @param name The name of the dynamic color.
-     * @param palette Function that provides a TonalPalette given DynamicScheme. A TonalPalette is
+     * @param[name] The name of the dynamic color.
+     * @param[palette] Function that provides a TonalPalette given DynamicScheme. A TonalPalette is
      * defined by a hue and chroma, so this replaces the need to specify hue/chroma. By providing
      * a tonal palette, when contrast adjustments are made, intended chroma can be preserved.
-     * @param tone Function that provides a tone, given a DynamicScheme.
-     * @param isBackground Whether this dynamic color is a background, with some other color as the
+     * @param[tone] Function that provides a tone, given a DynamicScheme.
+     * @param[isBackground] Whether this dynamic color is a background, with some other color as the
      * foreground.
-     * @param background The background of the dynamic color (as a function of a `DynamicScheme`), if
+     * @param[background] The background of the dynamic color (as a function of a `DynamicScheme`), if
      * it exists.
-     * @param secondBackground A second background of the dynamic color (as a function of a
+     * @param[secondBackground] A second background of the dynamic color (as a function of a
      * `DynamicScheme`), if it exists.
-     * @param contrastCurve A `ContrastCurve` object specifying how its contrast against its
+     * @param[contrastCurve] A `ContrastCurve` object specifying how its contrast against its
      * background should behave in various contrast levels options.
-     * @param toneDeltaPair A `ToneDeltaPair` object specifying a tone delta constraint between two
+     * @param[toneDeltaPair] A `ToneDeltaPair` object specifying a tone delta constraint between two
      * colors. One of them must be the color being constructed.
-     * @param opacity A function returning the opacity of a color, as a number between 0 and 1.
+     * @param[opacity] A function returning the opacity of a color, as a number between 0 and 1.
      */
     constructor(
         name: String,
@@ -178,14 +169,13 @@ class DynamicColor {
     /**
      * Returns an ARGB integer (i.e. a hex code).
      *
-     * @param scheme Defines the conditions of the user interface, for example, whether or not it is
+     * @param[scheme] Defines the conditions of the user interface, for example, whether or not it is
      * dark mode or light mode, and what the desired contrast level is.
      */
     fun getArgb(scheme: DynamicScheme): Int {
         val argb: Int = getHct(scheme).toInt()
-        if (opacity == null) {
-            return argb
-        }
+        if (opacity == null) return argb
+
         val percentage: Double = opacity.apply(scheme)
         val alpha = MathUtils.clampInt(0, 255, round(percentage * 255).toInt())
         return argb and 0x00ffffff or (alpha shl 24)
@@ -194,14 +184,15 @@ class DynamicColor {
     /**
      * Returns an HCT object.
      *
-     * @param scheme Defines the conditions of the user interface, for example, whether or not it is
+     * @param[scheme] Defines the conditions of the user interface, for example, whether or not it is
      * dark mode or light mode, and what the desired contrast level is.
      */
     fun getHct(scheme: DynamicScheme): Hct {
-        val cachedAnswer = hctCache.get(scheme)
+        val cachedAnswer = hctCache[scheme]
         if (cachedAnswer != null) {
             return cachedAnswer
         }
+
         // This is crucial for aesthetics: we aren't simply the taking the standard color
         // and changing its tone for contrast. Rather, we find the tone for contrast, then
         // use the specified chroma from the palette to construct a new color.
@@ -215,7 +206,7 @@ class DynamicColor {
             hctCache.clear()
         }
         // NOMUTANTS--trivial test with onerous dependency injection requirement.
-        hctCache.put(scheme, answer)
+        hctCache[scheme] = answer
         return answer
     }
 
@@ -233,7 +224,10 @@ class DynamicColor {
             val stayTogether: Boolean = toneDeltaPair.stayTogether
             val bg: DynamicColor = background!!.apply(scheme)
             val bgTone = bg.getTone(scheme)
-            val aIsNearer = polarity === TonePolarity.NEARER || polarity === TonePolarity.LIGHTER && !scheme.isDark || polarity === TonePolarity.DARKER && scheme.isDark
+            val aIsNearer =
+                polarity === TonePolarity.NEARER || polarity === TonePolarity.LIGHTER &&
+                    !scheme.isDark || polarity === TonePolarity.DARKER && scheme.isDark
+
             val nearer = if (aIsNearer) roleA else roleB
             val farther = if (aIsNearer) roleB else roleA
             val amNearer = name == nearer.name
@@ -246,10 +240,16 @@ class DynamicColor {
             // If a color is good enough, it is not adjusted.
             // Initial and adjusted tones for `nearer`
             val nInitialTone: Double = nearer.tone.apply(scheme)
-            var nTone = if (Contrast.ratioOfTones(bgTone, nInitialTone) >= nContrast) nInitialTone else foregroundTone(bgTone, nContrast)
+            var nTone =
+                if (Contrast.ratioOfTones(bgTone, nInitialTone) >= nContrast) nInitialTone
+                else foregroundTone(bgTone, nContrast)
+
             // Initial and adjusted tones for `farther`
             val fInitialTone: Double = farther.tone.apply(scheme)
-            var fTone = if (Contrast.ratioOfTones(bgTone, fInitialTone) >= fContrast) fInitialTone else foregroundTone(bgTone, fContrast)
+            var fTone =
+                if (Contrast.ratioOfTones(bgTone, fInitialTone) >= fContrast) fInitialTone
+                else foregroundTone(bgTone, fContrast)
+
             if (decreasingContrast) {
                 // If decreasing contrast, adjust color to the "bare minimum"
                 // that satisfies contrast.
@@ -269,20 +269,10 @@ class DynamicColor {
             }
 
             // Avoids the 50-59 awkward zone.
-            if (50 <= nTone && nTone < 60) {
-                // If `nearer` is in the awkward zone, move it away, together with
-                // `farther`.
-                if (expansionDir > 0) {
-                    nTone = 60.0
-                    fTone = max(fTone, nTone + delta * expansionDir)
-                } else {
-                    nTone = 49.0
-                    fTone = min(fTone, nTone + delta * expansionDir)
-                }
-            } else if (50 <= fTone && fTone < 60) {
-                if (stayTogether) {
-                    // Fixes both, to avoid two colors on opposite sides of the "awkward
-                    // zone".
+            when {
+                50 <= nTone && nTone < 60 -> {
+                    // If `nearer` is in the awkward zone, move it away, together with
+                    // `farther`.
                     if (expansionDir > 0) {
                         nTone = 60.0
                         fTone = max(fTone, nTone + delta * expansionDir)
@@ -290,12 +280,21 @@ class DynamicColor {
                         nTone = 49.0
                         fTone = min(fTone, nTone + delta * expansionDir)
                     }
-                } else {
-                    // Not required to stay together; fixes just one.
-                    fTone = if (expansionDir > 0) {
-                        60.0
+                }
+                50 <= fTone && fTone < 60 -> {
+                    if (stayTogether) {
+                        // Fixes both, to avoid two colors on opposite sides of the "awkward
+                        // zone".
+                        if (expansionDir > 0) {
+                            nTone = 60.0
+                            fTone = max(fTone, nTone + delta * expansionDir)
+                        } else {
+                            nTone = 49.0
+                            fTone = min(fTone, nTone + delta * expansionDir)
+                        }
                     } else {
-                        49.0
+                        // Not required to stay together; fixes just one.
+                        fTone = (if (expansionDir > 0) 60.0 else 49.0)
                     }
                 }
             }
@@ -322,11 +321,7 @@ class DynamicColor {
             }
             if (isBackground && 50 <= answer && answer < 60) {
                 // Must adjust
-                answer = if (Contrast.ratioOfTones(49.0, bgTone) >= desiredRatio) {
-                    49.0
-                } else {
-                    60.0
-                }
+                answer = (if (Contrast.ratioOfTones(49.0, bgTone) >= desiredRatio) 49.0 else 60.0)
             }
             if (secondBackground != null) {
                 // Case 3: Adjust for dual backgrounds.
@@ -362,7 +357,7 @@ class DynamicColor {
                     return if (lightOption == -1.0) 100.0 else lightOption
                 }
                 if (availables.size == 1) {
-                    return availables.get(0)
+                    return availables[0]
                 }
                 return if (darkOption == -1.0) 0.0 else darkOption
             }
@@ -370,75 +365,66 @@ class DynamicColor {
         }
     }
 
+    @Suppress("unused")
     companion object {
 
         /**
          * A convenience constructor for DynamicColor.
          *
-         *
          * _Strongly_ prefer using one of the convenience constructors. This class is arguably too
          * flexible to ensure it can support any scenario. Functional arguments allow overriding without
          * risks that come with subclasses.
-         *
          *
          * For example, the default behavior of adjust tone at max contrast to be at a 7.0 ratio with
          * its background is principled and matches accessibility guidance. That does not mean it's the
          * desired approach for _every_ design system, and every color pairing, always, in every case.
          *
-         *
          * For opaque colors (colors with alpha = 100%).
-         *
          *
          * For colors that are not backgrounds, and do not have backgrounds.
          *
-         * @param name The name of the dynamic color.
-         * @param palette Function that provides a TonalPalette given DynamicScheme. A TonalPalette is
+         * @param[name] The name of the dynamic color.
+         * @param[palette] Function that provides a TonalPalette given DynamicScheme. A TonalPalette is
          * defined by a hue and chroma, so this replaces the need to specify hue/chroma. By providing
          * a tonal palette, when contrast adjustments are made, intended chroma can be preserved.
-         * @param tone Function that provides a tone, given a DynamicScheme.
+         * @param[tone] Function that provides a tone, given a DynamicScheme.
          */
         fun fromPalette(
             name: String,
             palette: Function1<DynamicScheme, TonalPalette>,
             tone: Function1<DynamicScheme, Double>,
-        ): DynamicColor {
-            return DynamicColor(
-                name = name,
-                palette = palette,
-                tone = tone,
-                isBackground = false,
-                background = null,
-                secondBackground = null,
-                contrastCurve = null,
-                toneDeltaPair = null,
-            )
-        }
+        ): DynamicColor = DynamicColor(
+            name = name,
+            palette = palette,
+            tone = tone,
+            isBackground = false,
+            background = null,
+            secondBackground = null,
+            contrastCurve = null,
+            toneDeltaPair = null,
+        )
 
         /**
          * A convenience constructor for DynamicColor.
-         *
          *
          * _Strongly_ prefer using one of the convenience constructors. This class is arguably too
          * flexible to ensure it can support any scenario. Functional arguments allow overriding without
          * risks that come with subclasses.
          *
-         *
          * For example, the default behavior of adjust tone at max contrast to be at a 7.0 ratio with
          * its background is principled and matches accessibility guidance. That does not mean it's the
          * desired approach for _every_ design system, and every color pairing, always, in every case.
          *
-         *
          * For opaque colors (colors with alpha = 100%).
-         *
          *
          * For colors that do not have backgrounds.
          *
-         * @param name The name of the dynamic color.
-         * @param palette Function that provides a TonalPalette given DynamicScheme. A TonalPalette is
+         * @param[name] The name of the dynamic color.
+         * @param[palette] Function that provides a TonalPalette given DynamicScheme. A TonalPalette is
          * defined by a hue and chroma, so this replaces the need to specify hue/chroma. By providing
          * a tonal palette, when contrast adjustments are made, intended chroma can be preserved.
-         * @param tone Function that provides a tone, given a DynamicScheme.
-         * @param isBackground Whether this dynamic color is a background, with some other color as the
+         * @param[tone] Function that provides a tone, given a DynamicScheme.
+         * @param[isBackground] Whether this dynamic color is a background, with some other color as the
          * foreground.
          */
         fun fromPalette(
@@ -446,26 +432,24 @@ class DynamicColor {
             palette: Function1<DynamicScheme, TonalPalette>,
             tone: Function1<DynamicScheme, Double>,
             isBackground: Boolean,
-        ): DynamicColor {
-            return DynamicColor(
-                name,
-                palette,
-                tone,
-                isBackground,  /* background= */
-                null,  /* secondBackground= */
-                null,  /* contrastCurve= */
-                null,  /* toneDeltaPair= */
-                null)
-        }
+        ): DynamicColor = DynamicColor(
+            name = name,
+            palette = palette,
+            tone = tone,
+            isBackground = isBackground,
+            background = null,
+            secondBackground = null,
+            contrastCurve = null,
+            toneDeltaPair = null,
+        )
 
         /**
          * Create a DynamicColor from a hex code.
          *
-         *
          * Result has no background; thus no support for increasing/decreasing contrast for a11y.
          *
-         * @param name The name of the dynamic color.
-         * @param argb The source color from which to extract the hue and chroma.
+         * @param[name] The name of the dynamic color.
+         * @param[argb] The source color from which to extract the hue and chroma.
          */
         fun fromArgb(name: String, argb: Int): DynamicColor {
             val hct: Hct = Hct.fromInt(argb)
@@ -484,14 +468,17 @@ class DynamicColor {
             val darkerRatio: Double = Contrast.ratioOfTones(darkerTone, bgTone)
             val preferLighter = tonePrefersLightForeground(bgTone)
             return if (preferLighter) {
-                // "Neglible difference" handles an edge case where the initial contrast ratio is high
+                // "Negligible difference" handles an edge case where the initial contrast ratio is high
                 // (ex. 13.0), and the ratio passed to the function is that high ratio, and both the lighter
                 // and darker ratio fails to pass that ratio.
                 //
                 // This was observed with Tonal Spot's On Primary Container turning black momentarily between
                 // high and max contrast in light mode. PC's standard tone was T90, OPC's was T10, it was
                 // light mode, and the contrast level was 0.6568521221032331.
-                val negligibleDifference = abs(lighterRatio - darkerRatio) < 0.1 && lighterRatio < ratio && darkerRatio < ratio
+                val negligibleDifference = abs(lighterRatio - darkerRatio) < 0.1 &&
+                    lighterRatio < ratio &&
+                    darkerRatio < ratio
+
                 if (lighterRatio >= ratio || lighterRatio >= darkerRatio || negligibleDifference) {
                     lighterTone
                 } else {
@@ -506,31 +493,25 @@ class DynamicColor {
          * Adjust a tone down such that white has 4.5 contrast, if the tone is reasonably close to
          * supporting it.
          */
-        fun enableLightForeground(tone: Double): Double {
-            return if (tonePrefersLightForeground(tone) && !toneAllowsLightForeground(tone)) {
-                49.0
-            } else tone
-        }
+        fun enableLightForeground(tone: Double): Double =
+            if (tonePrefersLightForeground(tone) && !toneAllowsLightForeground(tone)) 49.0
+            else tone
 
         /**
          * People prefer white foregrounds on ~T60-70. Observed over time, and also by Andrew Somers
          * during research for APCA.
          *
-         *
          * T60 used as to create the smallest discontinuity possible when skipping down to T49 in order
          * to ensure light foregrounds.
-         *
          *
          * Since `tertiaryContainer` in dark monochrome scheme requires a tone of 60, it should not be
          * adjusted. Therefore, 60 is excluded here.
          */
-        fun tonePrefersLightForeground(tone: Double): Boolean {
-            return round(tone) < 60
-        }
+        fun tonePrefersLightForeground(tone: Double): Boolean = round(tone) < 60
 
-        /** Tones less than ~T50 always permit white at 4.5 contrast.  */
-        fun toneAllowsLightForeground(tone: Double): Boolean {
-            return round(tone) <= 49
-        }
+        /**
+         * Tones less than ~T50 always permit white at 4.5 contrast.
+         */
+        fun toneAllowsLightForeground(tone: Double): Boolean = round(tone) <= 49
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/MaterialDynamicColors.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/MaterialDynamicColors.kt
@@ -22,14 +22,15 @@ import com.materialkolor.scheme.Variant
 import kotlin.math.abs
 import kotlin.math.max
 
-/** Named colors, otherwise known as tokens, or roles, in the Material Design system.  */ // Prevent lint for Function.apply not being available on Android before API level 14 (4.0.1).
-// "AndroidJdkLibsChecker" for Function, "NewApi" for Function.apply().
-// A java_library Bazel rule with an Android constraint cannot skip these warnings without this
-// annotation; another solution would be to create an android_library rule and supply
-// AndroidManifest with an SDK set higher than 14.
+/**
+ * Named colors, otherwise known as tokens, or roles, in the Material Design system.
+ *
+ * For `isExtendedFidelity` see [here](https://github.com/material-foundation/material-color-utilities/commit/c3681e12b72202723657b9ce5cf8dfdf7efb0781).
+ *
+ * @param[isExtendedFidelity] Whether to use the extended fidelity color system.
+ */
 @Suppress("unused", "MemberVisibilityCanBePrivate")
 class MaterialDynamicColors(
-    /* See https://github.com/material-foundation/material-color-utilities/commit/c3681e12b72202723657b9ce5cf8dfdf7efb0781 */
     private val isExtendedFidelity: Boolean = false,
 ) {
 
@@ -38,795 +39,780 @@ class MaterialDynamicColors(
     }
 
     // Compatibility Keys Colors for Android
-    fun primaryPaletteKeyColor(): DynamicColor {
-        return DynamicColor.fromPalette(
-            name = "primary_palette_key_color",
-            palette = { s -> s.primaryPalette },
-            tone = { s -> s.primaryPalette.keyColor.getTone() })
-    }
+    fun primaryPaletteKeyColor(): DynamicColor = DynamicColor.fromPalette(
+        name = "primary_palette_key_color",
+        palette = { it.primaryPalette },
+        tone = { it.primaryPalette.keyColor.getTone() },
+    )
 
-    fun secondaryPaletteKeyColor(): DynamicColor {
-        return DynamicColor.fromPalette(
-            name = "secondary_palette_key_color",
-            palette = { s -> s.secondaryPalette },
-            tone = { s -> s.secondaryPalette.keyColor.getTone() })
-    }
+    fun secondaryPaletteKeyColor(): DynamicColor = DynamicColor.fromPalette(
+        name = "secondary_palette_key_color",
+        palette = { it.secondaryPalette },
+        tone = { it.secondaryPalette.keyColor.getTone() },
+    )
 
-    fun tertiaryPaletteKeyColor(): DynamicColor {
-        return DynamicColor.fromPalette(
-            name = "tertiary_palette_key_color",
-            palette = { s -> s.tertiaryPalette },
-            tone = { s -> s.tertiaryPalette.keyColor.getTone() })
-    }
+    fun tertiaryPaletteKeyColor(): DynamicColor = DynamicColor.fromPalette(
+        name = "tertiary_palette_key_color",
+        palette = { it.tertiaryPalette },
+        tone = { it.tertiaryPalette.keyColor.getTone() },
+    )
 
-    fun neutralPaletteKeyColor(): DynamicColor {
-        return DynamicColor.fromPalette(
-            name = "neutral_palette_key_color",
-            palette = { s -> s.neutralPalette },
-            tone = { s -> s.neutralPalette.keyColor.getTone() })
-    }
+    fun neutralPaletteKeyColor(): DynamicColor = DynamicColor.fromPalette(
+        name = "neutral_palette_key_color",
+        palette = { it.neutralPalette },
+        tone = { it.neutralPalette.keyColor.getTone() })
 
-    fun neutralVariantPaletteKeyColor(): DynamicColor {
-        return DynamicColor.fromPalette(
-            name = "neutral_variant_palette_key_color",
-            palette = { s -> s.neutralVariantPalette },
-            tone = { s -> s.neutralVariantPalette.keyColor.getTone() })
-    }
+    fun neutralVariantPaletteKeyColor(): DynamicColor = DynamicColor.fromPalette(
+        name = "neutral_variant_palette_key_color",
+        palette = { it.neutralVariantPalette },
+        tone = { it.neutralVariantPalette.keyColor.getTone() })
 
-    fun background(): DynamicColor {
-        return DynamicColor(
-            name = "background",
-            palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 6.0 else 98.0 },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
-    }
+    fun background(): DynamicColor = DynamicColor(
+        name = "background",
+        palette = { it.neutralPalette },
+        tone = { if (it.isDark) 6.0 else 98.0 },
+        isBackground = true,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun onBackground(): DynamicColor {
-        return DynamicColor(
-            name = "on_background",
-            palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 90.0 else 10.0 },
-            isBackground = false,
-            background = { background() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 3.0, 4.5, 7.0),
-            toneDeltaPair = null,
-        )
-    }
+    fun onBackground(): DynamicColor = DynamicColor(
+        name = "on_background",
+        palette = { it.neutralPalette },
+        tone = { if (it.isDark) 90.0 else 10.0 },
+        isBackground = false,
+        background = { background() },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(3.0, 3.0, 4.5, 7.0),
+        toneDeltaPair = null,
+    )
 
-    fun surface(): DynamicColor {
-        return DynamicColor(
-            name = "surface",
-            palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 6.0 else 98.0 },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
-    }
+    fun surface(): DynamicColor = DynamicColor(
+        name = "surface",
+        palette = { it.neutralPalette },
+        tone = { if (it.isDark) 6.0 else 98.0 },
+        isBackground = true,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun surfaceDim(): DynamicColor {
-        return DynamicColor(
-            name = "surface_dim",
-            palette = { s -> s.neutralPalette },
-            tone = { s ->
-                if (s.isDark) 6.0
-                else ContrastCurve(87.0, 87.0, 80.0, 75.0).get(s.contrastLevel)
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
-    }
+    fun surfaceDim(): DynamicColor = DynamicColor(
+        name = "surface_dim",
+        palette = { it.neutralPalette },
+        tone = { scheme ->
+            if (scheme.isDark) 6.0
+            else ContrastCurve(87.0, 87.0, 80.0, 75.0).get(scheme.contrastLevel)
+        },
+        isBackground = true,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun surfaceBright(): DynamicColor {
-        return DynamicColor(
-            name = "surface_bright",
-            palette = { s -> s.neutralPalette },
-            tone = { s ->
-                if (s.isDark) ContrastCurve(24.0, 24.0, 29.0, 34.0).get(s.contrastLevel)
-                else 98.0
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
-    }
+    fun surfaceBright(): DynamicColor = DynamicColor(
+        name = "surface_bright",
+        palette = { it.neutralPalette },
+        tone = { scheme ->
+            if (scheme.isDark) ContrastCurve(24.0, 24.0, 29.0, 34.0).get(scheme.contrastLevel)
+            else 98.0
+        },
+        isBackground = true,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun surfaceContainerLowest(): DynamicColor {
-        return DynamicColor(
-            name = "surface_container_lowest",
-            palette = { s -> s.neutralPalette },
-            tone = { s ->
-                if (s.isDark) ContrastCurve(4.0, 4.0, 2.0, 0.0).get(s.contrastLevel)
-                else 100.0
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
-    }
+    fun surfaceContainerLowest(): DynamicColor = DynamicColor(
+        name = "surface_container_lowest",
+        palette = { it.neutralPalette },
+        tone = { scheme ->
+            if (scheme.isDark) ContrastCurve(4.0, 4.0, 2.0, 0.0).get(scheme.contrastLevel)
+            else 100.0
+        },
+        isBackground = true,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun surfaceContainerLow(): DynamicColor {
-        return DynamicColor(
-            name = "surface_container_low",
-            palette = { s -> s.neutralPalette },
-            tone = { s ->
-                if (s.isDark) ContrastCurve(10.0, 10.0, 11.0, 12.0).get(s.contrastLevel)
-                else ContrastCurve(96.0, 96.0, 96.0, 95.0).get(s.contrastLevel)
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
-    }
+    fun surfaceContainerLow(): DynamicColor = DynamicColor(
+        name = "surface_container_low",
+        palette = { it.neutralPalette },
+        tone = { scheme ->
+            if (scheme.isDark) ContrastCurve(10.0, 10.0, 11.0, 12.0).get(scheme.contrastLevel)
+            else ContrastCurve(96.0, 96.0, 96.0, 95.0).get(scheme.contrastLevel)
+        },
+        isBackground = true,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun surfaceContainer(): DynamicColor {
-        return DynamicColor(
-            name = "surface_container",
-            palette = { s -> s.neutralPalette },
-            tone = { s ->
-                if (s.isDark) ContrastCurve(12.0, 12.0, 16.0, 20.0).get(s.contrastLevel)
-                else ContrastCurve(94.0, 94.0, 92.0, 90.0).get(s.contrastLevel)
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
-    }
+    fun surfaceContainer(): DynamicColor = DynamicColor(
+        name = "surface_container",
+        palette = { it.neutralPalette },
+        tone = { scheme ->
+            if (scheme.isDark) ContrastCurve(12.0, 12.0, 16.0, 20.0).get(scheme.contrastLevel)
+            else ContrastCurve(94.0, 94.0, 92.0, 90.0).get(scheme.contrastLevel)
+        },
+        isBackground = true,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun surfaceContainerHigh(): DynamicColor {
-        return DynamicColor(
-            name = "surface_container_high",
-            palette = { s -> s.neutralPalette },
-            tone = { s ->
-                if (s.isDark) ContrastCurve(17.0, 17.0, 21.0, 25.0).get(s.contrastLevel)
-                else ContrastCurve(92.0, 92.0, 88.0, 85.0).get(s.contrastLevel)
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
-    }
+    fun surfaceContainerHigh(): DynamicColor = DynamicColor(
+        name = "surface_container_high",
+        palette = { it.neutralPalette },
+        tone = { scheme ->
+            if (scheme.isDark) ContrastCurve(17.0, 17.0, 21.0, 25.0).get(scheme.contrastLevel)
+            else ContrastCurve(92.0, 92.0, 88.0, 85.0).get(scheme.contrastLevel)
+        },
+        isBackground = true,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun surfaceContainerHighest(): DynamicColor {
-        return DynamicColor(
-            name = "surface_container_highest",
-            palette = { s -> s.neutralPalette },
-            tone = { s ->
-                if (s.isDark) ContrastCurve(22.0, 22.0, 26.0, 30.0).get(s.contrastLevel)
-                else ContrastCurve(90.0, 90.0, 84.0, 80.0).get(s.contrastLevel)
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
-    }
+    fun surfaceContainerHighest(): DynamicColor = DynamicColor(
+        name = "surface_container_highest",
+        palette = { it.neutralPalette },
+        tone = { scheme ->
+            if (scheme.isDark) ContrastCurve(22.0, 22.0, 26.0, 30.0).get(scheme.contrastLevel)
+            else ContrastCurve(90.0, 90.0, 84.0, 80.0).get(scheme.contrastLevel)
+        },
+        isBackground = true,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun onSurface(): DynamicColor {
-        return DynamicColor(
-            name = "on_surface",
-            palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 90.0 else 10.0 },
-            isBackground = false, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null,
-        )
-    }
+    fun onSurface(): DynamicColor = DynamicColor(
+        name = "on_surface",
+        palette = { it.neutralPalette },
+        tone = { if (it.isDark) 90.0 else 10.0 },
+        isBackground = false,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
+        toneDeltaPair = null,
+    )
 
-    fun surfaceVariant(): DynamicColor {
-        return DynamicColor(
-            name = "surface_variant",
-            palette = { s -> s.neutralVariantPalette },
-            tone = { s -> if (s.isDark) 30.0 else 90.0 },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
-    }
+    fun surfaceVariant(): DynamicColor = DynamicColor(
+        name = "surface_variant",
+        palette = { it.neutralVariantPalette },
+        tone = { if (it.isDark) 30.0 else 90.0 },
+        isBackground = true,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun onSurfaceVariant(): DynamicColor {
-        return DynamicColor(
-            name = "on_surface_variant",
-            palette = { s -> s.neutralVariantPalette },
-            tone = { s -> if (s.isDark) 80.0 else 30.0 },
-            isBackground = false, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = null)
-    }
+    fun onSurfaceVariant(): DynamicColor = DynamicColor(
+        name = "on_surface_variant",
+        palette = { it.neutralVariantPalette },
+        tone = { if (it.isDark) 80.0 else 30.0 },
+        isBackground = false,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
+        toneDeltaPair = null,
+    )
 
-    fun inverseSurface(): DynamicColor {
-        return DynamicColor(
-            name = "inverse_surface",
-            palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 90.0 else 20.0 },
-            isBackground = false,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null)
-    }
+    fun inverseSurface(): DynamicColor = DynamicColor(
+        name = "inverse_surface",
+        palette = { it.neutralPalette },
+        tone = { if (it.isDark) 90.0 else 20.0 },
+        isBackground = false,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun inverseOnSurface(): DynamicColor {
-        return DynamicColor(
-            name = "inverse_on_surface",
-            palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 20.0 else 95.0 },
-            isBackground = false,
-            background = { inverseSurface() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null)
-    }
+    fun inverseOnSurface(): DynamicColor = DynamicColor(
+        name = "inverse_on_surface",
+        palette = { it.neutralPalette },
+        tone = { if (it.isDark) 20.0 else 95.0 },
+        isBackground = false,
+        background = { inverseSurface() },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
+        toneDeltaPair = null,
+    )
 
-    fun outline(): DynamicColor {
-        return DynamicColor(
-            name = "outline",
-            palette = { s -> s.neutralVariantPalette },
-            tone = { s -> if (s.isDark) 60.0 else 50.0 },
-            isBackground = false, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.5, 3.0, 4.5, 7.0),
-            toneDeltaPair = null)
-    }
+    fun outline(): DynamicColor = DynamicColor(
+        name = "outline",
+        palette = { it.neutralVariantPalette },
+        tone = { if (it.isDark) 60.0 else 50.0 },
+        isBackground = false,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(1.5, 3.0, 4.5, 7.0),
+        toneDeltaPair = null,
+    )
 
-    fun outlineVariant(): DynamicColor {
-        return DynamicColor(
-            name = "outline_variant",
-            palette = { s -> s.neutralVariantPalette },
-            tone = { s -> if (s.isDark) 30.0 else 80.0 },
-            isBackground = false, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = null)
-    }
+    fun outlineVariant(): DynamicColor = DynamicColor(
+        name = "outline_variant",
+        palette = { it.neutralVariantPalette },
+        tone = { if (it.isDark) 30.0 else 80.0 },
+        isBackground = false,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+        toneDeltaPair = null,
+    )
 
-    fun shadow(): DynamicColor {
-        return DynamicColor(
-            name = "shadow",
-            palette = { s -> s.neutralPalette },
-            tone = { 0.0 },
-            isBackground = false,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null)
-    }
+    fun shadow(): DynamicColor = DynamicColor(
+        name = "shadow",
+        palette = { it.neutralPalette },
+        tone = { 0.0 },
+        isBackground = false,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun scrim(): DynamicColor {
-        return DynamicColor(
-            name = "scrim",
-            palette = { s -> s.neutralPalette },
-            tone = { 0.0 },
-            isBackground = false,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null)
-    }
+    fun scrim(): DynamicColor = DynamicColor(
+        name = "scrim",
+        palette = { it.neutralPalette },
+        tone = { 0.0 },
+        isBackground = false,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun surfaceTint(): DynamicColor {
-        return DynamicColor(
-            name = "surface_tint",
-            palette = { s -> s.primaryPalette },
-            tone = { s -> if (s.isDark) 80.0 else 40.0 },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null)
-    }
+    fun surfaceTint(): DynamicColor = DynamicColor(
+        name = "surface_tint",
+        palette = { it.primaryPalette },
+        tone = { if (it.isDark) 80.0 else 40.0 },
+        isBackground = true,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+    )
 
-    fun primary(): DynamicColor {
-        return DynamicColor(
-            name = "primary",
-            palette = { s -> s.primaryPalette },
-            tone = { s ->
-                if (isMonochrome(s)) {
-                    if (s.isDark) 100.0 else 0.0
-                } else {
-                    if (s.isDark) 80.0 else 40.0
+    fun primary(): DynamicColor = DynamicColor(
+        name = "primary",
+        palette = { it.primaryPalette },
+        tone = { scheme ->
+            when {
+                scheme.isMonochrome() -> if (scheme.isDark) 100.0 else 0.0
+                else -> if (scheme.isDark) 80.0 else 40.0
+            }
+        },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = primaryContainer(),
+                roleB = primary(),
+                delta = 10.0,
+                polarity = TonePolarity.NEARER,
+                stayTogether = false,
+            )
+        }
+    )
+
+    fun onPrimary(): DynamicColor = DynamicColor(
+        name = "on_primary",
+        palette = { it.primaryPalette },
+        tone = { scheme ->
+            when {
+                scheme.isMonochrome() -> if (scheme.isDark) 10.0 else 90.0
+                else -> if (scheme.isDark) 20.0 else 100.0
+            }
+        },
+        isBackground = false,
+        background = { primary() },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
+        toneDeltaPair = null)
+
+    fun primaryContainer(): DynamicColor = DynamicColor(
+        name = "primary_container",
+        palette = { it.primaryPalette },
+        tone = { scheme ->
+            when {
+                isFidelity(scheme) -> scheme.sourceColorHct.getTone()
+                scheme.isMonochrome() -> if (scheme.isDark) 85.0 else 25.0
+                else -> if (scheme.isDark) 30.0 else 90.0
+            }
+        },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = primaryContainer(),
+                roleB = primary(),
+                delta = 10.0,
+                polarity = TonePolarity.NEARER,
+                stayTogether = false,
+            )
+        },
+    )
+
+    fun onPrimaryContainer(): DynamicColor = DynamicColor(
+        name = "on_primary_container",
+        palette = { it.primaryPalette },
+        tone = { scheme ->
+            when {
+                isFidelity(scheme) -> {
+                    DynamicColor.foregroundTone(primaryContainer().tone.apply(scheme), 4.5)
                 }
-            },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = primaryContainer(),
-                    roleB = primary(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
+                scheme.isMonochrome() -> if (scheme.isDark) 0.0 else 100.0
+                else -> if (scheme.isDark) 90.0 else 10.0
+            }
+        },
+        isBackground = false,
+        background = { primaryContainer() },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
+        toneDeltaPair = null,
+    )
+
+    fun inversePrimary(): DynamicColor = DynamicColor(
+        name = "inverse_primary",
+        palette = { it.primaryPalette },
+        tone = { if (it.isDark) 40.0 else 80.0 },
+        isBackground = false,
+        background = { inverseSurface() },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
+        toneDeltaPair = null,
+    )
+
+    fun secondary(): DynamicColor = DynamicColor(
+        name = "secondary",
+        palette = { it.secondaryPalette },
+        tone = { if (it.isDark) 80.0 else 40.0 },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = secondaryContainer(),
+                roleB = secondary(),
+                delta = 10.0,
+                polarity = TonePolarity.NEARER,
+                stayTogether = false,
+            )
+        },
+    )
+
+    fun onSecondary(): DynamicColor = DynamicColor(
+        name = "on_secondary",
+        palette = { it.secondaryPalette },
+        tone = { scheme ->
+            when {
+                scheme.isMonochrome() -> if (scheme.isDark) 10.0 else 100.0
+                else -> if (scheme.isDark) 20.0 else 100.0
+            }
+        },
+        isBackground = false,
+        background = { secondary() },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
+        toneDeltaPair = null,
+    )
+
+    fun secondaryContainer(): DynamicColor = DynamicColor(
+        name = "secondary_container",
+        palette = { it.secondaryPalette },
+        tone = { scheme ->
+            val initialTone = if (scheme.isDark) 30.0 else 90.0
+            when {
+                scheme.isMonochrome() -> if (scheme.isDark) 30.0 else 85.0
+                !isFidelity(scheme) -> initialTone
+                else -> findDesiredChromaByTone(
+                    hue = scheme.secondaryPalette.hue,
+                    chroma = scheme.secondaryPalette.chroma,
+                    tone = initialTone,
+                    byDecreasingTone = !scheme.isDark,
                 )
             }
-        )
-    }
+        },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = secondaryContainer(),
+                roleB = secondary(),
+                delta = 10.0,
+                polarity = TonePolarity.NEARER,
+                stayTogether = false,
+            )
+        }
+    )
 
-    fun onPrimary(): DynamicColor {
-        return DynamicColor(
-            name = "on_primary",
-            palette = { s -> s.primaryPalette },
-            tone = { s ->
-                if (isMonochrome(s)) {
-                    if (s.isDark) 10.0 else 90.0
-                } else {
-                    if (s.isDark) 20.0 else 100.0
+    fun onSecondaryContainer(): DynamicColor = DynamicColor(
+        name = "on_secondary_container",
+        palette = { it.secondaryPalette },
+        tone = { scheme ->
+            when {
+                !isFidelity(scheme) -> if (scheme.isDark) 90.0 else 10.0
+                else -> {
+                    DynamicColor.foregroundTone(secondaryContainer().tone.apply(scheme), 4.5)
                 }
-            },
-            isBackground = false,
-            background = { primary() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null)
-    }
-
-    fun primaryContainer(): DynamicColor {
-        return DynamicColor(
-            name = "primary_container",
-            palette = { s -> s.primaryPalette },
-            tone = { s ->
-                if (isFidelity(s)) {
-                    s.sourceColorHct.getTone()
-                } else if (isMonochrome(s)) {
-                    if (s.isDark) 85.0 else 25.0
-                } else {
-                    if (s.isDark) 30.0 else 90.0
-                }
-            },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = { ToneDeltaPair(primaryContainer(), primary(), 10.0, TonePolarity.NEARER, false) })
-    }
-
-    fun onPrimaryContainer(): DynamicColor {
-        return DynamicColor(
-            name = "on_primary_container",
-            palette = { s -> s.primaryPalette },
-            tone = { s ->
-                if (isFidelity(s)) {
-                    DynamicColor.foregroundTone(primaryContainer().tone.apply(s), 4.5)
-                } else if (isMonochrome(s)) {
-                    if (s.isDark) 0.0 else 100.0
-                } else {
-                    if (s.isDark) 90.0 else 10.0
-                }
-            },
-            isBackground = false,
-            background = { primaryContainer() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null)
-    }
-
-    fun inversePrimary(): DynamicColor {
-        return DynamicColor(
-            name = "inverse_primary",
-            palette = { s -> s.primaryPalette },
-            tone = { s -> if (s.isDark) 40.0 else 80.0 },
-            isBackground = false,
-            background = { inverseSurface() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
-            toneDeltaPair = null)
-    }
-
-    fun secondary(): DynamicColor {
-        return DynamicColor(
-            name = "secondary",
-            palette = { s -> s.secondaryPalette },
-            tone = { s -> if (s.isDark) 80.0 else 40.0 },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
-            toneDeltaPair = { ToneDeltaPair(secondaryContainer(), secondary(), 10.0, TonePolarity.NEARER, false) })
-    }
-
-    fun onSecondary(): DynamicColor {
-        return DynamicColor(
-            name = "on_secondary",
-            palette = { s -> s.secondaryPalette },
-            tone = { s ->
-                if (isMonochrome(s)) {
-                    if (s.isDark) 10.0 else 100.0
-                } else {
-                    if (s.isDark) 20.0 else 100.0
-                }
-            },
-            isBackground = false,
-            background = { secondary() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null)
-    }
-
-    fun secondaryContainer(): DynamicColor {
-        return DynamicColor(
-            name = "secondary_container",
-            palette = { s -> s.secondaryPalette },
-            tone = { s ->
-                val initialTone = if (s.isDark) 30.0 else 90.0
-                if (isMonochrome(s)) {
-                    if (s.isDark) 30.0 else 85.0
-                } else if (!isFidelity(s)) {
-                    initialTone
-                } else {
-                    findDesiredChromaByTone(
-                        hue = s.secondaryPalette.hue,
-                        chroma = s.secondaryPalette.chroma,
-                        tone = initialTone,
-                        byDecreasingTone = !s.isDark
-                    )
-                }
-            },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = secondaryContainer(),
-                    roleB = secondary(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
-                )
             }
-        )
-    }
+        },
+        isBackground = false,
+        background = { secondaryContainer() },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
+        toneDeltaPair = null,
+    )
 
-    fun onSecondaryContainer(): DynamicColor {
-        return DynamicColor(
-            name = "on_secondary_container",
-            palette = { s -> s.secondaryPalette },
-            tone = { s ->
-                if (!isFidelity(s)) {
-                    if (s.isDark) 90.0 else 10.0
-                } else
-                    DynamicColor.foregroundTone(secondaryContainer().tone.apply(s), 4.5)
-            },
-            isBackground = false,
-            background = { secondaryContainer() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null)
-    }
-
-    fun tertiary(): DynamicColor {
-        return DynamicColor(
-            name = "tertiary",
-            palette = { s -> s.tertiaryPalette },
-            tone = { s ->
-                if (isMonochrome(s)) {
-                    if (s.isDark) 90.0 else 25.0
-                } else {
-                    if (s.isDark) 80.0 else 40.0
-                }
-            },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = tertiaryContainer(),
-                    roleB = tertiary(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
-                )
+    fun tertiary(): DynamicColor = DynamicColor(
+        name = "tertiary",
+        palette = { it.tertiaryPalette },
+        tone = { scheme ->
+            when {
+                scheme.isMonochrome() -> if (scheme.isDark) 90.0 else 25.0
+                else -> if (scheme.isDark) 80.0 else 40.0
             }
-        )
-    }
+        },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = tertiaryContainer(),
+                roleB = tertiary(),
+                delta = 10.0,
+                polarity = TonePolarity.NEARER,
+                stayTogether = false,
+            )
+        }
+    )
 
-    fun onTertiary(): DynamicColor {
-        return DynamicColor(
-            name = "on_tertiary",
-            palette = { s -> s.tertiaryPalette },
-            tone = { s ->
-                if (isMonochrome(s)) {
-                    if (s.isDark) 10.0 else 90.0
-                } else {
-                    if (s.isDark) 20.0 else 100.0
-                }
-            },
-            isBackground = false,
-            background = { tertiary() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null)
-    }
+    fun onTertiary(): DynamicColor = DynamicColor(
+        name = "on_tertiary",
+        palette = { it.tertiaryPalette },
+        tone = { scheme ->
+            when {
+                scheme.isMonochrome() -> if (scheme.isDark) 10.0 else 90.0
+                else -> if (scheme.isDark) 20.0 else 100.0
+            }
+        },
+        isBackground = false,
+        background = { tertiary() },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
+        toneDeltaPair = null,
+    )
 
-    fun tertiaryContainer(): DynamicColor {
-        return DynamicColor(
-            name = "tertiary_container",
-            palette = { s -> s.tertiaryPalette },
-            tone = { s ->
-                if (isMonochrome(s)) {
-                    if (s.isDark) 60.0 else 49.0
-                } else if (!isFidelity(s)) {
-                    if (s.isDark) 30.0 else 90.0
-                } else {
-                    val proposedHct: Hct = s.tertiaryPalette.getHct(s.sourceColorHct.getTone())
+    fun tertiaryContainer(): DynamicColor = DynamicColor(
+        name = "tertiary_container",
+        palette = { it.tertiaryPalette },
+        tone = { scheme ->
+            when {
+                scheme.isMonochrome() -> if (scheme.isDark) 60.0 else 49.0
+                !isFidelity(scheme) -> if (scheme.isDark) 30.0 else 90.0
+                else -> {
+                    val proposedHct =
+                        scheme.tertiaryPalette.getHct(scheme.sourceColorHct.getTone())
                     DislikeAnalyzer.fixIfDisliked(proposedHct).getTone()
                 }
-            },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = tertiaryContainer(),
-                    roleB = tertiary(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
-                )
             }
-        )
-    }
+        },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = tertiaryContainer(),
+                roleB = tertiary(),
+                delta = 10.0,
+                polarity = TonePolarity.NEARER,
+                stayTogether = false,
+            )
+        }
+    )
 
-    fun onTertiaryContainer(): DynamicColor {
-        return DynamicColor(
-            name = "on_tertiary_container",
-            palette = { s -> s.tertiaryPalette },
-            tone = { s ->
-                if (isMonochrome(s)) {
-                    if (s.isDark) 0.0 else 100.0
-                } else if (!isFidelity(s)) {
-                    if (s.isDark) 90.0 else 10.0
-                } else DynamicColor.foregroundTone(tertiaryContainer().tone.apply(s), 4.5)
-            },
-            isBackground = false,
-            background = { tertiaryContainer() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null)
-    }
+    fun onTertiaryContainer(): DynamicColor = DynamicColor(
+        name = "on_tertiary_container",
+        palette = { it.tertiaryPalette },
+        tone = { scheme ->
+            when {
+                scheme.isMonochrome() -> if (scheme.isDark) 0.0 else 100.0
+                !isFidelity(scheme) -> if (scheme.isDark) 90.0 else 10.0
+                else -> {
+                    DynamicColor.foregroundTone(tertiaryContainer().tone.apply(scheme), 4.5)
+                }
+            }
+        },
+        isBackground = false,
+        background = { tertiaryContainer() },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
+        toneDeltaPair = null,
+    )
 
-    fun error(): DynamicColor {
-        return DynamicColor(
-            name = "error",
-            palette = { s -> s.errorPalette },
-            tone = { s -> if (s.isDark) 80.0 else 40.0 },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = errorContainer(),
-                    roleB = error(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
-                )
-            },
-        )
-    }
+    fun error(): DynamicColor = DynamicColor(
+        name = "error",
+        palette = { it.errorPalette },
+        tone = { if (it.isDark) 80.0 else 40.0 },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = errorContainer(),
+                roleB = error(),
+                delta = 10.0,
+                polarity = TonePolarity.NEARER,
+                stayTogether = false,
+            )
+        },
+    )
 
-    fun onError(): DynamicColor {
-        return DynamicColor(
-            name = "on_error",
-            palette = { s -> s.errorPalette },
-            tone = { s -> if (s.isDark) 20.0 else 100.0 },
-            isBackground = false,
-            background = { error() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null)
-    }
+    fun onError(): DynamicColor = DynamicColor(
+        name = "on_error",
+        palette = { it.errorPalette },
+        tone = { if (it.isDark) 20.0 else 100.0 },
+        isBackground = false,
+        background = { error() },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
+        toneDeltaPair = null,
+    )
 
-    fun errorContainer(): DynamicColor {
-        return DynamicColor(
-            name = "error_container",
-            palette = { s -> s.errorPalette },
-            tone = { s -> if (s.isDark) 30.0 else 90.0 },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = errorContainer(),
-                    roleB = error(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
-                )
-            },
-        )
-    }
+    fun errorContainer(): DynamicColor = DynamicColor(
+        name = "error_container",
+        palette = { it.errorPalette },
+        tone = { if (it.isDark) 30.0 else 90.0 },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = errorContainer(),
+                roleB = error(),
+                delta = 10.0,
+                polarity = TonePolarity.NEARER,
+                stayTogether = false,
+            )
+        },
+    )
 
-    fun onErrorContainer(): DynamicColor {
-        return DynamicColor(
-            name = "on_error_container",
-            palette = { s -> s.errorPalette },
-            tone = { s -> if (s.isDark) 90.0 else 10.0 },
-            isBackground = false,
-            background = { errorContainer() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null)
-    }
+    fun onErrorContainer(): DynamicColor = DynamicColor(
+        name = "on_error_container",
+        palette = { it.errorPalette },
+        tone = { if (it.isDark) 90.0 else 10.0 },
+        isBackground = false,
+        background = { errorContainer() },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
+        toneDeltaPair = null,
+    )
 
-    fun primaryFixed(): DynamicColor {
-        return DynamicColor(
-            name = "primary_fixed",
-            palette = { s -> s.primaryPalette },
-            tone = { s -> if (isMonochrome(s)) 40.0 else 90.0 },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = { ToneDeltaPair(primaryFixed(), primaryFixedDim(), 10.0, TonePolarity.LIGHTER, true) })
-    }
+    fun primaryFixed(): DynamicColor = DynamicColor(
+        name = "primary_fixed",
+        palette = { it.primaryPalette },
+        tone = { if (it.isMonochrome()) 40.0 else 90.0 },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = primaryFixed(),
+                roleB = primaryFixedDim(),
+                delta = 10.0,
+                polarity = TonePolarity.LIGHTER,
+                stayTogether = true,
+            )
+        },
+    )
 
-    fun primaryFixedDim(): DynamicColor {
-        return DynamicColor(
-            name = "primary_fixed_dim",
-            palette = { s -> s.primaryPalette },
-            tone = { s -> if (isMonochrome(s)) 30.0 else 80.0 },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = { ToneDeltaPair(primaryFixed(), primaryFixedDim(), 10.0, TonePolarity.LIGHTER, true) })
-    }
+    fun primaryFixedDim(): DynamicColor = DynamicColor(
+        name = "primary_fixed_dim",
+        palette = { it.primaryPalette },
+        tone = { if (it.isMonochrome()) 30.0 else 80.0 },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = primaryFixed(),
+                roleB = primaryFixedDim(),
+                delta = 10.0,
+                polarity = TonePolarity.LIGHTER,
+                stayTogether = true,
+            )
+        },
+    )
 
-    fun onPrimaryFixed(): DynamicColor {
-        return DynamicColor(
-            name = "on_primary_fixed",
-            palette = { s -> s.primaryPalette },
-            tone = { s -> if (isMonochrome(s)) 100.0 else 10.0 },
-            isBackground = false,
-            background = { primaryFixedDim() },
-            secondBackground = { primaryFixed() },
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null)
-    }
+    fun onPrimaryFixed(): DynamicColor = DynamicColor(
+        name = "on_primary_fixed",
+        palette = { it.primaryPalette },
+        tone = { if (it.isMonochrome()) 100.0 else 10.0 },
+        isBackground = false,
+        background = { primaryFixedDim() },
+        secondBackground = { primaryFixed() },
+        contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
+        toneDeltaPair = null,
+    )
 
-    fun onPrimaryFixedVariant(): DynamicColor {
-        return DynamicColor(
-            name = "on_primary_fixed_variant",
-            palette = { s -> s.primaryPalette },
-            tone = { s -> if (isMonochrome(s)) 90.0 else 30.0 },
-            isBackground = false,
-            background = { primaryFixedDim() },
-            secondBackground = { primaryFixed() },
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = null)
-    }
+    fun onPrimaryFixedVariant(): DynamicColor = DynamicColor(
+        name = "on_primary_fixed_variant",
+        palette = { it.primaryPalette },
+        tone = { if (it.isMonochrome()) 90.0 else 30.0 },
+        isBackground = false,
+        background = { primaryFixedDim() },
+        secondBackground = { primaryFixed() },
+        contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
+        toneDeltaPair = null,
+    )
 
-    fun secondaryFixed(): DynamicColor {
-        return DynamicColor(
-            name = "secondary_fixed",
-            palette = { s -> s.secondaryPalette },
-            tone = { s -> if (isMonochrome(s)) 80.0 else 90.0 },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    secondaryFixed(), secondaryFixedDim(), 10.0, TonePolarity.LIGHTER, true)
-            })
-    }
+    fun secondaryFixed(): DynamicColor = DynamicColor(
+        name = "secondary_fixed",
+        palette = { it.secondaryPalette },
+        tone = { if (it.isMonochrome()) 80.0 else 90.0 },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = secondaryFixed(),
+                roleB = secondaryFixedDim(),
+                delta = 10.0,
+                polarity = TonePolarity.LIGHTER,
+                stayTogether = true,
+            )
+        },
+    )
 
-    fun secondaryFixedDim(): DynamicColor {
-        return DynamicColor(
-            name = "secondary_fixed_dim",
-            palette = { s -> s.secondaryPalette },
-            tone = { s -> if (isMonochrome(s)) 70.0 else 80.0 },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    secondaryFixed(), secondaryFixedDim(), 10.0, TonePolarity.LIGHTER, true)
-            })
-    }
+    fun secondaryFixedDim(): DynamicColor = DynamicColor(
+        name = "secondary_fixed_dim",
+        palette = { it.secondaryPalette },
+        tone = { if (it.isMonochrome()) 70.0 else 80.0 },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = secondaryFixed(),
+                roleB = secondaryFixedDim(),
+                delta = 10.0,
+                polarity = TonePolarity.LIGHTER,
+                stayTogether = true,
+            )
+        },
+    )
 
-    fun onSecondaryFixed(): DynamicColor {
-        return DynamicColor(
-            name = "on_secondary_fixed",
-            palette = { s -> s.secondaryPalette },
-            tone = { 10.0 },
-            isBackground = false,
-            background = { secondaryFixedDim() },
-            secondBackground = { secondaryFixed() },
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null)
-    }
+    fun onSecondaryFixed(): DynamicColor = DynamicColor(
+        name = "on_secondary_fixed",
+        palette = { it.secondaryPalette },
+        tone = { 10.0 },
+        isBackground = false,
+        background = { secondaryFixedDim() },
+        secondBackground = { secondaryFixed() },
+        contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
+        toneDeltaPair = null,
+    )
 
-    fun onSecondaryFixedVariant(): DynamicColor {
-        return DynamicColor(
-            name = "on_secondary_fixed_variant",
-            palette = { s -> s.secondaryPalette },
-            tone = { s -> if (isMonochrome(s)) 25.0 else 30.0 },
-            isBackground = false,
-            background = { secondaryFixedDim() },
-            secondBackground = { secondaryFixed() },
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = null)
-    }
+    fun onSecondaryFixedVariant(): DynamicColor = DynamicColor(
+        name = "on_secondary_fixed_variant",
+        palette = { it.secondaryPalette },
+        tone = { if (it.isMonochrome()) 25.0 else 30.0 },
+        isBackground = false,
+        background = { secondaryFixedDim() },
+        secondBackground = { secondaryFixed() },
+        contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
+        toneDeltaPair = null,
+    )
 
-    fun tertiaryFixed(): DynamicColor {
-        return DynamicColor(
-            name = "tertiary_fixed",
-            palette = { s -> s.tertiaryPalette },
-            tone = { s -> if (isMonochrome(s)) 40.0 else 90.0 },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    tertiaryFixed(), tertiaryFixedDim(), 10.0, TonePolarity.LIGHTER, true)
-            })
-    }
+    fun tertiaryFixed(): DynamicColor = DynamicColor(
+        name = "tertiary_fixed",
+        palette = { it.tertiaryPalette },
+        tone = { if (it.isMonochrome()) 40.0 else 90.0 },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = tertiaryFixed(),
+                roleB = tertiaryFixedDim(),
+                delta = 10.0,
+                polarity = TonePolarity.LIGHTER,
+                stayTogether = true,
+            )
+        },
+    )
 
-    fun tertiaryFixedDim(): DynamicColor {
-        return DynamicColor(
-            name = "tertiary_fixed_dim",
-            palette = { s -> s.tertiaryPalette },
-            tone = { s -> if (isMonochrome(s)) 30.0 else 80.0 },
-            isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = tertiaryFixed(),
-                    roleB = tertiaryFixedDim(),
-                    delta = 10.0,
-                    polarity = TonePolarity.LIGHTER,
-                    stayTogether = true,
-                )
-            },
-        )
-    }
+    fun tertiaryFixedDim(): DynamicColor = DynamicColor(
+        name = "tertiary_fixed_dim",
+        palette = { it.tertiaryPalette },
+        tone = { if (it.isMonochrome()) 30.0 else 80.0 },
+        isBackground = true,
+        background = { highestSurface(it) },
+        secondBackground = null,
+        contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+        toneDeltaPair = {
+            ToneDeltaPair(
+                roleA = tertiaryFixed(),
+                roleB = tertiaryFixedDim(),
+                delta = 10.0,
+                polarity = TonePolarity.LIGHTER,
+                stayTogether = true,
+            )
+        },
+    )
 
-    fun onTertiaryFixed(): DynamicColor {
-        return DynamicColor(
-            name = "on_tertiary_fixed",
-            palette = { s -> s.tertiaryPalette },
-            tone = { s -> if (isMonochrome(s)) 100.0 else 10.0 },
-            isBackground = false,
-            background = { tertiaryFixedDim() },
-            secondBackground = { tertiaryFixed() },
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null)
-    }
+    fun onTertiaryFixed(): DynamicColor = DynamicColor(
+        name = "on_tertiary_fixed",
+        palette = { it.tertiaryPalette },
+        tone = { if (it.isMonochrome()) 100.0 else 10.0 },
+        isBackground = false,
+        background = { tertiaryFixedDim() },
+        secondBackground = { tertiaryFixed() },
+        contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
+        toneDeltaPair = null,
+    )
 
-    fun onTertiaryFixedVariant(): DynamicColor {
-        return DynamicColor(
-            name = "on_tertiary_fixed_variant",
-            palette = { s -> s.tertiaryPalette },
-            tone = { s -> if (isMonochrome(s)) 90.0 else 30.0 },
-            isBackground = false,
-            background = { tertiaryFixedDim() },
-            secondBackground = { tertiaryFixed() },
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = null)
-    }
+    fun onTertiaryFixedVariant(): DynamicColor = DynamicColor(
+        name = "on_tertiary_fixed_variant",
+        palette = { it.tertiaryPalette },
+        tone = { if (it.isMonochrome()) 90.0 else 30.0 },
+        isBackground = false,
+        background = { tertiaryFixedDim() },
+        secondBackground = { tertiaryFixed() },
+        contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
+        toneDeltaPair = null,
+    )
 
     /**
      * These colors were present in Android framework before Android U, and used by MDC controls. They
@@ -842,24 +828,20 @@ class MaterialDynamicColors(
     // colorAccent documented as colorSecondary in M3 and colorPrimary in GM3.
     // Android used Material's Container as Primary/Secondary/Tertiary at launch.
     // Therefore, this is a duplicated version of Primary Container.
-    fun controlActivated(): DynamicColor {
-        return DynamicColor.fromPalette(
-            name = "control_activated",
-            palette = { s -> s.primaryPalette },
-            tone = { s -> if (s.isDark) 30.0 else 90.0 },
-        )
-    }
+    fun controlActivated(): DynamicColor = DynamicColor.fromPalette(
+        name = "control_activated",
+        palette = { it.primaryPalette },
+        tone = { if (it.isDark) 30.0 else 90.0 },
+    )
 
     // colorControlNormal documented as textColorSecondary in M3 & GM3.
     // In Material, textColorSecondary points to onSurfaceVariant in the non-disabled state,
     // which is Neutral Variant T30/80 in light/dark.
-    fun controlNormal(): DynamicColor {
-        return DynamicColor.fromPalette(
-            name = "control_normal",
-            palette = { s -> s.neutralVariantPalette },
-            tone = { s -> if (s.isDark) 80.0 else 30.0 },
-        )
-    }
+    fun controlNormal(): DynamicColor = DynamicColor.fromPalette(
+        name = "control_normal",
+        palette = { it.neutralVariantPalette },
+        tone = { if (it.isDark) 80.0 else 30.0 },
+    )
 
     // colorControlHighlight documented, in both M3 & GM3:
     // Light mode: #1f000000 dark mode: #33ffffff.
@@ -869,65 +851,54 @@ class MaterialDynamicColors(
     // DynamicColors do not support alpha currently, and _may_ not need it for this use case,
     // depending on how MDC resolved alpha for the other cases.
     // Returning black in dark mode, white in light mode.
-    fun controlHighlight(): DynamicColor {
-        return DynamicColor(
-            name = "control_highlight",
-            palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 100.0 else 0.0 },
-            isBackground = false,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-            opacity = { s -> if (s.isDark) 0.20 else 0.12 })
-    }
+    fun controlHighlight(): DynamicColor = DynamicColor(
+        name = "control_highlight",
+        palette = { it.neutralPalette },
+        tone = { if (it.isDark) 100.0 else 0.0 },
+        isBackground = false,
+        background = null,
+        secondBackground = null,
+        contrastCurve = null,
+        toneDeltaPair = null,
+        opacity = { if (it.isDark) 0.20 else 0.12 },
+    )
 
     // textColorPrimaryInverse documented, in both M3 & GM3, documented as N10/N90.
-    fun textPrimaryInverse(): DynamicColor {
-        return DynamicColor.fromPalette(
-            name = "text_primary_inverse",
-            palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 10.0 else 90.0 },
-        )
-    }
+    fun textPrimaryInverse(): DynamicColor = DynamicColor.fromPalette(
+        name = "text_primary_inverse",
+        palette = { it.neutralPalette },
+        tone = { if (it.isDark) 10.0 else 90.0 },
+    )
 
     // textColorSecondaryInverse and textColorTertiaryInverse both documented, in both M3 & GM3, as
     // NV30/NV80
-    fun textSecondaryAndTertiaryInverse(): DynamicColor {
-        return DynamicColor.fromPalette(
-            name = "text_secondary_and_tertiary_inverse",
-            palette = { s -> s.neutralVariantPalette },
-            tone = { s -> if (s.isDark) 30.0 else 80.0 },
-        )
-    }
+    fun textSecondaryAndTertiaryInverse(): DynamicColor = DynamicColor.fromPalette(
+        name = "text_secondary_and_tertiary_inverse",
+        palette = { it.neutralVariantPalette },
+        tone = { if (it.isDark) 30.0 else 80.0 },
+    )
 
     // textColorPrimaryInverseDisableOnly documented, in both M3 & GM3, as N10/N90
-    fun textPrimaryInverseDisableOnly(): DynamicColor {
-        return DynamicColor.fromPalette(
-            name = "text_primary_inverse_disable_only",
-            palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 10.0 else 90.0 },
-        )
-    }
+    fun textPrimaryInverseDisableOnly(): DynamicColor = DynamicColor.fromPalette(
+        name = "text_primary_inverse_disable_only",
+        palette = { it.neutralPalette },
+        tone = { if (it.isDark) 10.0 else 90.0 },
+    )
 
     // textColorSecondaryInverse and textColorTertiaryInverse in disabled state both documented,
     // in both M3 & GM3, as N10/N90
-    fun textSecondaryAndTertiaryInverseDisabled(): DynamicColor {
-        return DynamicColor.fromPalette(
-            name = "text_secondary_and_tertiary_inverse_disabled",
-            palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 10.0 else 90.0 },
-        )
-    }
+    fun textSecondaryAndTertiaryInverseDisabled(): DynamicColor = DynamicColor.fromPalette(
+        name = "text_secondary_and_tertiary_inverse_disabled",
+        palette = { it.neutralPalette },
+        tone = { if (it.isDark) 10.0 else 90.0 },
+    )
 
     // textColorHintInverse documented, in both M3 & GM3, as N10/N90
-    fun textHintInverse(): DynamicColor {
-        return DynamicColor.fromPalette(
-            name = "text_hint_inverse",
-            palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 10.0 else 90.0 },
-        )
-    }
+    fun textHintInverse(): DynamicColor = DynamicColor.fromPalette(
+        name = "text_hint_inverse",
+        palette = { it.neutralPalette },
+        tone = { if (it.isDark) 10.0 else 90.0 },
+    )
 
     private fun isFidelity(scheme: DynamicScheme): Boolean {
         if (isExtendedFidelity
@@ -935,17 +906,20 @@ class MaterialDynamicColors(
             && scheme.variant != Variant.NEUTRAL
         ) return true
 
-        return scheme.variant == Variant.FIDELITY || scheme.variant == Variant.CONTENT;
+        return scheme.variant == Variant.FIDELITY || scheme.variant == Variant.CONTENT
+    }
+
+    private fun DynamicScheme.isMonochrome(): Boolean {
+        return variant === Variant.MONOCHROME
     }
 
     companion object {
 
-        private fun isMonochrome(scheme: DynamicScheme): Boolean {
-            return scheme.variant === Variant.MONOCHROME
-        }
-
         fun findDesiredChromaByTone(
-            hue: Double, chroma: Double, tone: Double, byDecreasingTone: Boolean,
+            hue: Double,
+            chroma: Double,
+            tone: Double,
+            byDecreasingTone: Boolean,
         ): Double {
             var answer = tone
             var closestToChroma = Hct.from(hue, chroma, tone)
@@ -954,12 +928,10 @@ class MaterialDynamicColors(
                 while (closestToChroma.getChroma() < chroma) {
                     answer += if (byDecreasingTone) -1.0 else 1.0
                     val potentialSolution = Hct.from(hue, chroma, answer)
-                    if (chromaPeak > potentialSolution.getChroma()) {
-                        break
-                    }
-                    if (abs(potentialSolution.getChroma() - chroma) < 0.4) {
-                        break
-                    }
+
+                    if (chromaPeak > potentialSolution.getChroma()) break
+                    if (abs(potentialSolution.getChroma() - chroma) < 0.4) break
+
                     val potentialDelta: Double = abs(potentialSolution.getChroma() - chroma)
                     val currentDelta: Double = abs(closestToChroma.getChroma() - chroma)
                     if (potentialDelta < currentDelta) {

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/MaterialDynamicColors.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/MaterialDynamicColors.kt
@@ -116,7 +116,10 @@ class MaterialDynamicColors(
         return DynamicColor(
             name = "surface_dim",
             palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 6.0 else 87.0 },
+            tone = { s ->
+                if (s.isDark) 6.0
+                else ContrastCurve(87.0, 87.0, 80.0, 75.0).get(s.contrastLevel)
+            },
             isBackground = true,
             background = null,
             secondBackground = null,
@@ -129,7 +132,10 @@ class MaterialDynamicColors(
         return DynamicColor(
             name = "surface_bright",
             palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 24.0 else 98.0 },
+            tone = { s ->
+                if (s.isDark) ContrastCurve(24.0, 24.0, 29.0, 34.0).get(s.contrastLevel)
+                else 98.0
+            },
             isBackground = true,
             background = null,
             secondBackground = null,
@@ -142,7 +148,10 @@ class MaterialDynamicColors(
         return DynamicColor(
             name = "surface_container_lowest",
             palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 4.0 else 100.0 },
+            tone = { s ->
+                if (s.isDark) ContrastCurve(4.0, 4.0, 2.0, 0.0).get(s.contrastLevel)
+                else 100.0
+            },
             isBackground = true,
             background = null,
             secondBackground = null,
@@ -155,7 +164,10 @@ class MaterialDynamicColors(
         return DynamicColor(
             name = "surface_container_low",
             palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 10.0 else 96.0 },
+            tone = { s ->
+                if (s.isDark) ContrastCurve(10.0, 10.0, 11.0, 12.0).get(s.contrastLevel)
+                else ContrastCurve(96.0, 96.0, 96.0, 95.0).get(s.contrastLevel)
+            },
             isBackground = true,
             background = null,
             secondBackground = null,
@@ -168,7 +180,10 @@ class MaterialDynamicColors(
         return DynamicColor(
             name = "surface_container",
             palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 12.0 else 94.0 },
+            tone = { s ->
+                if (s.isDark) ContrastCurve(12.0, 12.0, 16.0, 20.0).get(s.contrastLevel)
+                else ContrastCurve(94.0, 94.0, 92.0, 90.0).get(s.contrastLevel)
+            },
             isBackground = true,
             background = null,
             secondBackground = null,
@@ -181,7 +196,10 @@ class MaterialDynamicColors(
         return DynamicColor(
             name = "surface_container_high",
             palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 17.0 else 92.0 },
+            tone = { s ->
+                if (s.isDark) ContrastCurve(17.0, 17.0, 21.0, 25.0).get(s.contrastLevel)
+                else ContrastCurve(92.0, 92.0, 88.0, 85.0).get(s.contrastLevel)
+            },
             isBackground = true,
             background = null,
             secondBackground = null,
@@ -194,7 +212,10 @@ class MaterialDynamicColors(
         return DynamicColor(
             name = "surface_container_highest",
             palette = { s -> s.neutralPalette },
-            tone = { s -> if (s.isDark) 22.0 else 90.0 },
+            tone = { s ->
+                if (s.isDark) ContrastCurve(22.0, 22.0, 26.0, 30.0).get(s.contrastLevel)
+                else ContrastCurve(90.0, 90.0, 84.0, 80.0).get(s.contrastLevel)
+            },
             isBackground = true,
             background = null,
             secondBackground = null,
@@ -281,7 +302,7 @@ class MaterialDynamicColors(
             tone = { s -> if (s.isDark) 30.0 else 80.0 },
             isBackground = false, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 7.0),
+            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
             toneDeltaPair = null)
     }
 
@@ -334,8 +355,17 @@ class MaterialDynamicColors(
             },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = { ToneDeltaPair(primaryContainer(), primary(), 15.0, TonePolarity.NEARER, false) })
+            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
+            toneDeltaPair = {
+                ToneDeltaPair(
+                    roleA = primaryContainer(),
+                    roleB = primary(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            }
+        )
     }
 
     fun onPrimary(): DynamicColor {
@@ -371,8 +401,8 @@ class MaterialDynamicColors(
             },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 7.0),
-            toneDeltaPair = { ToneDeltaPair(primaryContainer(), primary(), 15.0, TonePolarity.NEARER, false) })
+            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+            toneDeltaPair = { ToneDeltaPair(primaryContainer(), primary(), 10.0, TonePolarity.NEARER, false) })
     }
 
     fun onPrimaryContainer(): DynamicColor {
@@ -403,7 +433,7 @@ class MaterialDynamicColors(
             isBackground = false,
             background = { inverseSurface() },
             secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
+            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
             toneDeltaPair = null)
     }
 
@@ -414,8 +444,8 @@ class MaterialDynamicColors(
             tone = { s -> if (s.isDark) 80.0 else 40.0 },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = { ToneDeltaPair(secondaryContainer(), secondary(), 15.0, TonePolarity.NEARER, false) })
+            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
+            toneDeltaPair = { ToneDeltaPair(secondaryContainer(), secondary(), 10.0, TonePolarity.NEARER, false) })
     }
 
     fun onSecondary(): DynamicColor {
@@ -448,18 +478,26 @@ class MaterialDynamicColors(
                     initialTone
                 } else {
                     findDesiredChromaByTone(
-                        s.secondaryPalette.hue,
-                        s.secondaryPalette.chroma,
-                        initialTone,
-                        !s.isDark
+                        hue = s.secondaryPalette.hue,
+                        chroma = s.secondaryPalette.chroma,
+                        tone = initialTone,
+                        byDecreasingTone = !s.isDark
                     )
                 }
-
             },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 7.0),
-            toneDeltaPair = { ToneDeltaPair(secondaryContainer(), secondary(), 15.0, TonePolarity.NEARER, false) })
+            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+            toneDeltaPair = {
+                ToneDeltaPair(
+                    roleA = secondaryContainer(),
+                    roleB = secondary(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            }
+        )
     }
 
     fun onSecondaryContainer(): DynamicColor {
@@ -492,8 +530,17 @@ class MaterialDynamicColors(
             },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = { ToneDeltaPair(tertiaryContainer(), tertiary(), 15.0, TonePolarity.NEARER, false) })
+            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
+            toneDeltaPair = {
+                ToneDeltaPair(
+                    roleA = tertiaryContainer(),
+                    roleB = tertiary(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            }
+        )
     }
 
     fun onTertiary(): DynamicColor {
@@ -530,8 +577,17 @@ class MaterialDynamicColors(
             },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 7.0),
-            toneDeltaPair = { ToneDeltaPair(tertiaryContainer(), tertiary(), 15.0, TonePolarity.NEARER, false) })
+            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+            toneDeltaPair = {
+                ToneDeltaPair(
+                    roleA = tertiaryContainer(),
+                    roleB = tertiary(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            }
+        )
     }
 
     fun onTertiaryContainer(): DynamicColor {
@@ -559,8 +615,17 @@ class MaterialDynamicColors(
             tone = { s -> if (s.isDark) 80.0 else 40.0 },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = { ToneDeltaPair(errorContainer(), error(), 15.0, TonePolarity.NEARER, false) })
+            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
+            toneDeltaPair = {
+                ToneDeltaPair(
+                    roleA = errorContainer(),
+                    roleB = error(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            },
+        )
     }
 
     fun onError(): DynamicColor {
@@ -582,8 +647,17 @@ class MaterialDynamicColors(
             tone = { s -> if (s.isDark) 30.0 else 90.0 },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 7.0),
-            toneDeltaPair = { ToneDeltaPair(errorContainer(), error(), 15.0, TonePolarity.NEARER, false) })
+            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
+            toneDeltaPair = {
+                ToneDeltaPair(
+                    roleA = errorContainer(),
+                    roleB = error(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            },
+        )
     }
 
     fun onErrorContainer(): DynamicColor {
@@ -605,7 +679,7 @@ class MaterialDynamicColors(
             tone = { s -> if (isMonochrome(s)) 40.0 else 90.0 },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 7.0),
+            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
             toneDeltaPair = { ToneDeltaPair(primaryFixed(), primaryFixedDim(), 10.0, TonePolarity.LIGHTER, true) })
     }
 
@@ -616,7 +690,7 @@ class MaterialDynamicColors(
             tone = { s -> if (isMonochrome(s)) 30.0 else 80.0 },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 7.0),
+            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
             toneDeltaPair = { ToneDeltaPair(primaryFixed(), primaryFixedDim(), 10.0, TonePolarity.LIGHTER, true) })
     }
 
@@ -651,7 +725,7 @@ class MaterialDynamicColors(
             tone = { s -> if (isMonochrome(s)) 80.0 else 90.0 },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 7.0),
+            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
             toneDeltaPair = {
                 ToneDeltaPair(
                     secondaryFixed(), secondaryFixedDim(), 10.0, TonePolarity.LIGHTER, true)
@@ -665,7 +739,7 @@ class MaterialDynamicColors(
             tone = { s -> if (isMonochrome(s)) 70.0 else 80.0 },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 7.0),
+            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
             toneDeltaPair = {
                 ToneDeltaPair(
                     secondaryFixed(), secondaryFixedDim(), 10.0, TonePolarity.LIGHTER, true)
@@ -703,7 +777,7 @@ class MaterialDynamicColors(
             tone = { s -> if (isMonochrome(s)) 40.0 else 90.0 },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 7.0),
+            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
             toneDeltaPair = {
                 ToneDeltaPair(
                     tertiaryFixed(), tertiaryFixedDim(), 10.0, TonePolarity.LIGHTER, true)
@@ -717,11 +791,17 @@ class MaterialDynamicColors(
             tone = { s -> if (isMonochrome(s)) 30.0 else 80.0 },
             isBackground = true, background = { s: DynamicScheme -> highestSurface(s) },
             secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 7.0),
+            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
             toneDeltaPair = {
                 ToneDeltaPair(
-                    tertiaryFixed(), tertiaryFixedDim(), 10.0, TonePolarity.LIGHTER, true)
-            })
+                    roleA = tertiaryFixed(),
+                    roleB = tertiaryFixedDim(),
+                    delta = 10.0,
+                    polarity = TonePolarity.LIGHTER,
+                    stayTogether = true,
+                )
+            },
+        )
     }
 
     fun onTertiaryFixed(): DynamicColor {

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ToneDeltaPair.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ToneDeltaPair.kt
@@ -19,46 +19,33 @@ package com.materialkolor.dynamiccolor
  * Documents a constraint between two DynamicColors, in which their tones must have a certain
  * distance from each other.
  *
- *
  * Prefer a DynamicColor with a background, this is for special cases when designers want tonal
  * distance, literally contrast, between two colors that don't have a background / foreground
  * relationship or a contrast guarantee.
- */
-class ToneDeltaPair
-/**
- * Documents a constraint in tone distance between two DynamicColors.
  *
+ * Documents a constraint in tone distance between two DynamicColors.
  *
  * The polarity is an adjective that describes "A", compared to "B".
  *
- *
  * For instance, ToneDeltaPair(A, B, 15, 'darker', stayTogether) states that A's tone should be
  * at least 15 darker than B's.
- *
  *
  * 'nearer' and 'farther' describes closeness to the surface roles. For instance,
  * ToneDeltaPair(A, B, 10, 'nearer', stayTogether) states that A should be 10 lighter than B in
  * light mode, and 10 darker than B in dark mode.
  *
- * @param roleA The first role in a pair.
- * @param roleB The second role in a pair.
- * @param delta Required difference between tones. Absolute value, negative values have undefined
+ * @param[roleA] The first role in a pair.
+ * @param[roleB] The second role in a pair.
+ * @param[delta] Required difference between tones. Absolute value, negative values have undefined
  * behavior.
- * @param polarity The relative relation between tones of roleA and roleB, as described above.
- * @param stayTogether Whether these two roles should stay on the same side of the "awkward zone"
+ * @param[polarity] The relative relation between tones of roleA and roleB, as described above.
+ * @param[stayTogether] Whether these two roles should stay on the same side of the "awkward zone"
  * (T50-59). This is necessary for certain cases where one role has two backgrounds.
- */(
-    /** The first role in a pair.  */
+ */
+class ToneDeltaPair(
     val roleA: DynamicColor,
-    /** The second role in a pair.  */
     val roleB: DynamicColor,
-    /** Required difference between tones. Absolute value, negative values have undefined behavior.  */
     val delta: Double,
-    /** The relative relation between tones of roleA and roleB, as described above.  */
     val polarity: TonePolarity,
-    /**
-     * Whether these two roles should stay on the same side of the "awkward zone" (T50-59). This is
-     * necessary for certain cases where one role has two backgrounds.
-     */
     val stayTogether: Boolean,
 )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/TonePolarity.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/TonePolarity.kt
@@ -18,18 +18,16 @@ package com.materialkolor.dynamiccolor
 /**
  * Describes the relationship in lightness between two colors.
  *
- *
  * 'nearer' and 'farther' describes closeness to the surface roles. For instance,
  * ToneDeltaPair(A, B, 10, 'nearer', stayTogether) states that A should be 10 lighter than B in
  * light mode, and 10 darker than B in dark mode.
  *
- *
- * See `ToneDeltaPair` for details.
+ * See [ToneDeltaPair] for details.
  */
 enum class TonePolarity {
 
     DARKER,
     LIGHTER,
     NEARER,
-    FARTHER
+    FARTHER,
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/Cam16.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/Cam16.kt
@@ -37,76 +37,47 @@ import kotlin.math.sqrt
  * CAM16, a color appearance model. Colors are not just defined by their hex code, but rather, a hex
  * code and viewing conditions.
  *
- *
  * CAM16 instances also have coordinates in the CAM16-UCS space, called J*, a*, b*, or jstar,
  * astar, bstar in code. CAM16-UCS is included in the CAM16 specification, and should be used when
  * measuring distances between colors.
- *
  *
  * In traditional color spaces, a color can be identified solely by the observer's measurement of
  * the color. Color appearance models such as CAM16 also use information about the environment where
  * the color was observed, known as the viewing conditions.
  *
- *
  * For example, white under the traditional assumption of a midday sun white point is accurately
  * measured as a slightly chromatic blue by CAM16. (roughly, hue 203, chroma 3, lightness 100)
- */
-internal class Cam16
-/**
+ *
  * All of the CAM16 dimensions can be calculated from 3 of the dimensions, in the following
  * combinations: - {j or q} and {c, m, or s} and hue - jstar, astar, bstar Prefer using a static
  * method that constructs from 3 of those dimensions. This constructor is intended for those
  * methods to use to return all possible dimensions.
  *
- * @param hue for example, red, orange, yellow, green, etc.
- * @param chroma informally, colorfulness / color intensity. like saturation in HSL, except
+ * @param[hue]  CAM16 color dimensions for example, red, orange, yellow, green, etc.
+ * @param[chroma] informally, colorfulness / color intensity. like saturation in HSL, except
  * perceptually accurate.
- * @param j lightness
- * @param q brightness; ratio of lightness to white point's lightness
- * @param m colorfulness
- * @param s saturation; ratio of chroma to white point's chroma
- * @param jstar CAM16-UCS J coordinate
- * @param astar CAM16-UCS a coordinate
- * @param bstar CAM16-UCS b coordinate
- */ private constructor(
-    /** Hue in CAM16  */
-    // CAM16 color dimensions, see getters for documentation.
+ * @param[j] lightness
+ * @param[q] Prefer lightness, brightness is an absolute quantity. For example, a sheet of white paper is
+ * much brighter viewed in sunlight than in indoor light, but it is the lightest object under any
+ * lighting.
+ * @param[m] Prefer chroma, colorfulness is an absolute quantity. For example, a yellow toy car is much
+ * more colorful outside than inside, but it has the same chroma in both environments.
+ * @param[s] Colorfulness in proportion to brightness. Prefer chroma, saturation measures colorfulness
+ * relative to the color's own brightness, where chroma is colorfulness relative to white.
+ * @param[jstar] CAM16-UCS J coordinate. Used to determine color distance, like delta E equations in L*a*b*.
+ * @param[astar] CAM16-UCS a coordinate
+ * @param[bstar] CAM16-UCS b coordinate
+ */
+@Suppress("unused", "MemberVisibilityCanBePrivate")
+internal class Cam16 private constructor(
     val hue: Double,
-    /** Chroma in CAM16  */
     val chroma: Double,
-    /** Lightness in CAM16  */
     val j: Double,
-    /**
-     * Brightness in CAM16.
-     *
-     *
-     * Prefer lightness, brightness is an absolute quantity. For example, a sheet of white paper is
-     * much brighter viewed in sunlight than in indoor light, but it is the lightest object under any
-     * lighting.
-     */
     val q: Double,
-    /**
-     * Colorfulness in CAM16.
-     *
-     *
-     * Prefer chroma, colorfulness is an absolute quantity. For example, a yellow toy car is much
-     * more colorful outside than inside, but it has the same chroma in both environments.
-     */
     val m: Double,
-    /**
-     * Saturation in CAM16.
-     *
-     *
-     * Colorfulness in proportion to brightness. Prefer chroma, saturation measures colorfulness
-     * relative to the color's own brightness, where chroma is colorfulness relative to white.
-     */
     val s: Double,
-    /** Lightness coordinate in CAM16-UCS  */
-    // Coordinates in UCS space. Used to determine color distance, like delta E equations in L*a*b*.
     val jstar: Double,
-    /** a* coordinate in CAM16-UCS  */
     val astar: Double,
-    /** b* coordinate in CAM16-UCS  */
     val bstar: Double,
 ) {
 
@@ -130,14 +101,12 @@ internal class Cam16
      * ARGB representation of the color. Assumes the color was viewed in default viewing conditions,
      * which are near-identical to the default viewing conditions for sRGB.
      */
-    fun toInt(): Int {
-        return viewed(ViewingConditions.DEFAULT)
-    }
+    fun toInt(): Int = viewed(ViewingConditions.DEFAULT)
 
     /**
      * ARGB representation of the color, in defined viewing conditions.
      *
-     * @param viewingConditions Information about the environment where the color will be viewed.
+     * @param[viewingConditions] Information about the environment where the color will be viewed.
      * @return ARGB representation of color
      */
     fun viewed(viewingConditions: ViewingConditions): Int {
@@ -145,7 +114,10 @@ internal class Cam16
         return argbFromXyz(xyz[0], xyz[1], xyz[2])
     }
 
-    fun xyzInViewingConditions(viewingConditions: ViewingConditions, returnArray: DoubleArray?): DoubleArray {
+    fun xyzInViewingConditions(
+        viewingConditions: ViewingConditions,
+        returnArray: DoubleArray?,
+    ): DoubleArray {
         val alpha = if (chroma == 0.0 || j == 0.0) 0.0 else chroma / sqrt(j / 100.0)
         val t: Double = pow(
             alpha / pow(1.64 - pow(0.29, viewingConditions.n), 0.73), 1.0 / 0.9)
@@ -169,9 +141,9 @@ internal class Cam16
         val gC: Double = signum(gA) * (100.0 / viewingConditions.fl) * pow(gCBase, 1.0 / 0.42)
         val bCBase: Double = max(0.0, 27.13 * abs(bA) / (400.0 - abs(bA)))
         val bC: Double = signum(bA) * (100.0 / viewingConditions.fl) * pow(bCBase, 1.0 / 0.42)
-        val rF: Double = rC / viewingConditions.rgbD.get(0)
-        val gF: Double = gC / viewingConditions.rgbD.get(1)
-        val bF: Double = bC / viewingConditions.rgbD.get(2)
+        val rF: Double = rC / viewingConditions.rgbD[0]
+        val gF: Double = gC / viewingConditions.rgbD[1]
+        val bF: Double = bC / viewingConditions.rgbD[2]
         val matrix = CAM16RGB_TO_XYZ
         val x = rF * matrix[0][0] + gF * matrix[0][1] + bF * matrix[0][2]
         val y = rF * matrix[1][0] + gF * matrix[1][1] + bF * matrix[1][2]
@@ -189,29 +161,36 @@ internal class Cam16
     companion object {
 
         // Transforms XYZ color space coordinates to 'cone'/'RGB' responses in CAM16.
-        val XYZ_TO_CAM16RGB = arrayOf(doubleArrayOf(0.401288, 0.650173, -0.051461), doubleArrayOf(-0.250268, 1.204414, 0.045854), doubleArrayOf(-0.002079, 0.048952, 0.953127))
+        val XYZ_TO_CAM16RGB = arrayOf(
+            doubleArrayOf(0.401288, 0.650173, -0.051461),
+            doubleArrayOf(-0.250268, 1.204414, 0.045854),
+            doubleArrayOf(-0.002079, 0.048952, 0.953127),
+        )
 
         // Transforms 'cone'/'RGB' responses in CAM16 to XYZ color space coordinates.
-        val CAM16RGB_TO_XYZ = arrayOf(doubleArrayOf(1.8620678, -1.0112547, 0.14918678), doubleArrayOf(0.38752654, 0.62144744, -0.00897398), doubleArrayOf(-0.01584150, -0.03412294, 1.0499644))
+        val CAM16RGB_TO_XYZ = arrayOf(
+            doubleArrayOf(1.8620678, -1.0112547, 0.14918678),
+            doubleArrayOf(0.38752654, 0.62144744, -0.00897398),
+            doubleArrayOf(-0.01584150, -0.03412294, 1.0499644),
+        )
 
         /**
          * Create a CAM16 color from a color, assuming the color was viewed in default viewing conditions.
          *
-         * @param argb ARGB representation of a color.
+         * @param[argb] ARGB representation of a color.
          */
-        fun fromInt(argb: Int): Cam16 {
-            return fromIntInViewingConditions(argb, ViewingConditions.DEFAULT)
-        }
+        fun fromInt(argb: Int): Cam16 = fromIntInViewingConditions(argb, ViewingConditions.DEFAULT)
 
         /**
          * Create a CAM16 color from a color in defined viewing conditions.
          *
-         * @param argb ARGB representation of a color.
-         * @param viewingConditions Information about the environment where the color was observed.
+         * The RGB => XYZ conversion matrix elements are derived scientific constants. While the values
+         * may differ at runtime due to floating point imprecision, keeping the values the same, and
+         * accurate, across implementations takes precedence.
+         *
+         * @param[argb] ARGB representation of a color.
+         * @param[viewingConditions] Information about the environment where the color was observed.
          */
-        // The RGB => XYZ conversion matrix elements are derived scientific constants. While the values
-        // may differ at runtime due to floating point imprecision, keeping the values the same, and
-        // accurate, across implementations takes precedence.
         fun fromIntInViewingConditions(argb: Int, viewingConditions: ViewingConditions): Cam16 {
             // Transform ARGB int to XYZ
             val red = argb and 0x00ff0000 shr 16
@@ -227,7 +206,10 @@ internal class Cam16
         }
 
         fun fromXyzInViewingConditions(
-            x: Double, y: Double, z: Double, viewingConditions: ViewingConditions,
+            x: Double,
+            y: Double,
+            z: Double,
+            viewingConditions: ViewingConditions,
         ): Cam16 {
             // Transform XYZ to 'cone'/'rgb' responses
             val matrix = XYZ_TO_CAM16RGB
@@ -236,9 +218,9 @@ internal class Cam16
             val bT = x * matrix[2][0] + y * matrix[2][1] + z * matrix[2][2]
 
             // Discount illuminant
-            val rD: Double = viewingConditions.rgbD.get(0) * rT
-            val gD: Double = viewingConditions.rgbD.get(1) * gT
-            val bD: Double = viewingConditions.rgbD.get(2) * bT
+            val rD: Double = viewingConditions.rgbD[0] * rT
+            val gD: Double = viewingConditions.rgbD[1] * gT
+            val bD: Double = viewingConditions.rgbD[2] * bT
 
             // Chromatic adaptation
             val rAF: Double = pow(viewingConditions.fl * abs(rD) / 100.0, 0.42)
@@ -260,7 +242,12 @@ internal class Cam16
             // hue
             val atan2: Double = atan2(b, a)
             val atanDegrees: Double = toDegrees(atan2)
-            val hue = if (atanDegrees < 0) atanDegrees + 360.0 else if (atanDegrees >= 360) atanDegrees - 360.0 else atanDegrees
+            val hue =
+                if (atanDegrees < 0) atanDegrees + 360.0
+                else {
+                    if (atanDegrees >= 360) atanDegrees - 360.0
+                    else atanDegrees
+                }
             val hueRadians: Double = toRadians(hue)
 
             // achromatic response to color
@@ -296,19 +283,19 @@ internal class Cam16
         }
 
         /**
-         * @param j CAM16 lightness
-         * @param c CAM16 chroma
-         * @param h CAM16 hue
+         * @param[j] CAM16 lightness
+         * @param[c] CAM16 chroma
+         * @param[h] CAM16 hue
          */
         fun fromJch(j: Double, c: Double, h: Double): Cam16 {
             return fromJchInViewingConditions(j, c, h, ViewingConditions.DEFAULT)
         }
 
         /**
-         * @param j CAM16 lightness
-         * @param c CAM16 chroma
-         * @param h CAM16 hue
-         * @param viewingConditions Information about the environment where the color was observed.
+         * @param[j] CAM16 lightness
+         * @param[c] CAM16 chroma
+         * @param[h] CAM16 hue
+         * @param[viewingConditions] Information about the environment where the color was observed.
          */
         private fun fromJchInViewingConditions(
             j: Double, c: Double, h: Double, viewingConditions: ViewingConditions,
@@ -331,10 +318,10 @@ internal class Cam16
         /**
          * Create a CAM16 color from CAM16-UCS coordinates.
          *
-         * @param jstar CAM16-UCS lightness.
-         * @param astar CAM16-UCS a dimension. Like a* in L*a*b*, it is a Cartesian coordinate on the Y
+         * @param[jstar] CAM16-UCS lightness.
+         * @param[astar] CAM16-UCS a dimension. Like a* in L*a*b*, it is a Cartesian coordinate on the Y
          * axis.
-         * @param bstar CAM16-UCS b dimension. Like a* in L*a*b*, it is a Cartesian coordinate on the X
+         * @param[bstar] CAM16-UCS b dimension. Like a* in L*a*b*, it is a Cartesian coordinate on the X
          * axis.
          */
         fun fromUcs(jstar: Double, astar: Double, bstar: Double): Cam16 {
@@ -344,12 +331,12 @@ internal class Cam16
         /**
          * Create a CAM16 color from CAM16-UCS coordinates in defined viewing conditions.
          *
-         * @param jstar CAM16-UCS lightness.
-         * @param astar CAM16-UCS a dimension. Like a* in L*a*b*, it is a Cartesian coordinate on the Y
+         * @param[jstar] CAM16-UCS lightness.
+         * @param[astar] CAM16-UCS a dimension. Like a* in L*a*b*, it is a Cartesian coordinate on the Y
          * axis.
-         * @param bstar CAM16-UCS b dimension. Like a* in L*a*b*, it is a Cartesian coordinate on the X
+         * @param[bstar] CAM16-UCS b dimension. Like a* in L*a*b*, it is a Cartesian coordinate on the X
          * axis.
-         * @param viewingConditions Information about the environment where the color was observed.
+         * @param[viewingConditions] Information about the environment where the color was observed.
          */
         fun fromUcsInViewingConditions(
             jstar: Double, astar: Double, bstar: Double, viewingConditions: ViewingConditions,

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/Hct.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/Hct.kt
@@ -33,12 +33,12 @@ import com.materialkolor.utils.ColorUtils.lstarFromY
  * Unlike contrast ratio, measuring contrast in L* is linear, and simple to calculate. A
  * difference of 40 in HCT tone guarantees a contrast ratio >= 3.0, and a difference of 50
  * guarantees a contrast ratio >= 4.5.
- */
-/**
+ *
  * HCT, hue, chroma, and tone. A color system that provides a perceptually accurate color
  * measurement system that can also accurately render what colors will appear as in different
  * lighting environments.
  */
+@Suppress("unused")
 class Hct private constructor(argb: Int) {
 
     private var hue = 0.0
@@ -50,27 +50,16 @@ class Hct private constructor(argb: Int) {
         setInternalState(argb)
     }
 
-    fun getHue(): Double {
-        return hue
-    }
-
-    fun getChroma(): Double {
-        return chroma
-    }
-
-    fun getTone(): Double {
-        return tone
-    }
-
-    fun toInt(): Int {
-        return argb
-    }
+    fun getHue(): Double = hue
+    fun getChroma(): Double = chroma
+    fun getTone(): Double = tone
+    fun toInt(): Int = argb
 
     /**
      * Set the hue of this color. Chroma may decrease because chroma has a different maximum for any
      * given hue and tone.
      *
-     * @param newHue 0 <= newHue < 360; invalid values are corrected.
+     * @param[newHue] 0 <= newHue < 360; invalid values are corrected.
      */
     fun setHue(newHue: Double) {
         setInternalState(HctSolver.solveToInt(newHue, chroma, tone))
@@ -80,7 +69,7 @@ class Hct private constructor(argb: Int) {
      * Set the chroma of this color. Chroma may decrease because chroma has a different maximum for
      * any given hue and tone.
      *
-     * @param newChroma 0 <= newChroma < ?
+     * @param[newChroma] 0 <= newChroma < ?
      */
     fun setChroma(newChroma: Double) {
         setInternalState(HctSolver.solveToInt(hue, newChroma, tone))
@@ -90,7 +79,7 @@ class Hct private constructor(argb: Int) {
      * Set the tone of this color. Chroma may decrease because chroma has a different maximum for any
      * given hue and tone.
      *
-     * @param newTone 0 <= newTone <= 100; invalid valids are corrected.
+     * @param[newTone] 0 <= newTone <= 100; invalid valids are corrected.
      */
     fun setTone(newTone: Double) {
         setInternalState(HctSolver.solveToInt(hue, chroma, newTone))
@@ -141,10 +130,10 @@ class Hct private constructor(argb: Int) {
         /**
          * Create an HCT color from hue, chroma, and tone.
          *
-         * @param hue 0 <= hue < 360; invalid values are corrected.
-         * @param chroma 0 <= chroma < ?; Informally, colorfulness. The color returned may be lower than
+         * @param[hue] 0 <= hue < 360; invalid values are corrected.
+         * @param[chroma] 0 <= chroma < ?; Informally, colorfulness. The color returned may be lower than
          * the requested chroma. Chroma has a different maximum for any given hue and tone.
-         * @param tone 0 <= tone <= 100; invalid values are corrected.
+         * @param[tone] 0 <= tone <= 100; invalid values are corrected.
          * @return HCT representation of a color in default viewing conditions.
          */
         fun from(hue: Double, chroma: Double, tone: Double): Hct {
@@ -155,11 +144,9 @@ class Hct private constructor(argb: Int) {
         /**
          * Create an HCT color from a color.
          *
-         * @param argb ARGB representation of a color.
+         * @param[argb] ARGB representation of a color.
          * @return HCT representation of a color in default viewing conditions
          */
-        fun fromInt(argb: Int): Hct {
-            return Hct(argb)
-        }
+        fun fromInt(argb: Int): Hct = Hct(argb)
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/HctSolver.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/HctSolver.kt
@@ -34,17 +34,23 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 
 /** A class that solves the HCT equation.  */
+@Suppress("MemberVisibilityCanBePrivate", "unused")
 internal object HctSolver {
 
-    val SCALED_DISCOUNT_FROM_LINRGB = arrayOf(doubleArrayOf(
-        0.001200833568784504, 0.002389694492170889, 0.0002795742885861124), doubleArrayOf(
-        0.0005891086651375999, 0.0029785502573438758, 0.0003270666104008398), doubleArrayOf(
-        0.00010146692491640572, 0.0005364214359186694, 0.0032979401770712076))
-    val LINRGB_FROM_SCALED_DISCOUNT = arrayOf(doubleArrayOf(
-        1373.2198709594231, -1100.4251190754821, -7.278681089101213), doubleArrayOf(
-        -271.815969077903, 559.6580465940733, -32.46047482791194), doubleArrayOf(
-        1.9622899599665666, -57.173814538844006, 308.7233197812385))
+    val SCALED_DISCOUNT_FROM_LINRGB = arrayOf(
+        doubleArrayOf(0.001200833568784504, 0.002389694492170889, 0.0002795742885861124),
+        doubleArrayOf(0.0005891086651375999, 0.0029785502573438758, 0.0003270666104008398),
+        doubleArrayOf(0.00010146692491640572, 0.0005364214359186694, 0.0032979401770712076),
+    )
+
+    val LINRGB_FROM_SCALED_DISCOUNT = arrayOf(
+        doubleArrayOf(1373.2198709594231, -1100.4251190754821, -7.278681089101213),
+        doubleArrayOf(-271.815969077903, 559.6580465940733, -32.46047482791194),
+        doubleArrayOf(1.9622899599665666, -57.173814538844006, 308.7233197812385),
+    )
+
     val Y_FROM_LINRGB = doubleArrayOf(0.2126, 0.7152, 0.0722)
+
     val CRITICAL_PLANES = doubleArrayOf(
         0.015176349177441876,
         0.045529047532325624,
@@ -300,31 +306,29 @@ internal object HctSolver {
         96.9059996312159,
         97.78421388448044,
         98.6670533535366,
-        99.55452497210776)
+        99.55452497210776,
+    )
 
     /**
      * Sanitizes a small enough angle in radians.
      *
-     * @param angle An angle in radians; must not deviate too much from 0.
+     * @param[angle] An angle in radians; must not deviate too much from 0.
      * @return A coterminal angle between 0 and 2pi.
      */
-    fun sanitizeRadians(angle: Double): Double {
-        return (angle + PI * 8) % (PI * 2)
-    }
+    fun sanitizeRadians(angle: Double): Double = (angle + PI * 8) % (PI * 2)
 
     /**
      * Delinearizes an RGB component, returning a floating-point number.
      *
-     * @param rgbComponent 0.0 <= rgb_component <= 100.0, represents linear R/G/B channel
+     * @param[rgbComponent] 0.0 <= rgb_component <= 100.0, represents linear R/G/B channel
      * @return 0.0 <= output <= 255.0, color channel converted to regular RGB space
      */
     fun trueDelinearized(rgbComponent: Double): Double {
         val normalized = rgbComponent / 100.0
-        val delinearized: Double = if (normalized <= 0.0031308) {
-            normalized * 12.92
-        } else {
-            1.055 * normalized.pow(1.0 / 2.4) - 0.055
-        }
+        val delinearized: Double =
+            if (normalized <= 0.0031308) normalized * 12.92
+            else 1.055 * normalized.pow(1.0 / 2.4) - 0.055
+
         return delinearized * 255.0
     }
 
@@ -336,7 +340,7 @@ internal object HctSolver {
     /**
      * Returns the hue of a linear RGB color in CAM16.
      *
-     * @param linrgb The linear RGB coordinates of a color.
+     * @param[linrgb] The linear RGB coordinates of a color.
      * @return The hue of the color in CAM16, in radians.
      */
     fun hueOf(linrgb: DoubleArray?): Double {
@@ -360,46 +364,48 @@ internal object HctSolver {
     /**
      * Solves the lerp equation.
      *
-     * @param source The starting number.
-     * @param mid The number in the middle.
-     * @param target The ending number.
+     * @param[source] The starting number.
+     * @param[mid] The number in the middle.
+     * @param[target] The ending number.
      * @return A number t such that lerp(source, target, t) = mid.
      */
     fun intercept(source: Double, mid: Double, target: Double): Double {
         return (mid - source) / (target - source)
     }
 
-    fun lerpPoint(source: DoubleArray, t: Double, target: DoubleArray): DoubleArray {
-        return doubleArrayOf(
-            source[0] + (target[0] - source[0]) * t,
-            source[1] + (target[1] - source[1]) * t,
-            source[2] + (target[2] - source[2]) * t)
-    }
+    fun lerpPoint(source: DoubleArray, t: Double, target: DoubleArray): DoubleArray = doubleArrayOf(
+        source[0] + (target[0] - source[0]) * t,
+        source[1] + (target[1] - source[1]) * t,
+        source[2] + (target[2] - source[2]) * t,
+    )
 
     /**
      * Intersects a segment with a plane.
      *
-     * @param source The coordinates of point A.
-     * @param coordinate The R-, G-, or B-coordinate of the plane.
-     * @param target The coordinates of point B.
-     * @param axis The axis the plane is perpendicular with. (0: R, 1: G, 2: B)
+     * @param[source] The coordinates of point A.
+     * @param[coordinate] The R-, G-, or B-coordinate of the plane.
+     * @param[target] The coordinates of point B.
+     * @param[axis] The axis the plane is perpendicular with. (0: R, 1: G, 2: B)
      * @return The intersection point of the segment AB with the plane R=coordinate, G=coordinate, or
      * B=coordinate
      */
-    fun setCoordinate(source: DoubleArray, coordinate: Double, target: DoubleArray, axis: Int): DoubleArray {
+    fun setCoordinate(
+        source: DoubleArray,
+        coordinate: Double,
+        target: DoubleArray,
+        axis: Int,
+    ): DoubleArray {
         val t = intercept(source[axis], coordinate, target[axis])
         return lerpPoint(source, t, target)
     }
 
-    fun isBounded(x: Double): Boolean {
-        return x in 0.0..100.0
-    }
+    fun isBounded(x: Double): Boolean = x in 0.0..100.0
 
     /**
      * Returns the nth possible vertex of the polygonal intersection.
      *
-     * @param y The Y value of the plane.
-     * @param n The zero-based index of the point. 0 <= n <= 11.
+     * @param[y] The Y value of the plane.
+     * @param[n] The zero-based index of the point. 0 <= n <= 11.
      * @return The nth possible vertex of the polygonal intersection of the y plane and the RGB cube,
      * in linear RGB coordinates, if it exists. If this possible vertex lies outside of the cube,
      * [-1.0, -1.0, -1.0] is returned.
@@ -410,26 +416,21 @@ internal object HctSolver {
         val kB = Y_FROM_LINRGB[2]
         val coordA = if (n % 4 <= 1) 0.0 else 100.0
         val coordB = if (n % 2 == 0) 0.0 else 100.0
-        return if (n < 4) {
-            val r = (y - coordA * kG - coordB * kB) / kR
-            if (isBounded(r)) {
-                doubleArrayOf(r, coordA, coordB)
-            } else {
-                doubleArrayOf(-1.0, -1.0, -1.0)
+        return when {
+            n < 4 -> {
+                val r = (y - coordA * kG - coordB * kB) / kR
+                if (isBounded(r)) doubleArrayOf(r, coordA, coordB)
+                else doubleArrayOf(-1.0, -1.0, -1.0)
             }
-        } else if (n < 8) {
-            val g = (y - coordB * kR - coordA * kB) / kG
-            if (isBounded(g)) {
-                doubleArrayOf(coordB, g, coordA)
-            } else {
-                doubleArrayOf(-1.0, -1.0, -1.0)
+            n < 8 -> {
+                val g = (y - coordB * kR - coordA * kB) / kG
+                if (isBounded(g)) doubleArrayOf(coordB, g, coordA)
+                else doubleArrayOf(-1.0, -1.0, -1.0)
             }
-        } else {
-            val b = (y - coordA * kR - coordB * kG) / kB
-            if (isBounded(b)) {
-                doubleArrayOf(coordA, coordB, b)
-            } else {
-                doubleArrayOf(-1.0, -1.0, -1.0)
+            else -> {
+                val b = (y - coordA * kR - coordB * kG) / kB
+                if (isBounded(b)) doubleArrayOf(coordA, coordB, b)
+                else doubleArrayOf(-1.0, -1.0, -1.0)
             }
         }
     }
@@ -437,8 +438,8 @@ internal object HctSolver {
     /**
      * Finds the segment containing the desired color.
      *
-     * @param y The Y value of the color.
-     * @param targetHue The hue of the color.
+     * @param[y] The Y value of the color.
+     * @param[targetHue] The hue of the color.
      * @return A list of two sets of linear RGB coordinates, each corresponding to an endpoint of the
      * segment containing the desired color.
      */
@@ -477,24 +478,22 @@ internal object HctSolver {
         return arrayOf(left, right)
     }
 
-    fun midpoint(a: DoubleArray, b: DoubleArray): DoubleArray {
-        return doubleArrayOf(
-            (a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2)
-    }
+    fun midpoint(a: DoubleArray, b: DoubleArray): DoubleArray =
+        doubleArrayOf(
+            (a[0] + b[0]) / 2,
+            (a[1] + b[1]) / 2,
+            (a[2] + b[2]) / 2,
+        )
 
-    fun criticalPlaneBelow(x: Double): Int {
-        return floor(x - 0.5).toInt()
-    }
+    fun criticalPlaneBelow(x: Double): Int = floor(x - 0.5).toInt()
 
-    fun criticalPlaneAbove(x: Double): Int {
-        return ceil(x - 0.5).toInt()
-    }
+    fun criticalPlaneAbove(x: Double): Int = ceil(x - 0.5).toInt()
 
     /**
      * Finds a color with the given Y and hue on the boundary of the cube.
      *
-     * @param y The Y value of the color.
-     * @param targetHue The hue of the color.
+     * @param[y] The Y value of the color.
+     * @param[targetHue] The hue of the color.
      * @return The desired color, in linear RGB coordinates.
      */
     fun bisectToLimit(y: Double, targetHue: Double): DoubleArray {
@@ -504,8 +503,8 @@ internal object HctSolver {
         var right = segment[1]
         for (axis in 0..2) {
             if (left[axis] != right[axis]) {
-                @Suppress("VARIABLE_WITH_REDUNDANT_INITIALIZER") var lPlane = -1
-                @Suppress("VARIABLE_WITH_REDUNDANT_INITIALIZER") var rPlane = 255
+                var lPlane: Int
+                var rPlane: Int
                 if (left[axis] < right[axis]) {
                     lPlane = criticalPlaneBelow(trueDelinearized(left[axis]))
                     rPlane = criticalPlaneAbove(trueDelinearized(right[axis]))
@@ -514,9 +513,8 @@ internal object HctSolver {
                     rPlane = criticalPlaneBelow(trueDelinearized(right[axis]))
                 }
                 for (i in 0..7) {
-                    if (abs(rPlane - lPlane) <= 1) {
-                        break
-                    } else {
+                    if (abs(rPlane - lPlane) <= 1) break
+                    else {
                         val mPlane: Int = floor((lPlane + rPlane) / 2.0).toInt()
                         val midPlaneCoordinate = CRITICAL_PLANES[mPlane]
                         val mid = setCoordinate(left, midPlaneCoordinate, right, axis)
@@ -545,9 +543,9 @@ internal object HctSolver {
     /**
      * Finds a color with the given hue, chroma, and Y.
      *
-     * @param hueRadians The desired hue in radians.
-     * @param chroma The desired chroma.
-     * @param y The desired Y.
+     * @param[hueRadians] The desired hue in radians.
+     * @param[chroma] The desired chroma.
+     * @param[y] The desired Y.
      * @return The desired color as a hexadecimal integer, if found; 0 otherwise.
      */
     fun findResultByJ(hueRadians: Double, chroma: Double, y: Double): Int {
@@ -596,9 +594,8 @@ internal object HctSolver {
                 return 0
             }
             if (iterationRound == 4 || abs(fnj - y) < 0.002) {
-                return if (linrgb[0] > 100.01 || linrgb[1] > 100.01 || linrgb[2] > 100.01) {
-                    0
-                } else argbFromLinrgb(linrgb)
+                return if (linrgb[0] > 100.01 || linrgb[1] > 100.01 || linrgb[2] > 100.01) 0
+                else argbFromLinrgb(linrgb)
             }
             // Iterates with Newton method,
             // Using 2 * fn(j) / j as the approximation of fn'(j)
@@ -610,9 +607,9 @@ internal object HctSolver {
     /**
      * Finds an sRGB color with the given hue, chroma, and L*, if possible.
      *
-     * @param hueDegrees The desired hue, in degrees.
-     * @param chroma The desired chroma.
-     * @param lstar The desired L*.
+     * @param[hueDegrees] The desired hue, in degrees.
+     * @param[chroma] The desired chroma.
+     * @param[lstar] The desired L*.
      * @return A hexadecimal representing the sRGB color. The color has sufficiently close hue,
      * chroma, and L* to the desired values, if possible; otherwise, the hue and L* will be
      * sufficiently close, and chroma will be maximized.
@@ -622,12 +619,13 @@ internal object HctSolver {
         if (chroma < 0.0001 || lstar < 0.0001 || lstar > 99.9999) {
             return argbFromLstar(lstar)
         }
+
         val hueRadians: Double = hueDegrees1 / 180 * PI
         val y = yFromLstar(lstar)
+
         val exactAnswer = findResultByJ(hueRadians, chroma, y)
-        if (exactAnswer != 0) {
-            return exactAnswer
-        }
+        if (exactAnswer != 0) return exactAnswer
+
         val linrgb = bisectToLimit(y, hueRadians)
         return argbFromLinrgb(linrgb)
     }
@@ -635,9 +633,9 @@ internal object HctSolver {
     /**
      * Finds an sRGB color with the given hue, chroma, and L*, if possible.
      *
-     * @param hueDegrees The desired hue, in degrees.
-     * @param chroma The desired chroma.
-     * @param lstar The desired L*.
+     * @param[hueDegrees] The desired hue, in degrees.
+     * @param[chroma] The desired chroma.
+     * @param[lstar] The desired L*.
      * @return A CAM16 object representing the sRGB color. The color has sufficiently close hue,
      * chroma, and L* to the desired values, if possible; otherwise, the hue and L* will be
      * sufficiently close, and chroma will be maximized.

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/ViewingConditions.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/ViewingConditions.kt
@@ -31,21 +31,18 @@ import kotlin.math.sqrt
  * the color. Color appearance models such as CAM16 also use information about the environment where
  * the color was observed, known as the viewing conditions.
  *
- *
  * For example, white under the traditional assumption of a midday sun white point is accurately
  * measured as a slightly chromatic blue by CAM16. (roughly, hue 203, chroma 3, lightness 100)
  *
- *
  * This class caches intermediate values of the CAM16 conversion process that depend only on
  * viewing conditions, enabling speed ups.
- */
-internal class ViewingConditions
-/**
+ *
  * Parameters are intermediate values of the CAM16 conversion process. Their names are shorthand
  * for technical color science terminology, this class would not benefit from documenting them
  * individually. A brief overview is available in the CAM16 specification, and a complete overview
  * requires a color science textbook, such as Fairchild's Color Appearance Models.
- */ private constructor(
+ */
+internal class ViewingConditions private constructor(
     val n: Double,
     val aw: Double,
     val nbb: Double,
@@ -58,6 +55,7 @@ internal class ViewingConditions
     val z: Double,
 ) {
 
+    @Suppress("MemberVisibilityCanBePrivate")
     companion object {
 
         /** sRGB-like viewing conditions.  */
@@ -97,11 +95,19 @@ internal class ViewingConditions
             val gW = whitePoint[0] * matrix[1][0] + whitePoint[1] * matrix[1][1] + whitePoint[2] * matrix[1][2]
             val bW = whitePoint[0] * matrix[2][0] + whitePoint[1] * matrix[2][1] + whitePoint[2] * matrix[2][2]
             val f = 0.8 + surround / 10.0
-            val c = if (f >= 0.9) lerp(0.59, 0.69, (f - 0.9) * 10.0) else lerp(0.525, 0.59, (f - 0.8) * 10.0)
-            var d = if (discountingIlluminant) 1.0 else f * (1.0 - 1.0 / 3.6 * exp((-adaptingLuminance - 42.0) / 92.0))
+            val c =
+                if (f >= 0.9) lerp(0.59, 0.69, (f - 0.9) * 10.0)
+                else lerp(0.525, 0.59, (f - 0.8) * 10.0)
+
+            var d =
+                if (discountingIlluminant) 1.0
+                else f * (1.0 - 1.0 / 3.6 * exp((-adaptingLuminance - 42.0) / 92.0))
             d = clampDouble(0.0, 1.0, d)
+
             val rgbD = doubleArrayOf(
-                d * (100.0 / rW) + 1.0 - d, d * (100.0 / gW) + 1.0 - d, d * (100.0 / bW) + 1.0 - d
+                d * (100.0 / rW) + 1.0 - d,
+                d * (100.0 / gW) + 1.0 - d,
+                d * (100.0 / bW) + 1.0 - d,
             )
             val k = 1.0 / (5.0 * adaptingLuminance + 1.0)
             val k4 = k * k * k * k
@@ -118,7 +124,7 @@ internal class ViewingConditions
             val rgbA = doubleArrayOf(
                 400.0 * rgbAFactors[0] / (rgbAFactors[0] + 27.13),
                 400.0 * rgbAFactors[1] / (rgbAFactors[1] + 27.13),
-                400.0 * rgbAFactors[2] / (rgbAFactors[2] + 27.13)
+                400.0 * rgbAFactors[2] / (rgbAFactors[2] + 27.13),
             )
             val aw = (2.0 * rgbA[0] + rgbA[1] + 0.05 * rgbA[2]) * nbb
             return ViewingConditions(n, aw, nbb, nbb, c, f, rgbD, fl, fl.pow(0.25), z)
@@ -127,16 +133,14 @@ internal class ViewingConditions
         /**
          * Create sRGB-like viewing conditions with a custom background lstar.
          *
-         *
          * Default viewing conditions have a lstar of 50, midgray.
          */
-        fun defaultWithBackgroundLstar(lstar: Double): ViewingConditions {
-            return make(
-                whitePointD65(),
-                200.0 / PI * yFromLstar(50.0) / 100f,
-                lstar,
-                2.0,
-                false)
-        }
+        fun defaultWithBackgroundLstar(lstar: Double): ViewingConditions = make(
+            whitePoint = whitePointD65(),
+            adaptingLuminance = 200.0 / PI * yFromLstar(50.0) / 100f,
+            backgroundLstar = lstar,
+            surround = 2.0,
+            discountingIlluminant = false,
+        )
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/palettes/CorePalette.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/palettes/CorePalette.kt
@@ -59,17 +59,13 @@ class CorePalette private constructor(argb: Int, isContent: Boolean) {
          *
          * @param argb ARGB representation of a color
          */
-        fun of(argb: Int): CorePalette {
-            return CorePalette(argb, false)
-        }
+        fun of(argb: Int): CorePalette = CorePalette(argb, false)
 
         /**
          * Create content key tones from a color.
          *
          * @param argb ARGB representation of a color
          */
-        fun contentOf(argb: Int): CorePalette {
-            return CorePalette(argb, true)
-        }
+        fun contentOf(argb: Int): CorePalette = CorePalette(argb, true)
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/palettes/TonalPalette.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/palettes/TonalPalette.kt
@@ -21,13 +21,14 @@ import kotlin.math.round
 
 /**
  * A convenience class for retrieving colors that are constant in hue and chroma, but vary in tone.
+ *
+ * @param[hue] The hue of the Tonal Palette, in HCT. Ranges from 0 to 360.
+ * @param[chroma] The chroma of the Tonal Palette, in HCT. Ranges from 0 to ~130 (for sRGB gamut).
+ * @param[keyColor] The key color is the first tone, starting from T50, that matches the palette's chroma.
  */
 class TonalPalette private constructor(
-    /** The hue of the Tonal Palette, in HCT. Ranges from 0 to 360.  */
     var hue: Double,
-    /** The chroma of the Tonal Palette, in HCT. Ranges from 0 to ~130 (for sRGB gamut).  */
     var chroma: Double,
-    /** The key color is the first tone, starting from T50, that matches the palette's chroma.  */
     var keyColor: Hct,
 ) {
 
@@ -36,10 +37,9 @@ class TonalPalette private constructor(
     /**
      * Create an ARGB color with HCT hue and chroma of this Tones instance, and the provided HCT tone.
      *
-     * @param tone HCT tone, measured from 0 to 100.
+     * @param[tone] HCT tone, measured from 0 to 100.
      * @return ARGB representation of a color with that tone.
      */
-    // AndroidJdkLibsChecker is higher priority than ComputeIfAbsentUseValue (b/119581923)
     fun tone(tone: Int): Int {
         var color = cache[tone]
         if (color == null) {
@@ -50,44 +50,40 @@ class TonalPalette private constructor(
     }
 
     /** Given a tone, use hue and chroma of palette to create a color, and return it as HCT.  */
-    fun getHct(tone: Double): Hct {
-        return Hct.from(hue, chroma, tone)
-    }
+    fun getHct(tone: Double): Hct = Hct.from(hue, chroma, tone)
 
     companion object {
 
         /**
          * Create tones using the HCT hue and chroma from a color.
          *
-         * @param argb ARGB representation of a color
+         * @param[argb] ARGB representation of a color
          * @return Tones matching that color's hue and chroma.
          */
-        fun fromInt(argb: Int): TonalPalette {
-            return fromHct(Hct.fromInt(argb))
-        }
+        fun fromInt(argb: Int): TonalPalette = fromHct(Hct.fromInt(argb))
 
         /**
          * Create tones using a HCT color.
          *
-         * @param hct HCT representation of a color.
+         * @param[hct] HCT representation of a color.
          * @return Tones matching that color's hue and chroma.
          */
-        fun fromHct(hct: Hct): TonalPalette {
-            return TonalPalette(hct.getHue(), hct.getChroma(), hct)
-        }
+        fun fromHct(hct: Hct): TonalPalette = TonalPalette(hct.getHue(), hct.getChroma(), hct)
 
         /**
          * Create tones from a defined HCT hue and chroma.
          *
-         * @param hue HCT hue
-         * @param chroma HCT chroma
+         * @param[hue] HCT hue
+         * @param[chroma] HCT chroma
          * @return Tones matching hue and chroma.
          */
         fun fromHueAndChroma(hue: Double, chroma: Double): TonalPalette {
             return TonalPalette(hue, chroma, createKeyColor(hue, chroma))
         }
 
-        /** The key color is the first tone, starting from T50, matching the given hue and chroma.  */
+        /**
+         * The key color is the first tone, starting from T50, matching the given hue and chroma.
+         */
         private fun createKeyColor(hue: Double, chroma: Double): Hct {
             val startTone = 50.0
             var smallestDeltaHct = Hct.from(hue, chroma, startTone)
@@ -100,20 +96,19 @@ class TonalPalette private constructor(
             // iteration.
             var delta = 1.0
             while (delta < 50.0) {
-
                 // Termination condition rounding instead of minimizing delta to avoid
                 // case where requested chroma is 16.51, and the closest chroma is 16.49.
                 // Error is minimized, but when rounded and displayed, requested chroma
                 // is 17, key color's chroma is 16.
-                if (round(chroma) == round(smallestDeltaHct.getChroma())) {
-                    return smallestDeltaHct
-                }
+                if (round(chroma) == round(smallestDeltaHct.getChroma())) return smallestDeltaHct
+
                 val hctAdd = Hct.from(hue, chroma, startTone + delta)
                 val hctAddDelta: Double = abs(hctAdd.getChroma() - chroma)
                 if (hctAddDelta < smallestDelta) {
                     smallestDelta = hctAddDelta
                     smallestDeltaHct = hctAdd
                 }
+
                 val hctSubtract = Hct.from(hue, chroma, startTone - delta)
                 val hctSubtractDelta: Double = abs(hctSubtract.getChroma() - chroma)
                 if (hctSubtractDelta < smallestDelta) {
@@ -122,6 +117,7 @@ class TonalPalette private constructor(
                 }
                 delta += 1.0
             }
+
             return smallestDeltaHct
         }
     }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/PointProvider.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/PointProvider.kt
@@ -15,13 +15,19 @@
  */
 package com.materialkolor.quantize
 
-/** An interface to allow use of different color spaces by quantizers.  */
+/**
+ * An interface to allow use of different color spaces by quantizers.
+ */
 internal interface PointProvider {
 
-    /** The four components in the color space of an sRGB color.  */
+    /**
+     * The four components in the color space of an sRGB color.
+     */
     fun fromInt(argb: Int): DoubleArray?
 
-    /** The ARGB (i.e. hex code) representation of this color.  */
+    /**
+     * The ARGB (i.e. hex code) representation of this color.
+     */
     fun toInt(point: DoubleArray?): Int
 
     /**

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/PointProviderLab.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/PointProviderLab.kt
@@ -27,7 +27,7 @@ internal class PointProviderLab : PointProvider {
     /**
      * Convert a color represented in ARGB to a 3-element array of L*a*b* coordinates of the color.
      */
-    override fun fromInt(argb: Int): DoubleArray? {
+    override fun fromInt(argb: Int): DoubleArray {
         val lab = labFromArgb(argb)
         return doubleArrayOf(lab[0], lab[1], lab[2])
     }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerCelebi.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerCelebi.kt
@@ -21,7 +21,6 @@ package com.materialkolor.quantize
  * speed by several optimizations, as implemented in Wsmeans, or Weighted Square Means, K-Means with
  * those optimizations.
  *
- *
  * This algorithm was designed by M. Emre Celebi, and was found in their 2011 paper, Improving
  * the Performance of K-Means for Color Quantization. https://arxiv.org/abs/1101.0395
  */
@@ -31,8 +30,8 @@ internal object QuantizerCelebi {
      * Reduce the number of colors needed to represented the input, minimizing the difference between
      * the original image and the recolored image.
      *
-     * @param pixels Colors in ARGB format.
-     * @param maxColors The number of colors to divide the image into. A lower number of colors may be
+     * @param[pixels] Colors in ARGB format.
+     * @param[maxColors] The number of colors to divide the image into. A lower number of colors may be
      * returned.
      * @return Map with keys of colors in ARGB format, and values of number of pixels in the original
      * image that correspond to the color in the quantized image.

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerMap.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerMap.kt
@@ -15,7 +15,10 @@
  */
 package com.materialkolor.quantize
 
-/** Creates a dictionary with keys of colors, and values of count of the color  */
+/**
+ * Creates a dictionary with keys of colors, and values of count of the color
+ */
+@Suppress("MemberVisibilityCanBePrivate")
 internal class QuantizerMap : Quantizer {
 
     var colorToCount: Map<Int, Int>? = null

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerResult.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerResult.kt
@@ -15,5 +15,7 @@
  */
 package com.materialkolor.quantize
 
-/** Represents result of a quantizer run  */
+/**
+ * Represents result of a quantizer run
+ * */
 internal class QuantizerResult internal constructor(val colorToCount: Map<Int, Int>)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerWu.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerWu.kt
@@ -23,9 +23,9 @@ import com.materialkolor.utils.ColorUtils.redFromArgb
  * An image quantizer that divides the image's pixels into clusters by recursively cutting an RGB
  * cube, based on the weight of pixels in each area of the cube.
  *
- *
  * The algorithm was described by Xiaolin Wu in Graphic Gems II, published in 1991.
  */
+@Suppress("MemberVisibilityCanBePrivate")
 internal class QuantizerWu : Quantizer {
 
     lateinit var weights: IntArray
@@ -142,11 +142,11 @@ internal class QuantizerWu : Quantizer {
             }
             i++
         }
-        return CreateBoxesResult(maxColorCount, generatedColorCount)
+        return CreateBoxesResult(generatedColorCount)
     }
 
     fun createResult(colorCount: Int): List<Int> {
-        val colors: MutableList<Int> = ArrayList<Int>()
+        val colors: MutableList<Int> = mutableListOf()
         for (i in 0 until colorCount) {
             val cube = cubes[i]
             val weight = volume(cube, weights)
@@ -283,12 +283,14 @@ internal class QuantizerWu : Quantizer {
         BLUE
     }
 
+    // < 0 if cut impossible
     class MaximizeResult internal constructor(
-// < 0 if cut impossible
-        var cutLocation: Int, var maximum: Double,
+        var cutLocation: Int,
+        var maximum: Double,
     )
 
-    class CreateBoxesResult internal constructor(var requestedCount: Int, var resultCount: Int)
+    class CreateBoxesResult internal constructor(var resultCount: Int)
+
     class Box {
 
         var r0 = 0
@@ -309,6 +311,7 @@ internal class QuantizerWu : Quantizer {
         private const val INDEX_BITS = 5
         private const val INDEX_COUNT = 33 // ((1 << INDEX_BITS) + 1)
         private const val TOTAL_SIZE = 35937 // INDEX_COUNT * INDEX_COUNT * INDEX_COUNT
+
         fun getIndex(r: Int, g: Int, b: Int): Int {
             return (r shl INDEX_BITS * 2) + (r shl INDEX_BITS + 1) + r + (g shl INDEX_BITS) + g + b
         }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/DynamicScheme.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/DynamicScheme.kt
@@ -20,9 +20,12 @@ import com.materialkolor.utils.MathUtils
 import com.materialkolor.palettes.TonalPalette
 
 /**
- * Provides important settings for creating colors dynamically, and 6 color palettes. Requires: 1. A
- * color. (source color) 2. A theme. (Variant) 3. Whether or not its dark mode. 4. Contrast level.
- * (-1 to 1, currently contrast ratio 3.0 and 7.0)
+ * Provides important settings for creating colors dynamically, and 6 color palettes.
+ * Requires:
+ *  1. A color. (source color)
+ *  2. A theme. (Variant)
+ *  3. Whether or not its dark mode.
+ *  4. Contrast level. (-1 to 1, currently contrast ratio 3.0 and 7.0)
  */
 open class DynamicScheme(
     sourceColorHct: Hct,

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/DynamicScheme.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/DynamicScheme.kt
@@ -69,9 +69,9 @@ open class DynamicScheme(
          * between, apply the rotation at the same index as the first hue in the range, and return the
          * rotated hue.
          *
-         * @param sourceColorHct The color whose hue should be rotated.
-         * @param hues A set of hues.
-         * @param rotations A set of hue rotations.
+         * @param[sourceColorHct] The color whose hue should be rotated.
+         * @param[hues] A set of hues.
+         * @param[rotations] A set of hue rotations.
          * @return Color's hue with a rotation applied.
          */
         fun getRotatedHue(sourceColorHct: Hct, hues: DoubleArray, rotations: DoubleArray): Double {
@@ -87,6 +87,7 @@ open class DynamicScheme(
                     return MathUtils.sanitizeDegreesDouble(sourceHue + rotations[i])
                 }
             }
+
             // If this statement executes, something is wrong, there should have been a rotation
             // found using the arrays.
             return sourceHue

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/Scheme.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/Scheme.kt
@@ -17,102 +17,44 @@
 package com.materialkolor.scheme
 
 import com.materialkolor.palettes.CorePalette
+import dev.drewhamilton.poko.Poko
 
-/** Represents a Material color scheme, a mapping of color roles to colors.  */
-internal class Scheme {
-
-    var primary = 0
-    var onPrimary = 0
-    var primaryContainer = 0
-    var onPrimaryContainer = 0
-    var secondary = 0
-    var onSecondary = 0
-    var secondaryContainer = 0
-    var onSecondaryContainer = 0
-    var tertiary = 0
-    var onTertiary = 0
-    var tertiaryContainer = 0
-    var onTertiaryContainer = 0
-    var error = 0
-    var onError = 0
-    var errorContainer = 0
-    var onErrorContainer = 0
-    var background = 0
-    var onBackground = 0
-    var surface = 0
-    var onSurface = 0
-    var surfaceVariant = 0
-    var onSurfaceVariant = 0
-    var outline = 0
-    var outlineVariant = 0
-    var shadow = 0
-    var scrim = 0
-    var inverseSurface = 0
-    var inverseOnSurface = 0
-    var inversePrimary = 0
-
-    constructor()
-    constructor(
-        primary: Int,
-        onPrimary: Int,
-        primaryContainer: Int,
-        onPrimaryContainer: Int,
-        secondary: Int,
-        onSecondary: Int,
-        secondaryContainer: Int,
-        onSecondaryContainer: Int,
-        tertiary: Int,
-        onTertiary: Int,
-        tertiaryContainer: Int,
-        onTertiaryContainer: Int,
-        error: Int,
-        onError: Int,
-        errorContainer: Int,
-        onErrorContainer: Int,
-        background: Int,
-        onBackground: Int,
-        surface: Int,
-        onSurface: Int,
-        surfaceVariant: Int,
-        onSurfaceVariant: Int,
-        outline: Int,
-        outlineVariant: Int,
-        shadow: Int,
-        scrim: Int,
-        inverseSurface: Int,
-        inverseOnSurface: Int,
-        inversePrimary: Int
-    ) : super() {
-        this.primary = primary
-        this.onPrimary = onPrimary
-        this.primaryContainer = primaryContainer
-        this.onPrimaryContainer = onPrimaryContainer
-        this.secondary = secondary
-        this.onSecondary = onSecondary
-        this.secondaryContainer = secondaryContainer
-        this.onSecondaryContainer = onSecondaryContainer
-        this.tertiary = tertiary
-        this.onTertiary = onTertiary
-        this.tertiaryContainer = tertiaryContainer
-        this.onTertiaryContainer = onTertiaryContainer
-        this.error = error
-        this.onError = onError
-        this.errorContainer = errorContainer
-        this.onErrorContainer = onErrorContainer
-        this.background = background
-        this.onBackground = onBackground
-        this.surface = surface
-        this.onSurface = onSurface
-        this.surfaceVariant = surfaceVariant
-        this.onSurfaceVariant = onSurfaceVariant
-        this.outline = outline
-        this.outlineVariant = outlineVariant
-        this.shadow = shadow
-        this.scrim = scrim
-        this.inverseSurface = inverseSurface
-        this.inverseOnSurface = inverseOnSurface
-        this.inversePrimary = inversePrimary
-    }
+/**
+ * Represents a Material color scheme, a mapping of color roles to colors.
+ */
+@Suppress("unused", "MemberVisibilityCanBePrivate")
+@Poko
+internal class Scheme(
+    var primary: Int = 0,
+    var onPrimary: Int = 0,
+    var primaryContainer: Int = 0,
+    var onPrimaryContainer: Int = 0,
+    var secondary: Int = 0,
+    var onSecondary: Int = 0,
+    var secondaryContainer: Int = 0,
+    var onSecondaryContainer: Int = 0,
+    var tertiary: Int = 0,
+    var onTertiary: Int = 0,
+    var tertiaryContainer: Int = 0,
+    var onTertiaryContainer: Int = 0,
+    var error: Int = 0,
+    var onError: Int = 0,
+    var errorContainer: Int = 0,
+    var onErrorContainer: Int = 0,
+    var background: Int = 0,
+    var onBackground: Int = 0,
+    var surface: Int = 0,
+    var onSurface: Int = 0,
+    var surfaceVariant: Int = 0,
+    var onSurfaceVariant: Int = 0,
+    var outline: Int = 0,
+    var outlineVariant: Int = 0,
+    var shadow: Int = 0,
+    var scrim: Int = 0,
+    var inverseSurface: Int = 0,
+    var inverseOnSurface: Int = 0,
+    var inversePrimary: Int = 0,
+) {
 
     fun withPrimary(primary: Int): Scheme {
         this.primary = primary
@@ -259,289 +201,96 @@ internal class Scheme {
         return this
     }
 
-    override fun toString(): String {
-        return ("Scheme{"
-            + "primary="
-            + primary
-            + ", onPrimary="
-            + onPrimary
-            + ", primaryContainer="
-            + primaryContainer
-            + ", onPrimaryContainer="
-            + onPrimaryContainer
-            + ", secondary="
-            + secondary
-            + ", onSecondary="
-            + onSecondary
-            + ", secondaryContainer="
-            + secondaryContainer
-            + ", onSecondaryContainer="
-            + onSecondaryContainer
-            + ", tertiary="
-            + tertiary
-            + ", onTertiary="
-            + onTertiary
-            + ", tertiaryContainer="
-            + tertiaryContainer
-            + ", onTertiaryContainer="
-            + onTertiaryContainer
-            + ", error="
-            + error
-            + ", onError="
-            + onError
-            + ", errorContainer="
-            + errorContainer
-            + ", onErrorContainer="
-            + onErrorContainer
-            + ", background="
-            + background
-            + ", onBackground="
-            + onBackground
-            + ", surface="
-            + surface
-            + ", onSurface="
-            + onSurface
-            + ", surfaceVariant="
-            + surfaceVariant
-            + ", onSurfaceVariant="
-            + onSurfaceVariant
-            + ", outline="
-            + outline
-            + ", outlineVariant="
-            + outlineVariant
-            + ", shadow="
-            + shadow
-            + ", scrim="
-            + scrim
-            + ", inverseSurface="
-            + inverseSurface
-            + ", inverseOnSurface="
-            + inverseOnSurface
-            + ", inversePrimary="
-            + inversePrimary
-            + '}')
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) {
-            return true
-        }
-        if (other !is Scheme) {
-            return false
-        }
-        if (!super.equals(other)) {
-            return false
-        }
-        val scheme = other
-        if (primary != scheme.primary) {
-            return false
-        }
-        if (onPrimary != scheme.onPrimary) {
-            return false
-        }
-        if (primaryContainer != scheme.primaryContainer) {
-            return false
-        }
-        if (onPrimaryContainer != scheme.onPrimaryContainer) {
-            return false
-        }
-        if (secondary != scheme.secondary) {
-            return false
-        }
-        if (onSecondary != scheme.onSecondary) {
-            return false
-        }
-        if (secondaryContainer != scheme.secondaryContainer) {
-            return false
-        }
-        if (onSecondaryContainer != scheme.onSecondaryContainer) {
-            return false
-        }
-        if (tertiary != scheme.tertiary) {
-            return false
-        }
-        if (onTertiary != scheme.onTertiary) {
-            return false
-        }
-        if (tertiaryContainer != scheme.tertiaryContainer) {
-            return false
-        }
-        if (onTertiaryContainer != scheme.onTertiaryContainer) {
-            return false
-        }
-        if (error != scheme.error) {
-            return false
-        }
-        if (onError != scheme.onError) {
-            return false
-        }
-        if (errorContainer != scheme.errorContainer) {
-            return false
-        }
-        if (onErrorContainer != scheme.onErrorContainer) {
-            return false
-        }
-        if (background != scheme.background) {
-            return false
-        }
-        if (onBackground != scheme.onBackground) {
-            return false
-        }
-        if (surface != scheme.surface) {
-            return false
-        }
-        if (onSurface != scheme.onSurface) {
-            return false
-        }
-        if (surfaceVariant != scheme.surfaceVariant) {
-            return false
-        }
-        if (onSurfaceVariant != scheme.onSurfaceVariant) {
-            return false
-        }
-        if (outline != scheme.outline) {
-            return false
-        }
-        if (outlineVariant != scheme.outlineVariant) {
-            return false
-        }
-        if (shadow != scheme.shadow) {
-            return false
-        }
-        if (scrim != scheme.scrim) {
-            return false
-        }
-        if (inverseSurface != scheme.inverseSurface) {
-            return false
-        }
-        if (inverseOnSurface != scheme.inverseOnSurface) {
-            return false
-        }
-        return if (inversePrimary != scheme.inversePrimary) {
-            false
-        } else true
-    }
-
-    override fun hashCode(): Int {
-        var result = super.hashCode()
-        result = 31 * result + primary
-        result = 31 * result + onPrimary
-        result = 31 * result + primaryContainer
-        result = 31 * result + onPrimaryContainer
-        result = 31 * result + secondary
-        result = 31 * result + onSecondary
-        result = 31 * result + secondaryContainer
-        result = 31 * result + onSecondaryContainer
-        result = 31 * result + tertiary
-        result = 31 * result + onTertiary
-        result = 31 * result + tertiaryContainer
-        result = 31 * result + onTertiaryContainer
-        result = 31 * result + error
-        result = 31 * result + onError
-        result = 31 * result + errorContainer
-        result = 31 * result + onErrorContainer
-        result = 31 * result + background
-        result = 31 * result + onBackground
-        result = 31 * result + surface
-        result = 31 * result + onSurface
-        result = 31 * result + surfaceVariant
-        result = 31 * result + onSurfaceVariant
-        result = 31 * result + outline
-        result = 31 * result + outlineVariant
-        result = 31 * result + shadow
-        result = 31 * result + scrim
-        result = 31 * result + inverseSurface
-        result = 31 * result + inverseOnSurface
-        result = 31 * result + inversePrimary
-        return result
-    }
-
     companion object {
 
-        /** Creates a light theme Scheme from a source color in ARGB, i.e. a hex code.  */
+        /**
+         * Creates a light theme Scheme from a source color in ARGB, i.e. a hex code.
+         */
         fun light(argb: Int): Scheme {
             return lightFromCorePalette(CorePalette.of(argb))
         }
 
-        /** Creates a dark theme Scheme from a source color in ARGB, i.e. a hex code.  */
+        /**
+         * Creates a dark theme Scheme from a source color in ARGB, i.e. a hex code.
+         */
         fun dark(argb: Int): Scheme {
             return darkFromCorePalette(CorePalette.of(argb))
         }
 
-        /** Creates a light theme content-based Scheme from a source color in ARGB, i.e. a hex code.  */
+        /**
+         * Creates a light theme content-based Scheme from a source color in ARGB, i.e. a hex code.
+         */
         fun lightContent(argb: Int): Scheme {
             return lightFromCorePalette(CorePalette.contentOf(argb))
         }
 
-        /** Creates a dark theme content-based Scheme from a source color in ARGB, i.e. a hex code.  */
+        /**
+         * Creates a dark theme content-based Scheme from a source color in ARGB, i.e. a hex code.
+         */
         fun darkContent(argb: Int): Scheme {
             return darkFromCorePalette(CorePalette.contentOf(argb))
         }
 
-        private fun lightFromCorePalette(core: CorePalette): Scheme {
-            return Scheme()
-                .withPrimary(core.a1.tone(40))
-                .withOnPrimary(core.a1.tone(100))
-                .withPrimaryContainer(core.a1.tone(90))
-                .withOnPrimaryContainer(core.a1.tone(10))
-                .withSecondary(core.a2.tone(40))
-                .withOnSecondary(core.a2.tone(100))
-                .withSecondaryContainer(core.a2.tone(90))
-                .withOnSecondaryContainer(core.a2.tone(10))
-                .withTertiary(core.a3.tone(40))
-                .withOnTertiary(core.a3.tone(100))
-                .withTertiaryContainer(core.a3.tone(90))
-                .withOnTertiaryContainer(core.a3.tone(10))
-                .withError(core.error.tone(40))
-                .withOnError(core.error.tone(100))
-                .withErrorContainer(core.error.tone(90))
-                .withOnErrorContainer(core.error.tone(10))
-                .withBackground(core.n1.tone(99))
-                .withOnBackground(core.n1.tone(10))
-                .withSurface(core.n1.tone(99))
-                .withOnSurface(core.n1.tone(10))
-                .withSurfaceVariant(core.n2.tone(90))
-                .withOnSurfaceVariant(core.n2.tone(30))
-                .withOutline(core.n2.tone(50))
-                .withOutlineVariant(core.n2.tone(80))
-                .withShadow(core.n1.tone(0))
-                .withScrim(core.n1.tone(0))
-                .withInverseSurface(core.n1.tone(20))
-                .withInverseOnSurface(core.n1.tone(95))
-                .withInversePrimary(core.a1.tone(80))
-        }
+        private fun lightFromCorePalette(core: CorePalette): Scheme = Scheme()
+            .withPrimary(core.a1.tone(40))
+            .withOnPrimary(core.a1.tone(100))
+            .withPrimaryContainer(core.a1.tone(90))
+            .withOnPrimaryContainer(core.a1.tone(10))
+            .withSecondary(core.a2.tone(40))
+            .withOnSecondary(core.a2.tone(100))
+            .withSecondaryContainer(core.a2.tone(90))
+            .withOnSecondaryContainer(core.a2.tone(10))
+            .withTertiary(core.a3.tone(40))
+            .withOnTertiary(core.a3.tone(100))
+            .withTertiaryContainer(core.a3.tone(90))
+            .withOnTertiaryContainer(core.a3.tone(10))
+            .withError(core.error.tone(40))
+            .withOnError(core.error.tone(100))
+            .withErrorContainer(core.error.tone(90))
+            .withOnErrorContainer(core.error.tone(10))
+            .withBackground(core.n1.tone(99))
+            .withOnBackground(core.n1.tone(10))
+            .withSurface(core.n1.tone(99))
+            .withOnSurface(core.n1.tone(10))
+            .withSurfaceVariant(core.n2.tone(90))
+            .withOnSurfaceVariant(core.n2.tone(30))
+            .withOutline(core.n2.tone(50))
+            .withOutlineVariant(core.n2.tone(80))
+            .withShadow(core.n1.tone(0))
+            .withScrim(core.n1.tone(0))
+            .withInverseSurface(core.n1.tone(20))
+            .withInverseOnSurface(core.n1.tone(95))
+            .withInversePrimary(core.a1.tone(80))
 
-        private fun darkFromCorePalette(core: CorePalette): Scheme {
-            return Scheme()
-                .withPrimary(core.a1.tone(80))
-                .withOnPrimary(core.a1.tone(20))
-                .withPrimaryContainer(core.a1.tone(30))
-                .withOnPrimaryContainer(core.a1.tone(90))
-                .withSecondary(core.a2.tone(80))
-                .withOnSecondary(core.a2.tone(20))
-                .withSecondaryContainer(core.a2.tone(30))
-                .withOnSecondaryContainer(core.a2.tone(90))
-                .withTertiary(core.a3.tone(80))
-                .withOnTertiary(core.a3.tone(20))
-                .withTertiaryContainer(core.a3.tone(30))
-                .withOnTertiaryContainer(core.a3.tone(90))
-                .withError(core.error.tone(80))
-                .withOnError(core.error.tone(20))
-                .withErrorContainer(core.error.tone(30))
-                .withOnErrorContainer(core.error.tone(80))
-                .withBackground(core.n1.tone(10))
-                .withOnBackground(core.n1.tone(90))
-                .withSurface(core.n1.tone(10))
-                .withOnSurface(core.n1.tone(90))
-                .withSurfaceVariant(core.n2.tone(30))
-                .withOnSurfaceVariant(core.n2.tone(80))
-                .withOutline(core.n2.tone(60))
-                .withOutlineVariant(core.n2.tone(30))
-                .withShadow(core.n1.tone(0))
-                .withScrim(core.n1.tone(0))
-                .withInverseSurface(core.n1.tone(90))
-                .withInverseOnSurface(core.n1.tone(20))
-                .withInversePrimary(core.a1.tone(40))
-        }
+        private fun darkFromCorePalette(core: CorePalette): Scheme = Scheme()
+            .withPrimary(core.a1.tone(80))
+            .withOnPrimary(core.a1.tone(20))
+            .withPrimaryContainer(core.a1.tone(30))
+            .withOnPrimaryContainer(core.a1.tone(90))
+            .withSecondary(core.a2.tone(80))
+            .withOnSecondary(core.a2.tone(20))
+            .withSecondaryContainer(core.a2.tone(30))
+            .withOnSecondaryContainer(core.a2.tone(90))
+            .withTertiary(core.a3.tone(80))
+            .withOnTertiary(core.a3.tone(20))
+            .withTertiaryContainer(core.a3.tone(30))
+            .withOnTertiaryContainer(core.a3.tone(90))
+            .withError(core.error.tone(80))
+            .withOnError(core.error.tone(20))
+            .withErrorContainer(core.error.tone(30))
+            .withOnErrorContainer(core.error.tone(80))
+            .withBackground(core.n1.tone(10))
+            .withOnBackground(core.n1.tone(90))
+            .withSurface(core.n1.tone(10))
+            .withOnSurface(core.n1.tone(90))
+            .withSurfaceVariant(core.n2.tone(30))
+            .withOnSurfaceVariant(core.n2.tone(80))
+            .withOutline(core.n2.tone(60))
+            .withOutlineVariant(core.n2.tone(30))
+            .withShadow(core.n1.tone(0))
+            .withScrim(core.n1.tone(0))
+            .withInverseSurface(core.n1.tone(90))
+            .withInverseOnSurface(core.n1.tone(20))
+            .withInversePrimary(core.a1.tone(40))
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeContent.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeContent.kt
@@ -35,20 +35,29 @@ import kotlin.math.max
  * grounded equivalent to rotating hue clockwise by 60 degrees. It also maintains constant
  * appearance.
  */
-class SchemeContent(sourceColorHct: Hct, isDark: Boolean, contrastLevel: Double) : DynamicScheme(
-    sourceColorHct,
-    Variant.CONTENT,
-    isDark,
-    contrastLevel,
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), sourceColorHct.getChroma()),
-    TonalPalette.fromHueAndChroma(
-        sourceColorHct.getHue(),
-        max(sourceColorHct.getChroma() - 32.0, sourceColorHct.getChroma() * 0.5)),
-    TonalPalette.fromHct(
-        DislikeAnalyzer.fixIfDisliked(
+class SchemeContent(
+    sourceColorHct: Hct,
+    isDark: Boolean,
+    contrastLevel: Double,
+) : DynamicScheme(
+    sourceColorHct = sourceColorHct,
+    variant = Variant.CONTENT,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), sourceColorHct.getChroma()),
+    secondaryPalette = TonalPalette.fromHueAndChroma(
+        hue = sourceColorHct.getHue(),
+        chroma = max(sourceColorHct.getChroma() - 32.0, sourceColorHct.getChroma() * 0.5),
+    ),
+    tertiaryPalette = TonalPalette.fromHct(
+        hct = DislikeAnalyzer.fixIfDisliked(
             TemperatureCache(sourceColorHct)
-                .getAnalogousColors( /* count= */3,  /* divisions= */6)
-                .get(2))),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), sourceColorHct.getChroma() / 8.0),
-    TonalPalette.fromHueAndChroma(
-        sourceColorHct.getHue(), sourceColorHct.getChroma() / 8.0 + 4.0))
+                .getAnalogousColors(count = 3, divisions = 6)
+                .get(2),
+        ),
+    ),
+    neutralPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), sourceColorHct.getChroma() / 8.0),
+    neutralVariantPalette = TonalPalette.fromHueAndChroma(
+        hue = sourceColorHct.getHue(),
+        chroma = sourceColorHct.getChroma() / 8.0 + 4.0),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeExpressive.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeExpressive.kt
@@ -19,28 +19,39 @@ import com.materialkolor.hct.Hct
 import com.materialkolor.palettes.TonalPalette
 import com.materialkolor.utils.MathUtils
 
-/** A playful theme - the source color's hue does not appear in the theme.  */
-class SchemeExpressive(sourceColorHct: Hct, isDark: Boolean, contrastLevel: Double) : DynamicScheme(
-    sourceColorHct,
-    Variant.EXPRESSIVE,
-    isDark,
-    contrastLevel,
-    TonalPalette.fromHueAndChroma(
+/**
+ * A playful theme - the source color's hue does not appear in the theme.
+ * */
+class SchemeExpressive(
+    sourceColorHct: Hct,
+    isDark: Boolean,
+    contrastLevel: Double,
+) : DynamicScheme(
+    sourceColorHct = sourceColorHct,
+    variant = Variant.EXPRESSIVE,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = TonalPalette.fromHueAndChroma(
         MathUtils.sanitizeDegreesDouble(sourceColorHct.getHue() + 240.0), 40.0),
-    TonalPalette.fromHueAndChroma(
-        DynamicScheme.getRotatedHue(sourceColorHct, HUES, SECONDARY_ROTATIONS), 24.0),
-    TonalPalette.fromHueAndChroma(
-        DynamicScheme.getRotatedHue(sourceColorHct, HUES, TERTIARY_ROTATIONS), 32.0),
-    TonalPalette.fromHueAndChroma(
+    secondaryPalette = TonalPalette.fromHueAndChroma(
+        getRotatedHue(sourceColorHct, HUES, SECONDARY_ROTATIONS), 24.0),
+    tertiaryPalette = TonalPalette.fromHueAndChroma(
+        getRotatedHue(sourceColorHct, HUES, TERTIARY_ROTATIONS), 32.0),
+    neutralPalette = TonalPalette.fromHueAndChroma(
         MathUtils.sanitizeDegreesDouble(sourceColorHct.getHue() + 15.0), 8.0),
-    TonalPalette.fromHueAndChroma(
-        MathUtils.sanitizeDegreesDouble(sourceColorHct.getHue() + 15.0), 12.0)) {
+    neutralVariantPalette = TonalPalette.fromHueAndChroma(
+        MathUtils.sanitizeDegreesDouble(sourceColorHct.getHue() + 15.0), 12.0),
+) {
 
     companion object {
 
         // NOMUTANTS--arbitrary increments/decrements, correctly, still passes tests.
         private val HUES = doubleArrayOf(0.0, 21.0, 51.0, 121.0, 151.0, 191.0, 271.0, 321.0, 360.0)
-        private val SECONDARY_ROTATIONS = doubleArrayOf(45.0, 95.0, 45.0, 20.0, 45.0, 90.0, 45.0, 45.0, 45.0)
-        private val TERTIARY_ROTATIONS = doubleArrayOf(120.0, 120.0, 20.0, 45.0, 20.0, 15.0, 20.0, 120.0, 120.0)
+
+        private val SECONDARY_ROTATIONS =
+            doubleArrayOf(45.0, 95.0, 45.0, 20.0, 45.0, 90.0, 45.0, 45.0, 45.0)
+
+        private val TERTIARY_ROTATIONS =
+            doubleArrayOf(120.0, 120.0, 20.0, 45.0, 20.0, 15.0, 20.0, 120.0, 120.0)
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeExpressive.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeExpressive.kt
@@ -21,7 +21,7 @@ import com.materialkolor.utils.MathUtils
 
 /**
  * A playful theme - the source color's hue does not appear in the theme.
- * */
+ */
 class SchemeExpressive(
     sourceColorHct: Hct,
     isDark: Boolean,

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFidelity.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFidelity.kt
@@ -24,26 +24,35 @@ import kotlin.math.max
 /**
  * A scheme that places the source color in Scheme.primaryContainer.
  *
- *
  * Primary Container is the source color, adjusted for color relativity. It maintains constant
  * appearance in light mode and dark mode. This adds ~5 tone in light mode, and subtracts ~5 tone in
  * dark mode.
  *
- *
  * Tertiary Container is the complement to the source color, using TemperatureCache. It also
  * maintains constant appearance.
  */
-class SchemeFidelity(sourceColorHct: Hct, isDark: Boolean, contrastLevel: Double) : DynamicScheme(
-    sourceColorHct,
-    Variant.FIDELITY,
-    isDark,
-    contrastLevel,
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), sourceColorHct.getChroma()),
-    TonalPalette.fromHueAndChroma(
-        sourceColorHct.getHue(),
-        max(sourceColorHct.getChroma() - 32.0, sourceColorHct.getChroma() * 0.5)),
-    TonalPalette.fromHct(
+class SchemeFidelity(
+    sourceColorHct: Hct,
+    isDark: Boolean,
+    contrastLevel: Double,
+) : DynamicScheme(
+    sourceColorHct = sourceColorHct,
+    variant = Variant.FIDELITY,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), sourceColorHct.getChroma()),
+    secondaryPalette = TonalPalette.fromHueAndChroma(
+        hue = sourceColorHct.getHue(),
+        chroma = max(sourceColorHct.getChroma() - 32.0, sourceColorHct.getChroma() * 0.5),
+    ),
+    tertiaryPalette = TonalPalette.fromHct(
         DislikeAnalyzer.fixIfDisliked(TemperatureCache(sourceColorHct).complement)),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), sourceColorHct.getChroma() / 8.0),
-    TonalPalette.fromHueAndChroma(
-        sourceColorHct.getHue(), sourceColorHct.getChroma() / 8.0 + 4.0))
+    neutralPalette = TonalPalette.fromHueAndChroma(
+        hue = sourceColorHct.getHue(),
+        chroma = sourceColorHct.getChroma() / 8.0,
+    ),
+    neutralVariantPalette = TonalPalette.fromHueAndChroma(
+        hue = sourceColorHct.getHue(),
+        chroma = sourceColorHct.getChroma() / 8.0 + 4.0,
+    ),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFruitSalad.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFruitSalad.kt
@@ -16,19 +16,26 @@
 package com.materialkolor.scheme
 
 import com.materialkolor.hct.Hct
-import com.materialkolor.utils.MathUtils
 import com.materialkolor.palettes.TonalPalette
+import com.materialkolor.utils.MathUtils
 
-/** A playful theme - the source color's hue does not appear in the theme.  */
-class SchemeFruitSalad(sourceColorHct: Hct, isDark: Boolean, contrastLevel: Double) : DynamicScheme(
-    sourceColorHct,
-    Variant.FRUIT_SALAD,
-    isDark,
-    contrastLevel,
-    TonalPalette.fromHueAndChroma(
+/**
+ * A playful theme - the source color's hue does not appear in the theme.
+ */
+class SchemeFruitSalad(
+    sourceColorHct: Hct,
+    isDark: Boolean,
+    contrastLevel: Double,
+) : DynamicScheme(
+    sourceColorHct = sourceColorHct,
+    variant = Variant.FRUIT_SALAD,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = TonalPalette.fromHueAndChroma(
         MathUtils.sanitizeDegreesDouble(sourceColorHct.getHue() - 50.0), 48.0),
-    TonalPalette.fromHueAndChroma(
+    secondaryPalette = TonalPalette.fromHueAndChroma(
         MathUtils.sanitizeDegreesDouble(sourceColorHct.getHue() - 50.0), 36.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 36.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 10.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 16.0))
+    tertiaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 36.0),
+    neutralPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 10.0),
+    neutralVariantPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 16.0),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeMonochrome.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeMonochrome.kt
@@ -18,14 +18,21 @@ package com.materialkolor.scheme
 import com.materialkolor.hct.Hct
 import com.materialkolor.palettes.TonalPalette
 
-/** A monochrome theme, colors are purely black / white / gray.  */
-class SchemeMonochrome(sourceColorHct: Hct, isDark: Boolean, contrastLevel: Double) : DynamicScheme(
-    sourceColorHct,
-    Variant.MONOCHROME,
-    isDark,
-    contrastLevel,
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0))
+/**
+ * A monochrome theme, colors are purely black / white / gray.
+ */
+class SchemeMonochrome(
+    sourceColorHct: Hct,
+    isDark: Boolean,
+    contrastLevel: Double,
+) : DynamicScheme(
+    sourceColorHct = sourceColorHct,
+    variant = Variant.MONOCHROME,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0),
+    secondaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0),
+    tertiaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0),
+    neutralPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0),
+    neutralVariantPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeNeutral.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeNeutral.kt
@@ -18,14 +18,21 @@ package com.materialkolor.scheme
 import com.materialkolor.hct.Hct
 import com.materialkolor.palettes.TonalPalette
 
-/** A theme that's slightly more chromatic than monochrome, which is purely black / white / gray.  */
-class SchemeNeutral(sourceColorHct: Hct, isDark: Boolean, contrastLevel: Double) : DynamicScheme(
-    sourceColorHct,
-    Variant.NEUTRAL,
-    isDark,
-    contrastLevel,
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 12.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 8.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 16.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 2.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 2.0))
+/**
+ * A theme that's slightly more chromatic than monochrome, which is purely black / white / gray.
+ */
+class SchemeNeutral(
+    sourceColorHct: Hct,
+    isDark: Boolean,
+    contrastLevel: Double,
+) : DynamicScheme(
+    sourceColorHct = sourceColorHct,
+    variant = Variant.NEUTRAL,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 12.0),
+    secondaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 8.0),
+    tertiaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 16.0),
+    neutralPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 2.0),
+    neutralVariantPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 2.0),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeRainbow.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeRainbow.kt
@@ -16,18 +16,26 @@
 package com.materialkolor.scheme
 
 import com.materialkolor.hct.Hct
-import com.materialkolor.utils.MathUtils
 import com.materialkolor.palettes.TonalPalette
+import com.materialkolor.utils.MathUtils
 
-/** A playful theme - the source color's hue does not appear in the theme.  */
-class SchemeRainbow(sourceColorHct: Hct, isDark: Boolean, contrastLevel: Double) : DynamicScheme(
-    sourceColorHct,
-    Variant.RAINBOW,
-    isDark,
-    contrastLevel,
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 48.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 16.0),
-    TonalPalette.fromHueAndChroma(
-        MathUtils.sanitizeDegreesDouble(sourceColorHct.getHue() + 60.0), 24.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0))
+/**
+ * A playful theme - the source color's hue does not appear in the theme.
+ */
+class SchemeRainbow(
+    sourceColorHct: Hct,
+    isDark: Boolean,
+    contrastLevel: Double,
+) : DynamicScheme(
+    sourceColorHct = sourceColorHct,
+    variant = Variant.RAINBOW,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 48.0),
+    secondaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 16.0),
+    tertiaryPalette = TonalPalette.fromHueAndChroma(
+        hue = MathUtils.sanitizeDegreesDouble(sourceColorHct.getHue() + 60.0),
+        chroma = 24.0,
+    ),
+    neutralPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0),
+    neutralVariantPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 0.0))

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeTonalSpot.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeTonalSpot.kt
@@ -21,7 +21,7 @@ import com.materialkolor.utils.MathUtils
 
 /**
  * A calm theme, sedated colors that aren't particularly chromatic.
- * */
+ */
 class SchemeTonalSpot(
     sourceColorHct: Hct,
     isDark: Boolean,

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeTonalSpot.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeTonalSpot.kt
@@ -16,18 +16,26 @@
 package com.materialkolor.scheme
 
 import com.materialkolor.hct.Hct
-import com.materialkolor.utils.MathUtils
 import com.materialkolor.palettes.TonalPalette
+import com.materialkolor.utils.MathUtils
 
-/** A calm theme, sedated colors that aren't particularly chromatic.  */
-class SchemeTonalSpot(sourceColorHct: Hct, isDark: Boolean, contrastLevel: Double) : DynamicScheme(
-    sourceColorHct,
-    Variant.TONAL_SPOT,
-    isDark,
-    contrastLevel,
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 36.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 16.0),
-    TonalPalette.fromHueAndChroma(
-        MathUtils.sanitizeDegreesDouble(sourceColorHct.getHue() + 60.0), 24.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 6.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 8.0))
+/**
+ * A calm theme, sedated colors that aren't particularly chromatic.
+ * */
+class SchemeTonalSpot(
+    sourceColorHct: Hct,
+    isDark: Boolean,
+    contrastLevel: Double,
+) : DynamicScheme(
+    sourceColorHct = sourceColorHct,
+    variant = Variant.TONAL_SPOT,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 36.0),
+    secondaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 16.0),
+    tertiaryPalette = TonalPalette.fromHueAndChroma(
+        hue = MathUtils.sanitizeDegreesDouble(sourceColorHct.getHue() + 60.0),
+        chroma = 24.0,
+    ),
+    neutralPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 6.0),
+    neutralVariantPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 8.0))

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeVibrant.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeVibrant.kt
@@ -18,24 +18,33 @@ package com.materialkolor.scheme
 import com.materialkolor.hct.Hct
 import com.materialkolor.palettes.TonalPalette
 
-/** A loud theme, colorfulness is maximum for Primary palette, increased for others.  */
-class SchemeVibrant(sourceColorHct: Hct, isDark: Boolean, contrastLevel: Double) : DynamicScheme(
-    sourceColorHct,
-    Variant.VIBRANT,
-    isDark,
-    contrastLevel,
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 200.0),
-    TonalPalette.fromHueAndChroma(
-        DynamicScheme.getRotatedHue(sourceColorHct, HUES, SECONDARY_ROTATIONS), 24.0),
-    TonalPalette.fromHueAndChroma(
-        DynamicScheme.getRotatedHue(sourceColorHct, HUES, TERTIARY_ROTATIONS), 32.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 10.0),
-    TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 12.0)) {
+/**
+ * A loud theme, colorfulness is maximum for Primary palette, increased for others.
+ */
+class SchemeVibrant(
+    sourceColorHct: Hct,
+    isDark: Boolean,
+    contrastLevel: Double,
+) : DynamicScheme(
+    sourceColorHct = sourceColorHct,
+    variant = Variant.VIBRANT,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 200.0),
+    secondaryPalette = TonalPalette.fromHueAndChroma(getRotatedHue(sourceColorHct, HUES, SECONDARY_ROTATIONS), 24.0),
+    tertiaryPalette = TonalPalette.fromHueAndChroma(getRotatedHue(sourceColorHct, HUES, TERTIARY_ROTATIONS), 32.0),
+    neutralPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 10.0),
+    neutralVariantPalette = TonalPalette.fromHueAndChroma(sourceColorHct.getHue(), 12.0),
+) {
 
     companion object {
 
         private val HUES = doubleArrayOf(0.0, 41.0, 61.0, 101.0, 131.0, 181.0, 251.0, 301.0, 360.0)
-        private val SECONDARY_ROTATIONS = doubleArrayOf(18.0, 15.0, 10.0, 12.0, 15.0, 18.0, 15.0, 12.0, 12.0)
-        private val TERTIARY_ROTATIONS = doubleArrayOf(35.0, 30.0, 20.0, 25.0, 30.0, 35.0, 30.0, 25.0, 25.0)
+
+        private val SECONDARY_ROTATIONS =
+            doubleArrayOf(18.0, 15.0, 10.0, 12.0, 15.0, 18.0, 15.0, 12.0, 12.0)
+
+        private val TERTIARY_ROTATIONS =
+            doubleArrayOf(35.0, 30.0, 20.0, 25.0, 30.0, 35.0, 30.0, 25.0, 25.0)
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/score/Score.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/score/Score.kt
@@ -26,10 +26,10 @@ import kotlin.math.round
  * Given a large set of colors, remove colors that are unsuitable for a UI theme, and rank the rest
  * based on suitability.
  *
- *
  * Enables use of a high cluster count for image quantization, thus ensuring colors aren't
  * muddied, while curating the high cluster count to a much smaller number of appropriate choices.
  */
+@Suppress("unused")
 internal object Score {
 
     private const val TARGET_CHROMA = 48.0 // A1 Chroma
@@ -43,11 +43,11 @@ internal object Score {
      * Given a map with keys of colors and values of how often the color appears, rank the colors
      * based on suitability for being used for a UI theme.
      *
-     * @param colorsToPopulation map with keys of colors and values of how often the color appears,
+     * @param[colorsToPopulation] map with keys of colors and values of how often the color appears,
      * usually from a source image.
-     * @param desired max count of colors to be returned in the list.
-     * @param fallbackColorArgb color to be returned if no other options available.
-     * @param filter whether to filter out undesireable combinations.
+     * @param[desired] max count of colors to be returned in the list.
+     * @param[fallbackColorArgb] color to be returned if no other options available.
+     * @param[filter] whether to filter out undesireable combinations.
      * @return Colors sorted by suitability for a UI theme. The most suitable color is the first item,
      * the least suitable is the last. There will always be at least one color returned. If all
      * the input colors were not suitable for a theme, a default fallback color will be provided,
@@ -60,7 +60,6 @@ internal object Score {
         fallbackColorArgb: Int = -0xbd7a0c,
         filter: Boolean = true,
     ): List<Int> {
-
         // Get the HCT color for each Argb value, while finding the per hue count and
         // total count.
         val colorsHct: MutableList<Hct> = mutableListOf()
@@ -99,6 +98,7 @@ internal object Score {
             val score = proportionScore + chromaScore
             scoredHcts.add(ScoredHCT(hct, score))
         }
+
         // Sorted so that colors with higher scores come first.
         scoredHcts.sortWith(ScoredComparator())
 
@@ -140,6 +140,7 @@ internal object Score {
     }
 
     private class ScoredHCT(val hct: Hct, val score: Double)
+
     private class ScoredComparator : Comparator<ScoredHCT> {
 
         override fun compare(a: ScoredHCT, b: ScoredHCT): Int {

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/ColorUtils.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/ColorUtils.kt
@@ -22,25 +22,36 @@ import kotlin.math.round
 /**
  * Color science utilities.
  *
- *
  * Utility methods for color science constants and color space conversions that aren't HCT or
  * CAM16.
  */
+@Suppress("MemberVisibilityCanBePrivate", "unused")
 internal object ColorUtils {
 
-    val SRGB_TO_XYZ = arrayOf(doubleArrayOf(0.41233895, 0.35762064, 0.18051042), doubleArrayOf(0.2126, 0.7152, 0.0722), doubleArrayOf(0.01932141, 0.11916382, 0.95034478))
-    val XYZ_TO_SRGB = arrayOf(doubleArrayOf(
-        3.2413774792388685, -1.5376652402851851, -0.49885366846268053), doubleArrayOf(
-        -0.9691452513005321, 1.8758853451067872, 0.04156585616912061), doubleArrayOf(
-        0.05562093689691305, -0.20395524564742123, 1.0571799111220335))
+    val SRGB_TO_XYZ = arrayOf(
+        doubleArrayOf(0.41233895, 0.35762064, 0.18051042),
+        doubleArrayOf(0.2126, 0.7152, 0.0722),
+        doubleArrayOf(0.01932141, 0.11916382, 0.95034478),
+    )
+
+    val XYZ_TO_SRGB = arrayOf(
+        doubleArrayOf(3.2413774792388685, -1.5376652402851851, -0.49885366846268053),
+        doubleArrayOf(-0.9691452513005321, 1.8758853451067872, 0.04156585616912061),
+        doubleArrayOf(0.05562093689691305, -0.20395524564742123, 1.0571799111220335),
+    )
+
     val WHITE_POINT_D65 = doubleArrayOf(95.047, 100.0, 108.883)
 
-    /** Converts a color from RGB components to ARGB format.  */
+    /**
+     * Converts a color from RGB components to ARGB format.
+     */
     fun argbFromRgb(red: Int, green: Int, blue: Int): Int {
         return 255 shl 24 or (red and 255 shl 16) or (green and 255 shl 8) or (blue and 255)
     }
 
-    /** Converts a color from linear RGB components to ARGB format.  */
+    /**
+     * Converts a color from linear RGB components to ARGB format.
+     */
     fun argbFromLinrgb(linrgb: DoubleArray): Int {
         val r = delinearized(linrgb[0])
         val g = delinearized(linrgb[1])
@@ -48,32 +59,34 @@ internal object ColorUtils {
         return argbFromRgb(r, g, b)
     }
 
-    /** Returns the alpha component of a color in ARGB format.  */
-    fun alphaFromArgb(argb: Int): Int {
-        return argb shr 24 and 255
-    }
+    /**
+     * Returns the alpha component of a color in ARGB format.
+     */
+    fun alphaFromArgb(argb: Int): Int = argb shr 24 and 255
 
-    /** Returns the red component of a color in ARGB format.  */
-    fun redFromArgb(argb: Int): Int {
-        return argb shr 16 and 255
-    }
+    /**
+     * Returns the red component of a color in ARGB format.
+     */
+    fun redFromArgb(argb: Int): Int = argb shr 16 and 255
 
-    /** Returns the green component of a color in ARGB format.  */
-    fun greenFromArgb(argb: Int): Int {
-        return argb shr 8 and 255
-    }
+    /**
+     * Returns the green component of a color in ARGB format.
+     */
+    fun greenFromArgb(argb: Int): Int = argb shr 8 and 255
 
-    /** Returns the blue component of a color in ARGB format.  */
-    fun blueFromArgb(argb: Int): Int {
-        return argb and 255
-    }
+    /**
+     * Returns the blue component of a color in ARGB format.
+     */
+    fun blueFromArgb(argb: Int): Int = argb and 255
 
-    /** Returns whether a color in ARGB format is opaque.  */
-    fun isOpaque(argb: Int): Boolean {
-        return alphaFromArgb(argb) >= 255
-    }
+    /**
+     * Returns whether a color in ARGB format is opaque.
+     */
+    fun isOpaque(argb: Int): Boolean = alphaFromArgb(argb) >= 255
 
-    /** Converts a color from ARGB to XYZ.  */
+    /**
+     * Converts a color from ARGB to XYZ.
+     */
     fun argbFromXyz(x: Double, y: Double, z: Double): Int {
         val matrix = XYZ_TO_SRGB
         val linearR = matrix[0][0] * x + matrix[0][1] * y + matrix[0][2] * z
@@ -85,7 +98,9 @@ internal object ColorUtils {
         return argbFromRgb(r, g, b)
     }
 
-    /** Converts a color from XYZ to ARGB.  */
+    /**
+     * Converts a color from XYZ to ARGB.
+     */
     fun xyzFromArgb(argb: Int): DoubleArray {
         val r = linearized(redFromArgb(argb))
         val g = linearized(greenFromArgb(argb))
@@ -93,7 +108,9 @@ internal object ColorUtils {
         return MathUtils.matrixMultiply(doubleArrayOf(r, g, b), SRGB_TO_XYZ)
     }
 
-    /** Converts a color represented in Lab color space into an ARGB integer.  */
+    /**
+     * Converts a color represented in Lab color space into an ARGB integer.
+     */
     fun argbFromLab(l: Double, a: Double, b: Double): Int {
         val whitePoint = WHITE_POINT_D65
         val fy = (l + 16.0) / 116.0
@@ -111,7 +128,7 @@ internal object ColorUtils {
     /**
      * Converts a color from ARGB representation to L*a*b* representation.
      *
-     * @param argb the ARGB representation of a color
+     * @param[argb] the ARGB representation of a color
      * @return a Lab object representing the color
      */
     fun labFromArgb(argb: Int): DoubleArray {
@@ -138,7 +155,7 @@ internal object ColorUtils {
     /**
      * Converts an L* value to an ARGB representation.
      *
-     * @param lstar L* in L*a*b*
+     * @param[lstar] L* in L*a*b*
      * @return ARGB representation of grayscale color with lightness matching L*
      */
     fun argbFromLstar(lstar: Double): Int {
@@ -150,7 +167,7 @@ internal object ColorUtils {
     /**
      * Computes the L* value of a color in ARGB representation.
      *
-     * @param argb ARGB representation of a color
+     * @param[argb] ARGB representation of a color
      * @return L*, from L*a*b*, coordinate of the color
      */
     fun lstarFromArgb(argb: Int): Double {
@@ -168,7 +185,7 @@ internal object ColorUtils {
      * L* measures perceptual luminance, a linear scale. Y in XYZ measures relative luminance, a
      * logarithmic scale.
      *
-     * @param lstar L* in L*a*b*
+     * @param[lstar] L* in L*a*b*
      * @return Y in XYZ
      */
     fun yFromLstar(lstar: Double): Double {
@@ -185,7 +202,7 @@ internal object ColorUtils {
      * L* measures perceptual luminance, a linear scale. Y in XYZ measures relative luminance, a
      * logarithmic scale.
      *
-     * @param y Y in XYZ
+     * @param[y] Y in XYZ
      * @return L* in L*a*b*
      */
     fun lstarFromY(y: Double): Double {
@@ -195,22 +212,19 @@ internal object ColorUtils {
     /**
      * Linearizes an RGB component.
      *
-     * @param rgbComponent 0 <= rgb_component <= 255, represents R/G/B channel
+     * @param[rgbComponent] 0 <= rgb_component <= 255, represents R/G/B channel
      * @return 0.0 <= output <= 100.0, color channel converted to linear RGB space
      */
     fun linearized(rgbComponent: Int): Double {
         val normalized = rgbComponent / 255.0
-        return if (normalized <= 0.040449936) {
-            normalized / 12.92 * 100.0
-        } else {
-            (normalized + 0.055 / 1.055).pow(2.4) * 100.0
-        }
+        return if (normalized <= 0.040449936) normalized / 12.92 * 100.0
+        else (normalized + 0.055 / 1.055).pow(2.4) * 100.0
     }
 
     /**
      * Delinearizes an RGB component.
      *
-     * @param rgbComponent 0.0 <= rgb_component <= 100.0, represents linear R/G/B channel
+     * @param[rgbComponent] 0.0 <= rgb_component <= 100.0, represents linear R/G/B channel
      * @return 0 <= output <= 255, color channel converted to regular RGB space
      */
     fun delinearized(rgbComponent: Double): Int {
@@ -228,28 +242,19 @@ internal object ColorUtils {
      *
      * @return The white point
      */
-    fun whitePointD65(): DoubleArray {
-        return WHITE_POINT_D65
-    }
+    fun whitePointD65(): DoubleArray = WHITE_POINT_D65
 
     fun labF(t: Double): Double {
         val e = 216.0 / 24389.0
         val kappa = 24389.0 / 27.0
-        return if (t > e) {
-            t.pow(1.0 / 3.0)
-        } else {
-            (kappa * t + 16) / 116
-        }
+        return if (t > e) t.pow(1.0 / 3.0)
+        else (kappa * t + 16) / 116
     }
 
     fun labInvf(ft: Double): Double {
         val e = 216.0 / 24389.0
         val kappa = 24389.0 / 27.0
         val ft3 = ft * ft * ft
-        return if (ft3 > e) {
-            ft3
-        } else {
-            (116 * ft - 16) / kappa
-        }
+        return if (ft3 > e) ft3 else (116 * ft - 16) / kappa
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/MathUtils.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/MathUtils.kt
@@ -18,7 +18,9 @@ package com.materialkolor.utils
 
 import kotlin.math.abs
 
-/** Utility methods for mathematical operations.  */
+/**
+ * Utility methods for mathematical operations.
+ */
 internal object MathUtils {
 
     /**
@@ -26,14 +28,10 @@ internal object MathUtils {
      *
      * @return 1 if num > 0, -1 if num < 0, and 0 if num = 0
      */
-    fun signum(num: Double): Int {
-        return if (num < 0) {
-            -1
-        } else if (num == 0.0) {
-            0
-        } else {
-            1
-        }
+    fun signum(num: Double): Int = when {
+        num < 0 -> -1
+        num == 0.0 -> 0
+        else -> 1
     }
 
     /**
@@ -50,13 +48,10 @@ internal object MathUtils {
      *
      * @return input when min <= input <= max, and either min or max otherwise.
      */
-    fun clampInt(min: Int, max: Int, input: Int): Int {
-        if (input < min) {
-            return min
-        } else if (input > max) {
-            return max
-        }
-        return input
+    fun clampInt(min: Int, max: Int, input: Int): Int = when {
+        input < min -> min
+        input > max -> max
+        else -> input
     }
 
     /**
@@ -64,13 +59,10 @@ internal object MathUtils {
      *
      * @return input when min <= input <= max, and either min or max otherwise.
      */
-    fun clampDouble(min: Double, max: Double, input: Double): Double {
-        if (input < min) {
-            return min
-        } else if (input > max) {
-            return max
-        }
-        return input
+    fun clampDouble(min: Double, max: Double, input: Double): Double = when {
+        input < min -> min
+        input > max -> max
+        else -> input
     }
 
     /**
@@ -81,7 +73,7 @@ internal object MathUtils {
     fun sanitizeDegreesInt(degrees: Int): Int {
         var sanitized = degrees % 360
         if (sanitized < 0) {
-            sanitized = sanitized + 360
+            sanitized += 360
         }
         return sanitized
     }
@@ -94,7 +86,7 @@ internal object MathUtils {
     fun sanitizeDegreesDouble(degrees: Double): Double {
         var sanitized = degrees % 360.0
         if (sanitized < 0) {
-            sanitized = sanitized + 360.0
+            sanitized += 360.0
         }
         return sanitized
     }
@@ -102,12 +94,11 @@ internal object MathUtils {
     /**
      * Sign of direction change needed to travel from one angle to another.
      *
-     *
      * For angles that are 180 degrees apart from each other, both directions have the same travel
      * distance, so either direction is shortest. The value 1.0 is returned in this case.
      *
-     * @param from The angle travel starts from, in degrees.
-     * @param to The angle travel ends at, in degrees.
+     * @param[from] The angle travel starts from, in degrees.
+     * @param[to] The angle travel ends at, in degrees.
      * @return -1 if decreasing from leads to the shortest travel distance, 1 if increasing from leads
      * to the shortest travel distance.
      */
@@ -117,10 +108,10 @@ internal object MathUtils {
     }
 
 
-    /** Distance of two points on a circle, represented using degrees.  */
-    fun differenceDegrees(a: Double, b: Double): Double {
-        return 180.0 - abs(abs(a - b) - 180.0)
-    }
+    /**
+     * Distance of two points on a circle, represented using degrees.
+     */
+    fun differenceDegrees(a: Double, b: Double): Double = 180.0 - abs(abs(a - b) - 180.0)
 
     /** Multiplies a 1x3 row vector with a 3x3 matrix.  */
     fun matrixMultiply(row: DoubleArray, matrix: Array<DoubleArray>): DoubleArray {
@@ -130,11 +121,7 @@ internal object MathUtils {
         return doubleArrayOf(a, b, c)
     }
 
-    fun toDegrees(angrad: Double): Double {
-        return angrad * 57.29577951308232
-    }
+    fun toDegrees(angrad: Double): Double = angrad * 57.29577951308232
 
-    fun toRadians(angdeg: Double): Double {
-        return angdeg * 0.017453292519943295
-    }
+    fun toRadians(angdeg: Double): Double = angdeg * 0.017453292519943295
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/pow.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/pow.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused")
+
 package com.materialkolor.utils
 
 import kotlin.math.pow

--- a/material-kolor/build.gradle.kts
+++ b/material-kolor/build.gradle.kts
@@ -1,7 +1,3 @@
-@file:Suppress("UNUSED_VARIABLE", "OPT_IN_USAGE")
-
-import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
-
 plugins {
     alias(libs.plugins.multiplatform)
     alias(libs.plugins.compose)
@@ -11,11 +7,11 @@ plugins {
 }
 
 kotlin {
-    explicitApi = ExplicitApiMode.Strict
+    explicitApi()
 
-    targetHierarchy.default()
+    applyDefaultHierarchyTemplate()
 
-    android {
+    androidTarget {
         publishAllLibraryVariants()
     }
 
@@ -71,11 +67,6 @@ android {
         release {
             isMinifyEnabled = false
         }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlin {

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicColorScheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicColorScheme.kt
@@ -15,6 +15,14 @@ import com.materialkolor.scheme.SchemeRainbow
 import com.materialkolor.scheme.SchemeTonalSpot
 import com.materialkolor.scheme.SchemeVibrant
 
+/**
+ * Creates a [ColorScheme] based on the given [seedColor] and [isDark] mode.
+ *
+ * @param[seedColor] The color to base the scheme on.
+ * @param[isDark] Whether the scheme should be dark or light.
+ * @param[style] The style of the scheme.
+ * @param[contrastLevel] The contrast level of the scheme.
+ */
 public fun dynamicColorScheme(
     seedColor: Color,
     isDark: Boolean,

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
@@ -14,6 +14,19 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 
+/**
+ * A Material Theme that adapts to the given seed color.
+ *
+ * You can access the current seed color via [LocalDynamicMaterialThemeSeed].
+ *
+ * @see dynamicColorScheme
+ * @see PaletteStyle
+ * @param[seedColor] The seed color to use for generating the color scheme.
+ * @param[useDarkTheme] Whether to use a dark theme or not.
+ * @param[style] The style of the color scheme.
+ * @param[contrastLevel] The contrast level of the color scheme.
+ * @param[content] The Composable content of the theme.
+ */
 @Composable
 public fun DynamicMaterialTheme(
     seedColor: Color,
@@ -38,6 +51,20 @@ public fun DynamicMaterialTheme(
     }
 }
 
+/**
+ * A Material Theme that adapts to the given seed color and animates the color scheme.
+ *
+ * You can access the current seed color via [LocalDynamicMaterialThemeSeed].
+ *
+ * @see dynamicColorScheme
+ * @see PaletteStyle
+ * @param[seedColor] The seed color to use for generating the color scheme.
+ * @param[useDarkTheme] Whether to use a dark theme or not.
+ * @param[style] The style of the color scheme.
+ * @param[contrastLevel] The contrast level of the color scheme.
+ * @param[animationSpec] The animation spec to use for animating the color scheme.
+ * @param[content] The Composable content of the theme.
+ */
 @Composable
 public fun AnimatedDynamicMaterialTheme(
     seedColor: Color,

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/LocalDynamicMaterialThemeSeed.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/LocalDynamicMaterialThemeSeed.kt
@@ -4,5 +4,9 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 
+/**
+ * LocalDynamicMaterialThemeSeed is a [CompositionLocal] that provides the seed color for the
+ * dynamic material theme.
+ */
 public val LocalDynamicMaterialThemeSeed: ProvidableCompositionLocal<Color> =
     staticCompositionLocalOf { error("DynamicMaterialTheme not initialized") }

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/PaletteStyle.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/PaletteStyle.kt
@@ -1,13 +1,65 @@
 package com.materialkolor
 
 public enum class PaletteStyle {
+
+    /**
+     * A calm theme, sedated colors that aren't particularly chromatic.
+     */
     TonalSpot,
+
+    /**
+     * A theme that's slightly more chromatic than monochrome, which is purely black / white / gray.
+     */
     Neutral,
+
+    /**
+     * A loud theme, colorfulness is maximum for Primary palette, increased for others.
+     */
     Vibrant,
+
+    /**
+     * A playful theme - the source color's hue does not appear in the theme.
+     */
     Expressive,
+
+    /**
+     * A playful theme - the source color's hue does not appear in the theme.
+     */
     Rainbow,
+
+    /**
+     * A playful theme - the source color's hue does not appear in the theme.
+     */
     FruitSalad,
+
+    /**
+     * A monochrome theme, colors are purely black / white / gray.
+     */
     Monochrome,
+
+    /**
+     * A scheme that places the source color in Scheme.primaryContainer.
+     *
+     * Primary Container is the source color, adjusted for color relativity. It maintains constant
+     * appearance in light mode and dark mode. This adds ~5 tone in light mode, and subtracts ~5 tone in
+     * dark mode.
+     *
+     * Tertiary Container is the complement to the source color, using TemperatureCache. It also
+     * maintains constant appearance.
+     */
     Fidelity,
+
+    /**
+     * A scheme that places the source color in Scheme.primaryContainer.
+     *
+     * Primary Container is the source color, adjusted for color relativity. It maintains constant
+     * appearance in light mode and dark mode. This adds ~5 tone in light mode, and subtracts ~5 tone in
+     * dark mode.
+     *
+     * Tertiary Container is an analogous color, specifically, the analog of a color wheel divided
+     * into 6, and the precise analog is the one found by increasing hue. This is a scientifically
+     * grounded equivalent to rotating hue clockwise by 60 degrees. It also maintains constant
+     * appearance.
+     */
     Content
 }


### PR DESCRIPTION
When I initially made this library, I just used Android Studio's Java to Kotlin and kept the output. I didn't make any formatting changes at all.

This PR remedies this and brings the Kotlin code inline with the rest of the codebase.

## Future steps

1. integrate ktlint/spotless/detekt
2. Remove unused classes in `material-color-utilities`. Keep only code related to the scheme generation.