### PR TITLE
Fix: Theme recomposition

### DIFF
--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialThemeState.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialThemeState.kt
@@ -31,6 +31,12 @@ public fun rememberDynamicMaterialThemeState(
     modifyColorScheme: (DynamicMaterialThemeState.(ColorScheme) -> ColorScheme)? = null,
 ): DynamicMaterialThemeState {
     return rememberSaveable(
+        seedColor,
+        isDark,
+        style,
+        contrastLevel,
+        extendedFidelity,
+        modifyColorScheme,
         saver = DynamicMaterialThemeState.Saver(modifyColorScheme),
     ) {
         DynamicMaterialThemeState(


### PR DESCRIPTION
This fixes the theme not recomposing if you don't use the `DynamicMaterialThemeState` parameter and instead use the individual parameters. Fixes #145
