### PR TITLE
Feature: Add `rememberDynamicColorScheme` Composable

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ fun MyTheme(
     useDarkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    val colorScheme = dynamicColorScheme(seedColor, useDarkTheme)
+  val colorScheme = rememberDynamicColorScheme(seedColor, useDarkTheme)
 
     MaterialTheme(
         colors = colorScheme.toMaterialColors(),

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ fun MyTheme(
     useDarkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-  val colorScheme = rememberDynamicColorScheme(seedColor, useDarkTheme)
+    val colorScheme = rememberDynamicColorScheme(seedColor, useDarkTheme)
 
     MaterialTheme(
         colors = colorScheme.toMaterialColors(),

--- a/material-kolor/api/android/material-kolor.api
+++ b/material-kolor/api/android/material-kolor.api
@@ -1,6 +1,7 @@
 public final class com/materialkolor/DynamicColorSchemeKt {
 	public static final fun dynamicColorScheme-Iv8Zu3U (JZLcom/materialkolor/PaletteStyle;D)Landroidx/compose/material3/ColorScheme;
 	public static synthetic fun dynamicColorScheme-Iv8Zu3U$default (JZLcom/materialkolor/PaletteStyle;DILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
+	public static final fun rememberDynamicColorScheme-euL9pac (JZLcom/materialkolor/PaletteStyle;DLandroidx/compose/runtime/Composer;II)Landroidx/compose/material3/ColorScheme;
 }
 
 public final class com/materialkolor/DynamicMaterialThemeKt {

--- a/material-kolor/api/jvm/material-kolor.api
+++ b/material-kolor/api/jvm/material-kolor.api
@@ -1,6 +1,7 @@
 public final class com/materialkolor/DynamicColorSchemeKt {
 	public static final fun dynamicColorScheme-Iv8Zu3U (JZLcom/materialkolor/PaletteStyle;D)Landroidx/compose/material3/ColorScheme;
 	public static synthetic fun dynamicColorScheme-Iv8Zu3U$default (JZLcom/materialkolor/PaletteStyle;DILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
+	public static final fun rememberDynamicColorScheme-euL9pac (JZLcom/materialkolor/PaletteStyle;DLandroidx/compose/runtime/Composer;II)Landroidx/compose/material3/ColorScheme;
 }
 
 public final class com/materialkolor/DynamicMaterialThemeKt {

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicColorScheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicColorScheme.kt
@@ -1,6 +1,8 @@
 package com.materialkolor
 
 import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import com.materialkolor.dynamiccolor.MaterialDynamicColors
@@ -14,6 +16,14 @@ import com.materialkolor.scheme.SchemeNeutral
 import com.materialkolor.scheme.SchemeRainbow
 import com.materialkolor.scheme.SchemeTonalSpot
 import com.materialkolor.scheme.SchemeVibrant
+
+@Composable
+public fun rememberDynamicColorScheme(
+    seedColor: Color,
+    isDark: Boolean,
+    style: PaletteStyle = PaletteStyle.TonalSpot,
+    contrastLevel: Double = 0.0,
+): ColorScheme = remember { dynamicColorScheme(seedColor, isDark, style, contrastLevel) }
 
 public fun dynamicColorScheme(
     seedColor: Color,

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
@@ -11,9 +11,6 @@ import androidx.compose.material3.Shapes
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 
 @Composable
@@ -26,16 +23,12 @@ public fun DynamicMaterialTheme(
     typography: Typography = MaterialTheme.typography,
     content: @Composable () -> Unit,
 ) {
-    val colorScheme: ColorScheme by remember(seedColor, useDarkTheme, style, contrastLevel) {
-        derivedStateOf {
-            dynamicColorScheme(
-                seedColor = seedColor,
-                isDark = useDarkTheme,
-                style = style,
-                contrastLevel = contrastLevel,
-            )
-        }
-    }
+    val colorScheme: ColorScheme = rememberDynamicColorScheme(
+        seedColor = seedColor,
+        isDark = useDarkTheme,
+        style = style,
+        contrastLevel = contrastLevel,
+    )
 
     CompositionLocalProvider(LocalDynamicMaterialThemeSeed provides seedColor) {
         MaterialTheme(
@@ -58,16 +51,12 @@ public fun AnimatedDynamicMaterialTheme(
     typography: Typography = MaterialTheme.typography,
     content: @Composable () -> Unit,
 ) {
-    val colors: ColorScheme by remember(seedColor, useDarkTheme, style, contrastLevel) {
-        derivedStateOf {
-            dynamicColorScheme(
-                seedColor = seedColor,
-                isDark = useDarkTheme,
-                style = style,
-                contrastLevel = contrastLevel,
-            )
-        }
-    }
+    val colors: ColorScheme = rememberDynamicColorScheme(
+        seedColor = seedColor,
+        isDark = useDarkTheme,
+        style = style,
+        contrastLevel = contrastLevel,
+    )
 
     val animatedColorScheme = colors.copy(
         primary = animateColorAsState(colors.primary, animationSpec).value,


### PR DESCRIPTION
If you don't want to use `DynamicMaterialTheme` or `AnimatedDynamicMaterialTheme`, and instead want to generate a color scheme within a `@Composable` you have to remember to use `remember {}`. This PR adds a composable function that does just that.