### PR TITLE
Fix: Demo

### DIFF
--- a/demo/composeApp/src/commonMain/kotlin/com/materialkolor/demo/App.kt
+++ b/demo/composeApp/src/commonMain/kotlin/com/materialkolor/demo/App.kt
@@ -230,7 +230,8 @@ internal fun App() {
                             Text("Button")
                         }
 
-                        LinearProgressIndicator()
+                        // TODO: Broken in Compose 1.6.0-beta01
+                        // LinearProgressIndicator()
                     }
                 }
             }


### PR DESCRIPTION
Progress indicators are currently broken in Compose 1.6.0-beta01 because of Androidx Material3 1.6.0.

This is a temporary fix until the issue is resolved upstream.