### PR TITLE
Feature - Animate ColorScheme using a Transition

### DIFF
--- a/material-kolor/api/android/material-kolor.api
+++ b/material-kolor/api/android/material-kolor.api
@@ -21,9 +21,9 @@ public final class com/materialkolor/DynamicColorSchemeKt {
 }
 
 public final class com/materialkolor/DynamicMaterialThemeKt {
-	public static final fun DynamicMaterialTheme (Lcom/materialkolor/DynamicMaterialThemeState;Landroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/AnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun DynamicMaterialTheme-7VznAdA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZZLandroidx/compose/animation/core/AnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
-	public static final fun DynamicMaterialTheme-XkNKMuA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZZLandroidx/compose/animation/core/AnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DynamicMaterialTheme (Lcom/materialkolor/DynamicMaterialThemeState;Landroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun DynamicMaterialTheme-7VznAdA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DynamicMaterialTheme-XkNKMuA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/materialkolor/DynamicMaterialThemeState {
@@ -175,7 +175,8 @@ public final class com/materialkolor/ktx/ColorKt {
 }
 
 public final class com/materialkolor/ktx/ColorSchemeKt {
-	public static final fun animateColorScheme (Landroidx/compose/material3/ColorScheme;Landroidx/compose/animation/core/AnimationSpec;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/ColorScheme;
+	public static final fun animateColorScheme (Landroidx/compose/material3/ColorScheme;Landroidx/compose/animation/core/FiniteAnimationSpec;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/ColorScheme;
+	public static final fun animateColorScheme (Landroidx/compose/material3/ColorScheme;Lkotlin/jvm/functions/Function3;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/ColorScheme;
 }
 
 public final class com/materialkolor/ktx/ContrastKt {

--- a/material-kolor/api/jvm/material-kolor.api
+++ b/material-kolor/api/jvm/material-kolor.api
@@ -21,9 +21,9 @@ public final class com/materialkolor/DynamicColorSchemeKt {
 }
 
 public final class com/materialkolor/DynamicMaterialThemeKt {
-	public static final fun DynamicMaterialTheme (Lcom/materialkolor/DynamicMaterialThemeState;Landroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/AnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun DynamicMaterialTheme-7VznAdA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZZLandroidx/compose/animation/core/AnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
-	public static final fun DynamicMaterialTheme-XkNKMuA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZZLandroidx/compose/animation/core/AnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DynamicMaterialTheme (Lcom/materialkolor/DynamicMaterialThemeState;Landroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun DynamicMaterialTheme-7VznAdA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DynamicMaterialTheme-XkNKMuA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/materialkolor/DynamicMaterialThemeState {
@@ -175,7 +175,8 @@ public final class com/materialkolor/ktx/ColorKt {
 }
 
 public final class com/materialkolor/ktx/ColorSchemeKt {
-	public static final fun animateColorScheme (Landroidx/compose/material3/ColorScheme;Landroidx/compose/animation/core/AnimationSpec;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/ColorScheme;
+	public static final fun animateColorScheme (Landroidx/compose/material3/ColorScheme;Landroidx/compose/animation/core/FiniteAnimationSpec;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/ColorScheme;
+	public static final fun animateColorScheme (Landroidx/compose/material3/ColorScheme;Lkotlin/jvm/functions/Function3;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/ColorScheme;
 }
 
 public final class com/materialkolor/ktx/ContrastKt {

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
@@ -1,6 +1,7 @@
 package com.materialkolor
 
 import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
@@ -52,7 +53,7 @@ public fun DynamicMaterialTheme(
     typography: Typography = MaterialTheme.typography,
     isExtendedFidelity: Boolean = false,
     animate: Boolean = false,
-    animationSpec: AnimationSpec<Color> = defaultColorSpring,
+    animationSpec: FiniteAnimationSpec<Color> = defaultColorSpring,
     content: @Composable () -> Unit,
 ) {
     val state = rememberDynamicMaterialThemeState(
@@ -118,7 +119,7 @@ public fun DynamicMaterialTheme(
     typography: Typography = MaterialTheme.typography,
     isExtendedFidelity: Boolean = false,
     animate: Boolean = false,
-    animationSpec: AnimationSpec<Color> = defaultColorSpring,
+    animationSpec: FiniteAnimationSpec<Color> = defaultColorSpring,
     content: @Composable () -> Unit,
 ) {
     val state = rememberDynamicMaterialThemeState(
@@ -163,7 +164,7 @@ public fun DynamicMaterialTheme(
     shapes: Shapes = MaterialTheme.shapes,
     typography: Typography = MaterialTheme.typography,
     animate: Boolean = false,
-    animationSpec: AnimationSpec<Color> = defaultColorSpring,
+    animationSpec: FiniteAnimationSpec<Color> = defaultColorSpring,
     content: @Composable () -> Unit,
 ) {
     val colorScheme = state.colorScheme

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
@@ -1,6 +1,5 @@
 package com.materialkolor
 
-import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/ColorScheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/ColorScheme.kt
@@ -1,6 +1,11 @@
 package com.materialkolor.ktx
 
+import androidx.compose.animation.animateColor
 import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.Transition
+import androidx.compose.animation.core.rememberTransition
+import androidx.compose.animation.core.updateTransition
 import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -20,152 +25,209 @@ import androidx.compose.ui.graphics.Color
 @Composable
 public fun animateColorScheme(
     colorScheme: ColorScheme,
-    animationSpec: AnimationSpec<Color> = defaultColorSpring,
+    animationSpec: FiniteAnimationSpec<Color> = defaultColorSpring,
+    label: String = "ColorSchemeAnimation",
+): ColorScheme = animateColorScheme(colorScheme, { animationSpec }, label)
+
+/**
+ * Creates an animated version of a [ColorScheme] where all colors smoothly animate when changed.
+ *
+ * This composable function creates a new [ColorScheme] where each color property will animate from
+ * its previous value to its new value whenever the input [colorScheme] changes.
+ *
+ * @param colorScheme The source color scheme to animate from/to.
+ * @param animationSpec The animation specification to control how each color animates.
+ * @param label A debugging label used to identify this animation.
+ * @return A new [ColorScheme] instance with animated color properties.
+ */
+@Composable
+public fun animateColorScheme(
+    colorScheme: ColorScheme,
+    animationSpec: @Composable Transition.Segment<ColorScheme>.() -> FiniteAnimationSpec<Color> =
+        { defaultColorSpring },
     label: String = "ColorSchemeAnimation",
 ): ColorScheme {
-    val primary by colorScheme.primary.animate(
-        animationSpec = animationSpec,
+    val transition = updateTransition(targetState = colorScheme, label = label)
+
+    val primary by transition.animateColor(
         label = "color_primary",
+        targetValueByState = { it.primary },
+        transitionSpec = animationSpec,
     )
-    val primaryContainer by colorScheme.primaryContainer.animate(
-        animationSpec = animationSpec,
+    val primaryContainer by transition.animateColor(
         label = "color_primaryContainer",
+        targetValueByState = { it.primaryContainer },
+        transitionSpec = animationSpec,
     )
-    val secondary by colorScheme.secondary.animate(
-        animationSpec = animationSpec,
+    val secondary by transition.animateColor(
         label = "color_secondary",
+        targetValueByState = { it.secondary },
+        transitionSpec = animationSpec,
     )
-    val secondaryContainer by colorScheme.secondaryContainer.animate(
-        animationSpec = animationSpec,
+    val secondaryContainer by transition.animateColor(
         label = "color_secondaryContainer",
+        targetValueByState = { it.secondaryContainer },
+        transitionSpec = animationSpec,
     )
-    val tertiary by colorScheme.tertiary.animate(
-        animationSpec = animationSpec,
+    val tertiary by transition.animateColor(
         label = "color_tertiary",
+        targetValueByState = { it.tertiary },
+        transitionSpec = animationSpec,
     )
-    val tertiaryContainer by colorScheme.tertiaryContainer.animate(
-        animationSpec = animationSpec,
+    val tertiaryContainer by transition.animateColor(
         label = "color_tertiaryContainer",
+        targetValueByState = { it.tertiaryContainer },
+        transitionSpec = animationSpec,
     )
-    val background by colorScheme.background.animate(
-        animationSpec = animationSpec,
+    val background by transition.animateColor(
         label = "color_background",
+        targetValueByState = { it.background },
+        transitionSpec = animationSpec,
     )
-    val surface by colorScheme.surface.animate(
-        animationSpec = animationSpec,
+    val surface by transition.animateColor(
         label = "color_surface",
+        targetValueByState = { it.surface },
+        transitionSpec = animationSpec,
     )
-    val surfaceTint by colorScheme.surfaceTint.animate(
-        animationSpec = animationSpec,
+    val surfaceTint by transition.animateColor(
         label = "color_surfaceTint",
+        targetValueByState = { it.surfaceTint },
+        transitionSpec = animationSpec,
     )
-    val surfaceBright by colorScheme.surfaceBright.animate(
-        animationSpec = animationSpec,
+    val surfaceBright by transition.animateColor(
         label = "color_surfaceBright",
+        targetValueByState = { it.surfaceBright },
+        transitionSpec = animationSpec,
     )
-    val surfaceDim by colorScheme.surfaceDim.animate(
-        animationSpec = animationSpec,
+    val surfaceDim by transition.animateColor(
         label = "color_surfaceDim",
+        targetValueByState = { it.surfaceDim },
+        transitionSpec = animationSpec,
     )
-    val surfaceContainer by colorScheme.surfaceContainer.animate(
-        animationSpec = animationSpec,
+    val surfaceContainer by transition.animateColor(
         label = "color_surfaceContainer",
+        targetValueByState = { it.surfaceContainer },
+        transitionSpec = animationSpec,
     )
-    val surfaceContainerHigh by colorScheme.surfaceContainerHigh.animate(
-        animationSpec = animationSpec,
+    val surfaceContainerHigh by transition.animateColor(
         label = "color_surfaceContainerHigh",
+        targetValueByState = { it.surfaceContainerHigh },
+        transitionSpec = animationSpec,
     )
-    val surfaceContainerHighest by colorScheme.surfaceContainerHighest.animate(
-        animationSpec = animationSpec,
+    val surfaceContainerHighest by transition.animateColor(
         label = "color_surfaceContainerHighest",
+        targetValueByState = { it.surfaceContainerHighest },
+        transitionSpec = animationSpec,
     )
-    val surfaceContainerLow by colorScheme.surfaceContainerLow.animate(
-        animationSpec = animationSpec,
+    val surfaceContainerLow by transition.animateColor(
         label = "color_surfaceContainerLow",
+        targetValueByState = { it.surfaceContainerLow },
+        transitionSpec = animationSpec,
     )
-    val surfaceContainerLowest by colorScheme.surfaceContainerLowest.animate(
-        animationSpec = animationSpec,
+    val surfaceContainerLowest by transition.animateColor(
         label = "color_surfaceContainerLowest",
+        targetValueByState = { it.surfaceContainerLowest },
+        transitionSpec = animationSpec,
     )
-    val surfaceVariant by colorScheme.surfaceVariant.animate(
-        animationSpec = animationSpec,
+    val surfaceVariant by transition.animateColor(
         label = "color_surfaceVariant",
+        targetValueByState = { it.surfaceVariant },
+        transitionSpec = animationSpec,
     )
-    val error by colorScheme.error.animate(
-        animationSpec = animationSpec,
+    val error by transition.animateColor(
         label = "color_error",
+        targetValueByState = { it.error },
+        transitionSpec = animationSpec,
     )
-    val errorContainer by colorScheme.errorContainer.animate(
-        animationSpec = animationSpec,
+    val errorContainer by transition.animateColor(
         label = "color_errorContainer",
+        targetValueByState = { it.errorContainer },
+        transitionSpec = animationSpec,
     )
-    val onPrimary by colorScheme.onPrimary.animate(
-        animationSpec = animationSpec,
+    val onPrimary by transition.animateColor(
         label = "color_onPrimary",
+        targetValueByState = { it.onPrimary },
+        transitionSpec = animationSpec,
     )
-    val onPrimaryContainer by colorScheme.onPrimaryContainer.animate(
-        animationSpec = animationSpec,
+    val onPrimaryContainer by transition.animateColor(
         label = "color_onPrimaryContainer",
+        targetValueByState = { it.onPrimaryContainer },
+        transitionSpec = animationSpec,
     )
-    val onSecondary by colorScheme.onSecondary.animate(
-        animationSpec = animationSpec,
+    val onSecondary by transition.animateColor(
         label = "color_onSecondary",
+        targetValueByState = { it.onSecondary },
+        transitionSpec = animationSpec,
     )
-    val onSecondaryContainer by colorScheme.onSecondaryContainer.animate(
-        animationSpec = animationSpec,
+    val onSecondaryContainer by transition.animateColor(
         label = "color_onSecondaryContainer",
+        targetValueByState = { it.onSecondaryContainer },
+        transitionSpec = animationSpec,
     )
-    val onTertiary by colorScheme.onTertiary.animate(
-        animationSpec = animationSpec,
+    val onTertiary by transition.animateColor(
         label = "color_onTertiary",
+        targetValueByState = { it.onTertiary },
+        transitionSpec = animationSpec,
     )
-    val onTertiaryContainer by colorScheme.onTertiaryContainer.animate(
-        animationSpec = animationSpec,
+    val onTertiaryContainer by transition.animateColor(
         label = "color_onTertiaryContainer",
+        targetValueByState = { it.onTertiaryContainer },
+        transitionSpec = animationSpec,
     )
-    val onBackground by colorScheme.onBackground.animate(
-        animationSpec = animationSpec,
+    val onBackground by transition.animateColor(
         label = "color_onBackground",
+        targetValueByState = { it.onBackground },
+        transitionSpec = animationSpec,
     )
-    val onSurface by colorScheme.onSurface.animate(
-        animationSpec = animationSpec,
+    val onSurface by transition.animateColor(
         label = "color_onSurface",
+        targetValueByState = { it.onSurface },
+        transitionSpec = animationSpec,
     )
-    val onSurfaceVariant by colorScheme.onSurfaceVariant.animate(
-        animationSpec = animationSpec,
+    val onSurfaceVariant by transition.animateColor(
         label = "color_onSurfaceVariant",
+        targetValueByState = { it.onSurfaceVariant },
+        transitionSpec = animationSpec,
     )
-    val onError by colorScheme.onError.animate(
-        animationSpec = animationSpec,
+    val onError by transition.animateColor(
         label = "color_onError",
+        targetValueByState = { it.onError },
+        transitionSpec = animationSpec,
     )
-    val onErrorContainer by colorScheme.onErrorContainer.animate(
-        animationSpec = animationSpec,
+    val onErrorContainer by transition.animateColor(
         label = "color_onErrorContainer",
+        targetValueByState = { it.onErrorContainer },
+        transitionSpec = animationSpec,
     )
-    val inversePrimary by colorScheme.inversePrimary.animate(
-        animationSpec = animationSpec,
+    val inversePrimary by transition.animateColor(
         label = "color_inversePrimary",
+        targetValueByState = { it.inversePrimary },
+        transitionSpec = animationSpec,
     )
-    val inverseSurface by colorScheme.inverseSurface.animate(
-        animationSpec = animationSpec,
+    val inverseSurface by transition.animateColor(
         label = "color_inverseSurface",
+        targetValueByState = { it.inverseSurface },
+        transitionSpec = animationSpec,
     )
-    val inverseOnSurface by colorScheme.inverseOnSurface.animate(
-        animationSpec = animationSpec,
+    val inverseOnSurface by transition.animateColor(
         label = "color_inverseOnSurface",
+        targetValueByState = { it.inverseOnSurface },
+        transitionSpec = animationSpec,
     )
-    val outline by colorScheme.outline.animate(
-        animationSpec = animationSpec,
+    val outline by transition.animateColor(
         label = "color_outline",
+        targetValueByState = { it.outline },
+        transitionSpec = animationSpec,
     )
-    val outlineVariant by colorScheme.outlineVariant.animate(
-        animationSpec = animationSpec,
+    val outlineVariant by transition.animateColor(
         label = "color_outlineVariant",
+        targetValueByState = { it.outlineVariant },
+        transitionSpec = animationSpec,
     )
-    val scrim by colorScheme.scrim.animate(
-        animationSpec = animationSpec,
+    val scrim by transition.animateColor(
         label = "color_scrim",
+        targetValueByState = { it.scrim },
+        transitionSpec = animationSpec,
     )
     return colorScheme.copy(
         primary = primary,

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/ColorScheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/ColorScheme.kt
@@ -1,10 +1,8 @@
 package com.materialkolor.ktx
 
 import androidx.compose.animation.animateColor
-import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.core.Transition
-import androidx.compose.animation.core.rememberTransition
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable


### PR DESCRIPTION
Switch to using `updateTransition` and `Transition<ColorScheme>.animatecolor` for a better animation experience.

Closes #286

**BREAKING CHANGES**
This change requires changing the type of `animationSpec` from a `AnimationSpec<Color>` to `FiniteAnimationSpec<Color>`.
