### PR TITLE
fix: ColorUtils.linearized()

### DIFF
--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/ColorUtils.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/utils/ColorUtils.kt
@@ -241,7 +241,7 @@ public object ColorUtils {
     public fun linearized(rgbComponent: Int): Double {
         val normalized = rgbComponent / 255.0
         return if (normalized <= 0.040449936) normalized / 12.92 * 100.0
-        else (normalized + 0.055 / 1.055).pow(2.4) * 100.0
+        else ((normalized + 0.055) / 1.055).pow(2.4) * 100.0
     }
 
     /**


### PR DESCRIPTION
I was tracking a different result compared to [material-components-android](https://github.com/material-components/material-components-android/) and I noticed a small parens error that was probably introduced when converting the code to kotlin.

Here is the original function https://github.com/material-foundation/material-color-utilities/blob/9281b3dbfab9fc82d28110752f3a7461d5e50c68/java/utils/ColorUtils.java#L216