### PR TITLE
Fix: Color scheme not re-generating on seed color change

### DIFF
--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicColorScheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicColorScheme.kt
@@ -23,7 +23,9 @@ public fun rememberDynamicColorScheme(
     isDark: Boolean,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = 0.0,
-): ColorScheme = remember { dynamicColorScheme(seedColor, isDark, style, contrastLevel) }
+): ColorScheme = remember(seedColor, isDark, style, contrastLevel) {
+    dynamicColorScheme(seedColor, isDark, style, contrastLevel)
+}
 
 public fun dynamicColorScheme(
     seedColor: Color,


### PR DESCRIPTION
fixes #84

When I implemented #83, I forgot to add the parameters to the `remember {}` call.