### PR TITLE
Upstream: Add support for ColorSpec version 2025

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 indent_size = 4
 indent_style = space
 insert_final_newline = true
-max_line_length = 100
+max_line_length = 120
 ktlint_code_style = ktlint_official
 ktlint_standard_wrapping = enabled
 ktlint_standard_multiline-expression-wrapping = disabled

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 indent_size = 4
 indent_style = space
 insert_final_newline = true
-max_line_length = 110
+max_line_length = 100
 ktlint_code_style = ktlint_official
 ktlint_standard_wrapping = enabled
 ktlint_standard_multiline-expression-wrapping = disabled

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,5 @@ jobs:
       - name: Lint
         run: ./gradlew lint --scan
 
-      - name: Spotless
-        run: ./gradlew spotlessCheck --scan
-
       - name: Upstream Tests
         run: ./gradlew :mcu-upstream:test --scan

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ subprojects {
 
     configure<com.diffplug.gradle.spotless.SpotlessExtension> {
         kotlin {
-            ktlint(libs.versions.ktlint.get())
+            ktlint(libs.versions.ktlint.get()).setEditorConfigPath("${project.rootDir}/.editorconfig")
             target("**/*.kt")
             targetExclude(
                 "${layout.buildDirectory}/**/*.kt",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-sdk-compile = "33"
+sdk-compile = "35"
 sdk-min = "21"
 jvmTarget = "17"
 agp = "8.9.2"

--- a/material-color-utilities/api/android/material-color-utilities.api
+++ b/material-color-utilities/api/android/material-color-utilities.api
@@ -272,14 +272,6 @@ public final class com/materialkolor/dynamiccolor/ColorSpec2025 : com/materialko
 public final class com/materialkolor/dynamiccolor/ColorSpec2025$Companion {
 }
 
-public final class com/materialkolor/dynamiccolor/ColorSpecs {
-	public static final field INSTANCE Lcom/materialkolor/dynamiccolor/ColorSpecs;
-	public final fun get ()Lcom/materialkolor/dynamiccolor/ColorSpec;
-	public final fun get (Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;)Lcom/materialkolor/dynamiccolor/ColorSpec;
-	public final fun get (Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Z)Lcom/materialkolor/dynamiccolor/ColorSpec;
-	public static synthetic fun get$default (Lcom/materialkolor/dynamiccolor/ColorSpecs;Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;ILjava/lang/Object;)Lcom/materialkolor/dynamiccolor/ColorSpec;
-}
-
 public final class com/materialkolor/dynamiccolor/ContrastCurve {
 	public fun <init> (DDDD)V
 	public fun equals (Ljava/lang/Object;)Z

--- a/material-color-utilities/api/android/material-color-utilities.api
+++ b/material-color-utilities/api/android/material-color-utilities.api
@@ -342,18 +342,14 @@ public final class com/materialkolor/dynamiccolor/DynamicColor$Companion$Builder
 public final class com/materialkolor/dynamiccolor/MaterialDynamicColors {
 	public static final field Companion Lcom/materialkolor/dynamiccolor/MaterialDynamicColors$Companion;
 	public fun <init> ()V
-	public fun <init> (Z)V
-	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun allDynamicColors ()Ljava/util/List;
 	public final fun background ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun controlActivated ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun controlHighlight ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun controlNormal ()Lcom/materialkolor/dynamiccolor/DynamicColor;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun error ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun errorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun errorPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
-	public fun hashCode ()I
 	public final fun highestSurface (Lcom/materialkolor/scheme/DynamicScheme;)Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun inverseOnSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun inversePrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
@@ -411,7 +407,6 @@ public final class com/materialkolor/dynamiccolor/MaterialDynamicColors {
 	public final fun textPrimaryInverseDisableOnly ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun textSecondaryAndTertiaryInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun textSecondaryAndTertiaryInverseDisabled ()Lcom/materialkolor/dynamiccolor/DynamicColor;
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/materialkolor/dynamiccolor/MaterialDynamicColors$Companion {

--- a/material-color-utilities/api/android/material-color-utilities.api
+++ b/material-color-utilities/api/android/material-color-utilities.api
@@ -26,6 +26,260 @@ public final class com/materialkolor/dislike/DislikeAnalyzer {
 	public final fun isDisliked (Lcom/materialkolor/hct/Hct;)Z
 }
 
+public abstract interface class com/materialkolor/dynamiccolor/ColorSpec {
+	public abstract fun background ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun controlActivated ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun controlHighlight ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun controlNormal ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun error ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun errorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun errorDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun errorPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun getErrorPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public abstract fun getHct (Lcom/materialkolor/scheme/DynamicScheme;Lcom/materialkolor/dynamiccolor/DynamicColor;)Lcom/materialkolor/hct/Hct;
+	public abstract fun getNeutralPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public abstract fun getNeutralVariantPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public abstract fun getPrimaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public abstract fun getSecondaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public abstract fun getTertiaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public abstract fun getTone (Lcom/materialkolor/scheme/DynamicScheme;Lcom/materialkolor/dynamiccolor/DynamicColor;)D
+	public abstract fun highestSurface (Lcom/materialkolor/scheme/DynamicScheme;)Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun inverseOnSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun inversePrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun inverseSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun neutralPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun neutralVariantPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onBackground ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onError ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onErrorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onPrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onPrimaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onPrimaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onPrimaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onSecondary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onSecondaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onSecondaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onSecondaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onSurfaceVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onTertiary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onTertiaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onTertiaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onTertiaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun outline ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun outlineVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun primary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun primaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun primaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun primaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun primaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun primaryPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun scrim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun secondary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun secondaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun secondaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun secondaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun secondaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun secondaryPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun shadow ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceBright ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceContainerHigh ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceContainerHighest ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceContainerLow ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceContainerLowest ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceTint ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun tertiary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun tertiaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun tertiaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun tertiaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun tertiaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun tertiaryPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun textHintInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun textPrimaryInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun textPrimaryInverseDisableOnly ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun textSecondaryAndTertiaryInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun textSecondaryAndTertiaryInverseDisabled ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+}
+
+public final class com/materialkolor/dynamiccolor/ColorSpec$SpecVersion : java/lang/Enum {
+	public static final field Companion Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion$Companion;
+	public static final field SPEC_2021 Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
+	public static final field SPEC_2025 Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
+	public static fun values ()[Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
+}
+
+public final class com/materialkolor/dynamiccolor/ColorSpec$SpecVersion$Companion {
+	public final fun getDefault ()Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
+}
+
+public class com/materialkolor/dynamiccolor/ColorSpec2021 : com/materialkolor/dynamiccolor/ColorSpec {
+	public static final field Companion Lcom/materialkolor/dynamiccolor/ColorSpec2021$Companion;
+	public fun <init> ()V
+	public fun background ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun controlActivated ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun controlHighlight ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun controlNormal ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun error ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun errorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun errorDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun errorPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun getErrorPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getHct (Lcom/materialkolor/scheme/DynamicScheme;Lcom/materialkolor/dynamiccolor/DynamicColor;)Lcom/materialkolor/hct/Hct;
+	public fun getNeutralPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getNeutralVariantPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getPrimaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getSecondaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getTertiaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getTone (Lcom/materialkolor/scheme/DynamicScheme;Lcom/materialkolor/dynamiccolor/DynamicColor;)D
+	public fun highestSurface (Lcom/materialkolor/scheme/DynamicScheme;)Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun inverseOnSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun inversePrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun inverseSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun neutralPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun neutralVariantPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onBackground ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onError ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onErrorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSurfaceVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun outline ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun outlineVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun scrim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun shadow ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceBright ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerHigh ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerHighest ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerLow ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerLowest ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceTint ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun textHintInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun textPrimaryInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun textPrimaryInverseDisableOnly ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun textSecondaryAndTertiaryInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun textSecondaryAndTertiaryInverseDisabled ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+}
+
+public final class com/materialkolor/dynamiccolor/ColorSpec2021$Companion {
+}
+
+public final class com/materialkolor/dynamiccolor/ColorSpec2025 : com/materialkolor/dynamiccolor/ColorSpec2021 {
+	public static final field Companion Lcom/materialkolor/dynamiccolor/ColorSpec2025$Companion;
+	public fun <init> ()V
+	public fun background ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun controlActivated ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun controlNormal ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun error ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun errorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun errorDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun getErrorPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getHct (Lcom/materialkolor/scheme/DynamicScheme;Lcom/materialkolor/dynamiccolor/DynamicColor;)Lcom/materialkolor/hct/Hct;
+	public fun getNeutralPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getNeutralVariantPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getPrimaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getSecondaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getTertiaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getTone (Lcom/materialkolor/scheme/DynamicScheme;Lcom/materialkolor/dynamiccolor/DynamicColor;)D
+	public fun inverseOnSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun inversePrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun inverseSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onBackground ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onError ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onErrorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSurfaceVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun outline ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun outlineVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceBright ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerHigh ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerHighest ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerLow ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerLowest ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceTint ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun textPrimaryInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+}
+
+public final class com/materialkolor/dynamiccolor/ColorSpec2025$Companion {
+}
+
+public final class com/materialkolor/dynamiccolor/ColorSpecs {
+	public static final field INSTANCE Lcom/materialkolor/dynamiccolor/ColorSpecs;
+	public final fun get ()Lcom/materialkolor/dynamiccolor/ColorSpec;
+	public final fun get (Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;)Lcom/materialkolor/dynamiccolor/ColorSpec;
+	public final fun get (Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Z)Lcom/materialkolor/dynamiccolor/ColorSpec;
+	public static synthetic fun get$default (Lcom/materialkolor/dynamiccolor/ColorSpecs;Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;ILjava/lang/Object;)Lcom/materialkolor/dynamiccolor/ColorSpec;
+}
+
 public final class com/materialkolor/dynamiccolor/ContrastCurve {
 	public fun <init> (DDDD)V
 	public fun equals (Ljava/lang/Object;)Z
@@ -36,12 +290,13 @@ public final class com/materialkolor/dynamiccolor/ContrastCurve {
 
 public final class com/materialkolor/dynamiccolor/DynamicColor {
 	public static final field Companion Lcom/materialkolor/dynamiccolor/DynamicColor$Companion;
-	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/materialkolor/dynamiccolor/ContrastCurve;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/materialkolor/dynamiccolor/ContrastCurve;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getArgb (Lcom/materialkolor/scheme/DynamicScheme;)I
 	public final fun getBackground ()Lkotlin/jvm/functions/Function1;
-	public final fun getContrastCurve ()Lcom/materialkolor/dynamiccolor/ContrastCurve;
+	public final fun getChromaMultiplier ()Lkotlin/jvm/functions/Function1;
+	public final fun getContrastCurve ()Lkotlin/jvm/functions/Function1;
 	public final fun getHct (Lcom/materialkolor/scheme/DynamicScheme;)Lcom/materialkolor/hct/Hct;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOpacity ()Lkotlin/jvm/functions/Function1;
@@ -52,6 +307,7 @@ public final class com/materialkolor/dynamiccolor/DynamicColor {
 	public final fun getToneDeltaPair ()Lkotlin/jvm/functions/Function1;
 	public fun hashCode ()I
 	public final fun isBackground ()Z
+	public final fun toBuilder ()Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -61,8 +317,26 @@ public final class com/materialkolor/dynamiccolor/DynamicColor$Companion {
 	public final fun fromArgb (Ljava/lang/String;I)Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun fromPalette (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun fromPalette (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Z)Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public final fun getInitialToneFromBackground (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+	public static synthetic fun getInitialToneFromBackground$default (Lcom/materialkolor/dynamiccolor/DynamicColor$Companion;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/jvm/functions/Function1;
 	public final fun toneAllowsLightForeground (D)Z
 	public final fun tonePrefersLightForeground (D)Z
+}
+
+public final class com/materialkolor/dynamiccolor/DynamicColor$Companion$Builder {
+	public fun <init> ()V
+	public final fun build ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public final fun extendSpecVersion (Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/dynamiccolor/DynamicColor;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setBackground (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setChromaMultiplier (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setContrastCurve (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setIsBackground (Z)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setName (Ljava/lang/String;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setOpacity (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setPalette (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setSecondBackground (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setTone (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setToneDeltaPair (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
 }
 
 public final class com/materialkolor/dynamiccolor/MaterialDynamicColors {
@@ -144,9 +418,11 @@ public final class com/materialkolor/dynamiccolor/MaterialDynamicColors$Companio
 }
 
 public final class com/materialkolor/dynamiccolor/ToneDeltaPair {
-	public fun <init> (Lcom/materialkolor/dynamiccolor/DynamicColor;Lcom/materialkolor/dynamiccolor/DynamicColor;DLcom/materialkolor/dynamiccolor/TonePolarity;Z)V
+	public fun <init> (Lcom/materialkolor/dynamiccolor/DynamicColor;Lcom/materialkolor/dynamiccolor/DynamicColor;DLcom/materialkolor/dynamiccolor/TonePolarity;ZLcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;)V
+	public synthetic fun <init> (Lcom/materialkolor/dynamiccolor/DynamicColor;Lcom/materialkolor/dynamiccolor/DynamicColor;DLcom/materialkolor/dynamiccolor/TonePolarity;ZLcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDelta ()D
+	public final fun getDeltaConstraint ()Lcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;
 	public final fun getPolarity ()Lcom/materialkolor/dynamiccolor/TonePolarity;
 	public final fun getRoleA ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun getRoleB ()Lcom/materialkolor/dynamiccolor/DynamicColor;
@@ -155,11 +431,22 @@ public final class com/materialkolor/dynamiccolor/ToneDeltaPair {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint : java/lang/Enum {
+	public static final field EXACT Lcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;
+	public static final field FARTHER Lcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;
+	public static final field NEARER Lcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;
+	public static fun values ()[Lcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;
+}
+
 public final class com/materialkolor/dynamiccolor/TonePolarity : java/lang/Enum {
 	public static final field DARKER Lcom/materialkolor/dynamiccolor/TonePolarity;
 	public static final field FARTHER Lcom/materialkolor/dynamiccolor/TonePolarity;
 	public static final field LIGHTER Lcom/materialkolor/dynamiccolor/TonePolarity;
 	public static final field NEARER Lcom/materialkolor/dynamiccolor/TonePolarity;
+	public static final field RELATIVE_DARKER Lcom/materialkolor/dynamiccolor/TonePolarity;
+	public static final field RELATIVE_LIGHTER Lcom/materialkolor/dynamiccolor/TonePolarity;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/materialkolor/dynamiccolor/TonePolarity;
 	public static fun values ()[Lcom/materialkolor/dynamiccolor/TonePolarity;
@@ -201,6 +488,9 @@ public final class com/materialkolor/hct/Hct {
 	public final fun getTone ()D
 	public fun hashCode ()I
 	public final fun inViewingConditions (Lcom/materialkolor/hct/ViewingConditions;)Lcom/materialkolor/hct/Hct;
+	public final fun isBlue ()Z
+	public final fun isCyan ()Z
+	public final fun isYellow ()Z
 	public final fun toInt ()I
 	public fun toString ()Ljava/lang/String;
 	public final fun withChroma (D)Lcom/materialkolor/hct/Hct;
@@ -282,23 +572,106 @@ public final class com/materialkolor/quantize/QuantizerCelebi {
 
 public class com/materialkolor/scheme/DynamicScheme {
 	public static final field Companion Lcom/materialkolor/scheme/DynamicScheme$Companion;
-	public fun <init> (Lcom/materialkolor/hct/Hct;Lcom/materialkolor/scheme/Variant;ZDLcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;)V
-	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;Lcom/materialkolor/scheme/Variant;ZDLcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;Lcom/materialkolor/scheme/Variant;ZDLcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/palettes/TonalPalette;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;Lcom/materialkolor/scheme/Variant;ZDLcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/palettes/TonalPalette;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;Lcom/materialkolor/scheme/Variant;ZDLcom/materialkolor/scheme/DynamicScheme$Platform;Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;Lcom/materialkolor/scheme/Variant;ZDLcom/materialkolor/scheme/DynamicScheme$Platform;Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getArgb (Lcom/materialkolor/dynamiccolor/DynamicColor;)I
+	public final fun getBackground ()I
 	public final fun getContrastLevel ()D
+	public final fun getControlActivated ()I
+	public final fun getControlHighlight ()I
+	public final fun getControlNormal ()I
+	public final fun getError ()I
+	public final fun getErrorContainer ()I
 	public final fun getErrorPalette ()Lcom/materialkolor/palettes/TonalPalette;
+	public final fun getHct (Lcom/materialkolor/dynamiccolor/DynamicColor;)Lcom/materialkolor/hct/Hct;
+	public final fun getInverseOnSurface ()I
+	public final fun getInversePrimary ()I
+	public final fun getInverseSurface ()I
 	public final fun getNeutralPalette ()Lcom/materialkolor/palettes/TonalPalette;
+	public final fun getNeutralPaletteKeyColor ()I
 	public final fun getNeutralVariantPalette ()Lcom/materialkolor/palettes/TonalPalette;
+	public final fun getNeutralVariantPaletteKeyColor ()I
+	public final fun getOnBackground ()I
+	public final fun getOnError ()I
+	public final fun getOnErrorContainer ()I
+	public final fun getOnPrimary ()I
+	public final fun getOnPrimaryContainer ()I
+	public final fun getOnPrimaryFixed ()I
+	public final fun getOnPrimaryFixedVariant ()I
+	public final fun getOnSecondary ()I
+	public final fun getOnSecondaryContainer ()I
+	public final fun getOnSecondaryFixed ()I
+	public final fun getOnSecondaryFixedVariant ()I
+	public final fun getOnSurface ()I
+	public final fun getOnSurfaceVariant ()I
+	public final fun getOnTertiary ()I
+	public final fun getOnTertiaryContainer ()I
+	public final fun getOnTertiaryFixed ()I
+	public final fun getOnTertiaryFixedVariant ()I
+	public final fun getOutline ()I
+	public final fun getOutlineVariant ()I
+	public final fun getPlatform ()Lcom/materialkolor/scheme/DynamicScheme$Platform;
+	public final fun getPrimary ()I
+	public final fun getPrimaryContainer ()I
+	public final fun getPrimaryFixed ()I
+	public final fun getPrimaryFixedDim ()I
 	public final fun getPrimaryPalette ()Lcom/materialkolor/palettes/TonalPalette;
+	public final fun getPrimaryPaletteKeyColor ()I
+	public final fun getScrim ()I
+	public final fun getSecondary ()I
+	public final fun getSecondaryContainer ()I
+	public final fun getSecondaryFixed ()I
+	public final fun getSecondaryFixedDim ()I
 	public final fun getSecondaryPalette ()Lcom/materialkolor/palettes/TonalPalette;
+	public final fun getSecondaryPaletteKeyColor ()I
+	public final fun getShadow ()I
 	public final fun getSourceColorArgb ()I
 	public final fun getSourceColorHct ()Lcom/materialkolor/hct/Hct;
+	public final fun getSpecVersion ()Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
+	public final fun getSurface ()I
+	public final fun getSurfaceBright ()I
+	public final fun getSurfaceContainer ()I
+	public final fun getSurfaceContainerHigh ()I
+	public final fun getSurfaceContainerHighest ()I
+	public final fun getSurfaceContainerLow ()I
+	public final fun getSurfaceContainerLowest ()I
+	public final fun getSurfaceDim ()I
+	public final fun getSurfaceTint ()I
+	public final fun getSurfaceVariant ()I
+	public final fun getTertiary ()I
+	public final fun getTertiaryContainer ()I
+	public final fun getTertiaryFixed ()I
+	public final fun getTertiaryFixedDim ()I
 	public final fun getTertiaryPalette ()Lcom/materialkolor/palettes/TonalPalette;
+	public final fun getTertiaryPaletteKeyColor ()I
+	public final fun getTextHintInverse ()I
+	public final fun getTextPrimaryInverse ()I
+	public final fun getTextPrimaryInverseDisableOnly ()I
+	public final fun getTextSecondaryAndTertiaryInverse ()I
+	public final fun getTextSecondaryAndTertiaryInverseDisabled ()I
 	public final fun getVariant ()Lcom/materialkolor/scheme/Variant;
 	public final fun isDark ()Z
 }
 
 public final class com/materialkolor/scheme/DynamicScheme$Companion {
+	public final fun from (Lcom/materialkolor/scheme/DynamicScheme;Z)Lcom/materialkolor/scheme/DynamicScheme;
+	public final fun getPiecewiseValue (Lcom/materialkolor/hct/Hct;[D[D)D
 	public final fun getRotatedHue (Lcom/materialkolor/hct/Hct;[D[D)D
+}
+
+public final class com/materialkolor/scheme/DynamicScheme$Platform : java/lang/Enum {
+	public static final field Companion Lcom/materialkolor/scheme/DynamicScheme$Platform$Companion;
+	public static final field PHONE Lcom/materialkolor/scheme/DynamicScheme$Platform;
+	public static final field WATCH Lcom/materialkolor/scheme/DynamicScheme$Platform;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/materialkolor/scheme/DynamicScheme$Platform;
+	public static fun values ()[Lcom/materialkolor/scheme/DynamicScheme$Platform;
+}
+
+public final class com/materialkolor/scheme/DynamicScheme$Platform$Companion {
+	public final fun getDefault ()Lcom/materialkolor/scheme/DynamicScheme$Platform;
 }
 
 public final class com/materialkolor/scheme/SchemeContent : com/materialkolor/scheme/DynamicScheme {
@@ -306,7 +679,8 @@ public final class com/materialkolor/scheme/SchemeContent : com/materialkolor/sc
 }
 
 public final class com/materialkolor/scheme/SchemeExpressive : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeFidelity : com/materialkolor/scheme/DynamicScheme {
@@ -322,7 +696,8 @@ public final class com/materialkolor/scheme/SchemeMonochrome : com/materialkolor
 }
 
 public final class com/materialkolor/scheme/SchemeNeutral : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeRainbow : com/materialkolor/scheme/DynamicScheme {
@@ -330,11 +705,13 @@ public final class com/materialkolor/scheme/SchemeRainbow : com/materialkolor/sc
 }
 
 public final class com/materialkolor/scheme/SchemeTonalSpot : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeVibrant : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/Variant : java/lang/Enum {

--- a/material-color-utilities/api/jvm/material-color-utilities.api
+++ b/material-color-utilities/api/jvm/material-color-utilities.api
@@ -272,14 +272,6 @@ public final class com/materialkolor/dynamiccolor/ColorSpec2025 : com/materialko
 public final class com/materialkolor/dynamiccolor/ColorSpec2025$Companion {
 }
 
-public final class com/materialkolor/dynamiccolor/ColorSpecs {
-	public static final field INSTANCE Lcom/materialkolor/dynamiccolor/ColorSpecs;
-	public final fun get ()Lcom/materialkolor/dynamiccolor/ColorSpec;
-	public final fun get (Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;)Lcom/materialkolor/dynamiccolor/ColorSpec;
-	public final fun get (Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Z)Lcom/materialkolor/dynamiccolor/ColorSpec;
-	public static synthetic fun get$default (Lcom/materialkolor/dynamiccolor/ColorSpecs;Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;ILjava/lang/Object;)Lcom/materialkolor/dynamiccolor/ColorSpec;
-}
-
 public final class com/materialkolor/dynamiccolor/ContrastCurve {
 	public fun <init> (DDDD)V
 	public fun equals (Ljava/lang/Object;)Z

--- a/material-color-utilities/api/jvm/material-color-utilities.api
+++ b/material-color-utilities/api/jvm/material-color-utilities.api
@@ -342,18 +342,14 @@ public final class com/materialkolor/dynamiccolor/DynamicColor$Companion$Builder
 public final class com/materialkolor/dynamiccolor/MaterialDynamicColors {
 	public static final field Companion Lcom/materialkolor/dynamiccolor/MaterialDynamicColors$Companion;
 	public fun <init> ()V
-	public fun <init> (Z)V
-	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun allDynamicColors ()Ljava/util/List;
 	public final fun background ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun controlActivated ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun controlHighlight ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun controlNormal ()Lcom/materialkolor/dynamiccolor/DynamicColor;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun error ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun errorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun errorPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
-	public fun hashCode ()I
 	public final fun highestSurface (Lcom/materialkolor/scheme/DynamicScheme;)Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun inverseOnSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun inversePrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
@@ -411,7 +407,6 @@ public final class com/materialkolor/dynamiccolor/MaterialDynamicColors {
 	public final fun textPrimaryInverseDisableOnly ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun textSecondaryAndTertiaryInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun textSecondaryAndTertiaryInverseDisabled ()Lcom/materialkolor/dynamiccolor/DynamicColor;
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/materialkolor/dynamiccolor/MaterialDynamicColors$Companion {

--- a/material-color-utilities/api/jvm/material-color-utilities.api
+++ b/material-color-utilities/api/jvm/material-color-utilities.api
@@ -26,6 +26,260 @@ public final class com/materialkolor/dislike/DislikeAnalyzer {
 	public final fun isDisliked (Lcom/materialkolor/hct/Hct;)Z
 }
 
+public abstract interface class com/materialkolor/dynamiccolor/ColorSpec {
+	public abstract fun background ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun controlActivated ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun controlHighlight ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun controlNormal ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun error ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun errorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun errorDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun errorPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun getErrorPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public abstract fun getHct (Lcom/materialkolor/scheme/DynamicScheme;Lcom/materialkolor/dynamiccolor/DynamicColor;)Lcom/materialkolor/hct/Hct;
+	public abstract fun getNeutralPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public abstract fun getNeutralVariantPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public abstract fun getPrimaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public abstract fun getSecondaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public abstract fun getTertiaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public abstract fun getTone (Lcom/materialkolor/scheme/DynamicScheme;Lcom/materialkolor/dynamiccolor/DynamicColor;)D
+	public abstract fun highestSurface (Lcom/materialkolor/scheme/DynamicScheme;)Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun inverseOnSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun inversePrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun inverseSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun neutralPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun neutralVariantPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onBackground ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onError ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onErrorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onPrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onPrimaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onPrimaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onPrimaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onSecondary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onSecondaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onSecondaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onSecondaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onSurfaceVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onTertiary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onTertiaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onTertiaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun onTertiaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun outline ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun outlineVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun primary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun primaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun primaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun primaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun primaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun primaryPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun scrim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun secondary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun secondaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun secondaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun secondaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun secondaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun secondaryPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun shadow ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceBright ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceContainerHigh ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceContainerHighest ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceContainerLow ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceContainerLowest ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceTint ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun surfaceVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun tertiary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun tertiaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun tertiaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun tertiaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun tertiaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun tertiaryPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun textHintInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun textPrimaryInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun textPrimaryInverseDisableOnly ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun textSecondaryAndTertiaryInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public abstract fun textSecondaryAndTertiaryInverseDisabled ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+}
+
+public final class com/materialkolor/dynamiccolor/ColorSpec$SpecVersion : java/lang/Enum {
+	public static final field Companion Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion$Companion;
+	public static final field SPEC_2021 Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
+	public static final field SPEC_2025 Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
+	public static fun values ()[Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
+}
+
+public final class com/materialkolor/dynamiccolor/ColorSpec$SpecVersion$Companion {
+	public final fun getDefault ()Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
+}
+
+public class com/materialkolor/dynamiccolor/ColorSpec2021 : com/materialkolor/dynamiccolor/ColorSpec {
+	public static final field Companion Lcom/materialkolor/dynamiccolor/ColorSpec2021$Companion;
+	public fun <init> ()V
+	public fun background ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun controlActivated ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun controlHighlight ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun controlNormal ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun error ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun errorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun errorDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun errorPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun getErrorPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getHct (Lcom/materialkolor/scheme/DynamicScheme;Lcom/materialkolor/dynamiccolor/DynamicColor;)Lcom/materialkolor/hct/Hct;
+	public fun getNeutralPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getNeutralVariantPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getPrimaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getSecondaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getTertiaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getTone (Lcom/materialkolor/scheme/DynamicScheme;Lcom/materialkolor/dynamiccolor/DynamicColor;)D
+	public fun highestSurface (Lcom/materialkolor/scheme/DynamicScheme;)Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun inverseOnSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun inversePrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun inverseSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun neutralPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun neutralVariantPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onBackground ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onError ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onErrorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSurfaceVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun outline ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun outlineVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun scrim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun shadow ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceBright ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerHigh ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerHighest ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerLow ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerLowest ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceTint ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryPaletteKeyColor ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun textHintInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun textPrimaryInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun textPrimaryInverseDisableOnly ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun textSecondaryAndTertiaryInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun textSecondaryAndTertiaryInverseDisabled ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+}
+
+public final class com/materialkolor/dynamiccolor/ColorSpec2021$Companion {
+}
+
+public final class com/materialkolor/dynamiccolor/ColorSpec2025 : com/materialkolor/dynamiccolor/ColorSpec2021 {
+	public static final field Companion Lcom/materialkolor/dynamiccolor/ColorSpec2025$Companion;
+	public fun <init> ()V
+	public fun background ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun controlActivated ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun controlNormal ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun error ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun errorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun errorDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun getErrorPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getHct (Lcom/materialkolor/scheme/DynamicScheme;Lcom/materialkolor/dynamiccolor/DynamicColor;)Lcom/materialkolor/hct/Hct;
+	public fun getNeutralPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getNeutralVariantPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getPrimaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getSecondaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getTertiaryPalette (Lcom/materialkolor/scheme/Variant;Lcom/materialkolor/hct/Hct;ZLcom/materialkolor/scheme/DynamicScheme$Platform;D)Lcom/materialkolor/palettes/TonalPalette;
+	public fun getTone (Lcom/materialkolor/scheme/DynamicScheme;Lcom/materialkolor/dynamiccolor/DynamicColor;)D
+	public fun inverseOnSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun inversePrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun inverseSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onBackground ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onError ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onErrorContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onPrimaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSecondaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSurface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onSurfaceVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun onTertiaryFixedVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun outline ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun outlineVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun primaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun secondaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surface ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceBright ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerHigh ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerHighest ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerLow ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceContainerLowest ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceTint ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun surfaceVariant ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiary ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryContainer ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryFixed ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun tertiaryFixedDim ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public fun textPrimaryInverse ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+}
+
+public final class com/materialkolor/dynamiccolor/ColorSpec2025$Companion {
+}
+
+public final class com/materialkolor/dynamiccolor/ColorSpecs {
+	public static final field INSTANCE Lcom/materialkolor/dynamiccolor/ColorSpecs;
+	public final fun get ()Lcom/materialkolor/dynamiccolor/ColorSpec;
+	public final fun get (Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;)Lcom/materialkolor/dynamiccolor/ColorSpec;
+	public final fun get (Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Z)Lcom/materialkolor/dynamiccolor/ColorSpec;
+	public static synthetic fun get$default (Lcom/materialkolor/dynamiccolor/ColorSpecs;Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;ILjava/lang/Object;)Lcom/materialkolor/dynamiccolor/ColorSpec;
+}
+
 public final class com/materialkolor/dynamiccolor/ContrastCurve {
 	public fun <init> (DDDD)V
 	public fun equals (Ljava/lang/Object;)Z
@@ -36,12 +290,13 @@ public final class com/materialkolor/dynamiccolor/ContrastCurve {
 
 public final class com/materialkolor/dynamiccolor/DynamicColor {
 	public static final field Companion Lcom/materialkolor/dynamiccolor/DynamicColor$Companion;
-	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/materialkolor/dynamiccolor/ContrastCurve;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/materialkolor/dynamiccolor/ContrastCurve;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getArgb (Lcom/materialkolor/scheme/DynamicScheme;)I
 	public final fun getBackground ()Lkotlin/jvm/functions/Function1;
-	public final fun getContrastCurve ()Lcom/materialkolor/dynamiccolor/ContrastCurve;
+	public final fun getChromaMultiplier ()Lkotlin/jvm/functions/Function1;
+	public final fun getContrastCurve ()Lkotlin/jvm/functions/Function1;
 	public final fun getHct (Lcom/materialkolor/scheme/DynamicScheme;)Lcom/materialkolor/hct/Hct;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOpacity ()Lkotlin/jvm/functions/Function1;
@@ -52,6 +307,7 @@ public final class com/materialkolor/dynamiccolor/DynamicColor {
 	public final fun getToneDeltaPair ()Lkotlin/jvm/functions/Function1;
 	public fun hashCode ()I
 	public final fun isBackground ()Z
+	public final fun toBuilder ()Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -61,8 +317,26 @@ public final class com/materialkolor/dynamiccolor/DynamicColor$Companion {
 	public final fun fromArgb (Ljava/lang/String;I)Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun fromPalette (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun fromPalette (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Z)Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public final fun getInitialToneFromBackground (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+	public static synthetic fun getInitialToneFromBackground$default (Lcom/materialkolor/dynamiccolor/DynamicColor$Companion;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/jvm/functions/Function1;
 	public final fun toneAllowsLightForeground (D)Z
 	public final fun tonePrefersLightForeground (D)Z
+}
+
+public final class com/materialkolor/dynamiccolor/DynamicColor$Companion$Builder {
+	public fun <init> ()V
+	public final fun build ()Lcom/materialkolor/dynamiccolor/DynamicColor;
+	public final fun extendSpecVersion (Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/dynamiccolor/DynamicColor;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setBackground (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setChromaMultiplier (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setContrastCurve (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setIsBackground (Z)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setName (Ljava/lang/String;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setOpacity (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setPalette (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setSecondBackground (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setTone (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
+	public final fun setToneDeltaPair (Lkotlin/jvm/functions/Function1;)Lcom/materialkolor/dynamiccolor/DynamicColor$Companion$Builder;
 }
 
 public final class com/materialkolor/dynamiccolor/MaterialDynamicColors {
@@ -144,9 +418,11 @@ public final class com/materialkolor/dynamiccolor/MaterialDynamicColors$Companio
 }
 
 public final class com/materialkolor/dynamiccolor/ToneDeltaPair {
-	public fun <init> (Lcom/materialkolor/dynamiccolor/DynamicColor;Lcom/materialkolor/dynamiccolor/DynamicColor;DLcom/materialkolor/dynamiccolor/TonePolarity;Z)V
+	public fun <init> (Lcom/materialkolor/dynamiccolor/DynamicColor;Lcom/materialkolor/dynamiccolor/DynamicColor;DLcom/materialkolor/dynamiccolor/TonePolarity;ZLcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;)V
+	public synthetic fun <init> (Lcom/materialkolor/dynamiccolor/DynamicColor;Lcom/materialkolor/dynamiccolor/DynamicColor;DLcom/materialkolor/dynamiccolor/TonePolarity;ZLcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDelta ()D
+	public final fun getDeltaConstraint ()Lcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;
 	public final fun getPolarity ()Lcom/materialkolor/dynamiccolor/TonePolarity;
 	public final fun getRoleA ()Lcom/materialkolor/dynamiccolor/DynamicColor;
 	public final fun getRoleB ()Lcom/materialkolor/dynamiccolor/DynamicColor;
@@ -155,11 +431,22 @@ public final class com/materialkolor/dynamiccolor/ToneDeltaPair {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint : java/lang/Enum {
+	public static final field EXACT Lcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;
+	public static final field FARTHER Lcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;
+	public static final field NEARER Lcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;
+	public static fun values ()[Lcom/materialkolor/dynamiccolor/ToneDeltaPair$DeltaConstraint;
+}
+
 public final class com/materialkolor/dynamiccolor/TonePolarity : java/lang/Enum {
 	public static final field DARKER Lcom/materialkolor/dynamiccolor/TonePolarity;
 	public static final field FARTHER Lcom/materialkolor/dynamiccolor/TonePolarity;
 	public static final field LIGHTER Lcom/materialkolor/dynamiccolor/TonePolarity;
 	public static final field NEARER Lcom/materialkolor/dynamiccolor/TonePolarity;
+	public static final field RELATIVE_DARKER Lcom/materialkolor/dynamiccolor/TonePolarity;
+	public static final field RELATIVE_LIGHTER Lcom/materialkolor/dynamiccolor/TonePolarity;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/materialkolor/dynamiccolor/TonePolarity;
 	public static fun values ()[Lcom/materialkolor/dynamiccolor/TonePolarity;
@@ -201,6 +488,9 @@ public final class com/materialkolor/hct/Hct {
 	public final fun getTone ()D
 	public fun hashCode ()I
 	public final fun inViewingConditions (Lcom/materialkolor/hct/ViewingConditions;)Lcom/materialkolor/hct/Hct;
+	public final fun isBlue ()Z
+	public final fun isCyan ()Z
+	public final fun isYellow ()Z
 	public final fun toInt ()I
 	public fun toString ()Ljava/lang/String;
 	public final fun withChroma (D)Lcom/materialkolor/hct/Hct;
@@ -282,23 +572,106 @@ public final class com/materialkolor/quantize/QuantizerCelebi {
 
 public class com/materialkolor/scheme/DynamicScheme {
 	public static final field Companion Lcom/materialkolor/scheme/DynamicScheme$Companion;
-	public fun <init> (Lcom/materialkolor/hct/Hct;Lcom/materialkolor/scheme/Variant;ZDLcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;)V
-	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;Lcom/materialkolor/scheme/Variant;ZDLcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;Lcom/materialkolor/scheme/Variant;ZDLcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/palettes/TonalPalette;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;Lcom/materialkolor/scheme/Variant;ZDLcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/palettes/TonalPalette;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;Lcom/materialkolor/scheme/Variant;ZDLcom/materialkolor/scheme/DynamicScheme$Platform;Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;Lcom/materialkolor/scheme/Variant;ZDLcom/materialkolor/scheme/DynamicScheme$Platform;Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;Lcom/materialkolor/palettes/TonalPalette;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getArgb (Lcom/materialkolor/dynamiccolor/DynamicColor;)I
+	public final fun getBackground ()I
 	public final fun getContrastLevel ()D
+	public final fun getControlActivated ()I
+	public final fun getControlHighlight ()I
+	public final fun getControlNormal ()I
+	public final fun getError ()I
+	public final fun getErrorContainer ()I
 	public final fun getErrorPalette ()Lcom/materialkolor/palettes/TonalPalette;
+	public final fun getHct (Lcom/materialkolor/dynamiccolor/DynamicColor;)Lcom/materialkolor/hct/Hct;
+	public final fun getInverseOnSurface ()I
+	public final fun getInversePrimary ()I
+	public final fun getInverseSurface ()I
 	public final fun getNeutralPalette ()Lcom/materialkolor/palettes/TonalPalette;
+	public final fun getNeutralPaletteKeyColor ()I
 	public final fun getNeutralVariantPalette ()Lcom/materialkolor/palettes/TonalPalette;
+	public final fun getNeutralVariantPaletteKeyColor ()I
+	public final fun getOnBackground ()I
+	public final fun getOnError ()I
+	public final fun getOnErrorContainer ()I
+	public final fun getOnPrimary ()I
+	public final fun getOnPrimaryContainer ()I
+	public final fun getOnPrimaryFixed ()I
+	public final fun getOnPrimaryFixedVariant ()I
+	public final fun getOnSecondary ()I
+	public final fun getOnSecondaryContainer ()I
+	public final fun getOnSecondaryFixed ()I
+	public final fun getOnSecondaryFixedVariant ()I
+	public final fun getOnSurface ()I
+	public final fun getOnSurfaceVariant ()I
+	public final fun getOnTertiary ()I
+	public final fun getOnTertiaryContainer ()I
+	public final fun getOnTertiaryFixed ()I
+	public final fun getOnTertiaryFixedVariant ()I
+	public final fun getOutline ()I
+	public final fun getOutlineVariant ()I
+	public final fun getPlatform ()Lcom/materialkolor/scheme/DynamicScheme$Platform;
+	public final fun getPrimary ()I
+	public final fun getPrimaryContainer ()I
+	public final fun getPrimaryFixed ()I
+	public final fun getPrimaryFixedDim ()I
 	public final fun getPrimaryPalette ()Lcom/materialkolor/palettes/TonalPalette;
+	public final fun getPrimaryPaletteKeyColor ()I
+	public final fun getScrim ()I
+	public final fun getSecondary ()I
+	public final fun getSecondaryContainer ()I
+	public final fun getSecondaryFixed ()I
+	public final fun getSecondaryFixedDim ()I
 	public final fun getSecondaryPalette ()Lcom/materialkolor/palettes/TonalPalette;
+	public final fun getSecondaryPaletteKeyColor ()I
+	public final fun getShadow ()I
 	public final fun getSourceColorArgb ()I
 	public final fun getSourceColorHct ()Lcom/materialkolor/hct/Hct;
+	public final fun getSpecVersion ()Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
+	public final fun getSurface ()I
+	public final fun getSurfaceBright ()I
+	public final fun getSurfaceContainer ()I
+	public final fun getSurfaceContainerHigh ()I
+	public final fun getSurfaceContainerHighest ()I
+	public final fun getSurfaceContainerLow ()I
+	public final fun getSurfaceContainerLowest ()I
+	public final fun getSurfaceDim ()I
+	public final fun getSurfaceTint ()I
+	public final fun getSurfaceVariant ()I
+	public final fun getTertiary ()I
+	public final fun getTertiaryContainer ()I
+	public final fun getTertiaryFixed ()I
+	public final fun getTertiaryFixedDim ()I
 	public final fun getTertiaryPalette ()Lcom/materialkolor/palettes/TonalPalette;
+	public final fun getTertiaryPaletteKeyColor ()I
+	public final fun getTextHintInverse ()I
+	public final fun getTextPrimaryInverse ()I
+	public final fun getTextPrimaryInverseDisableOnly ()I
+	public final fun getTextSecondaryAndTertiaryInverse ()I
+	public final fun getTextSecondaryAndTertiaryInverseDisabled ()I
 	public final fun getVariant ()Lcom/materialkolor/scheme/Variant;
 	public final fun isDark ()Z
 }
 
 public final class com/materialkolor/scheme/DynamicScheme$Companion {
+	public final fun from (Lcom/materialkolor/scheme/DynamicScheme;Z)Lcom/materialkolor/scheme/DynamicScheme;
+	public final fun getPiecewiseValue (Lcom/materialkolor/hct/Hct;[D[D)D
 	public final fun getRotatedHue (Lcom/materialkolor/hct/Hct;[D[D)D
+}
+
+public final class com/materialkolor/scheme/DynamicScheme$Platform : java/lang/Enum {
+	public static final field Companion Lcom/materialkolor/scheme/DynamicScheme$Platform$Companion;
+	public static final field PHONE Lcom/materialkolor/scheme/DynamicScheme$Platform;
+	public static final field WATCH Lcom/materialkolor/scheme/DynamicScheme$Platform;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/materialkolor/scheme/DynamicScheme$Platform;
+	public static fun values ()[Lcom/materialkolor/scheme/DynamicScheme$Platform;
+}
+
+public final class com/materialkolor/scheme/DynamicScheme$Platform$Companion {
+	public final fun getDefault ()Lcom/materialkolor/scheme/DynamicScheme$Platform;
 }
 
 public final class com/materialkolor/scheme/SchemeContent : com/materialkolor/scheme/DynamicScheme {
@@ -306,7 +679,8 @@ public final class com/materialkolor/scheme/SchemeContent : com/materialkolor/sc
 }
 
 public final class com/materialkolor/scheme/SchemeExpressive : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeFidelity : com/materialkolor/scheme/DynamicScheme {
@@ -322,7 +696,8 @@ public final class com/materialkolor/scheme/SchemeMonochrome : com/materialkolor
 }
 
 public final class com/materialkolor/scheme/SchemeNeutral : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeRainbow : com/materialkolor/scheme/DynamicScheme {
@@ -330,11 +705,13 @@ public final class com/materialkolor/scheme/SchemeRainbow : com/materialkolor/sc
 }
 
 public final class com/materialkolor/scheme/SchemeTonalSpot : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeVibrant : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/Variant : java/lang/Enum {

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec.kt
@@ -1,0 +1,237 @@
+package com.materialkolor.dynamiccolor
+
+import com.materialkolor.hct.Hct
+import com.materialkolor.palettes.TonalPalette
+import com.materialkolor.scheme.DynamicScheme
+import com.materialkolor.scheme.Variant
+
+/**
+ * An interface defining all the necessary methods that could be different between specs.
+ */
+public interface ColorSpec {
+    /**
+     * All available spec versions.
+     */
+    public enum class SpecVersion {
+        SPEC_2021,
+        SPEC_2025;
+
+        public companion object {
+            public val Default: SpecVersion = SPEC_2021
+        }
+    }
+
+    // Main Palettes
+
+    public fun primaryPaletteKeyColor(): DynamicColor
+
+    public fun secondaryPaletteKeyColor(): DynamicColor
+
+    public fun tertiaryPaletteKeyColor(): DynamicColor
+
+    public fun neutralPaletteKeyColor(): DynamicColor
+
+    public fun neutralVariantPaletteKeyColor(): DynamicColor
+
+    public fun errorPaletteKeyColor(): DynamicColor
+
+    // Surfaces [S]
+
+    public fun background(): DynamicColor
+
+    public fun onBackground(): DynamicColor
+
+    public fun surface(): DynamicColor
+
+    public fun surfaceDim(): DynamicColor
+
+    public fun surfaceBright(): DynamicColor
+
+    public fun surfaceContainerLowest(): DynamicColor
+
+    public fun surfaceContainerLow(): DynamicColor
+
+    public fun surfaceContainer(): DynamicColor
+
+    public fun surfaceContainerHigh(): DynamicColor
+
+    public fun surfaceContainerHighest(): DynamicColor
+
+    public fun onSurface(): DynamicColor
+
+    public fun surfaceVariant(): DynamicColor
+
+    public fun onSurfaceVariant(): DynamicColor
+
+    public fun inverseSurface(): DynamicColor
+
+    public fun inverseOnSurface(): DynamicColor
+
+    public fun outline(): DynamicColor
+
+    public fun outlineVariant(): DynamicColor
+
+    public fun shadow(): DynamicColor
+
+    public fun scrim(): DynamicColor
+
+    public fun surfaceTint(): DynamicColor
+
+    // Primaries [P]
+
+    public fun primary(): DynamicColor
+
+    public fun primaryDim(): DynamicColor?
+
+    public fun onPrimary(): DynamicColor
+
+    public fun primaryContainer(): DynamicColor
+
+    public fun onPrimaryContainer(): DynamicColor
+
+    public fun inversePrimary(): DynamicColor
+
+    // Secondaries [Q]
+
+    public fun secondary(): DynamicColor
+
+    public fun secondaryDim(): DynamicColor?
+
+    public fun onSecondary(): DynamicColor
+
+    public fun secondaryContainer(): DynamicColor
+
+    public fun onSecondaryContainer(): DynamicColor
+
+    // Tertiaries [T]
+
+    public fun tertiary(): DynamicColor
+
+    public fun tertiaryDim(): DynamicColor?
+
+    public fun onTertiary(): DynamicColor
+
+    public fun tertiaryContainer(): DynamicColor
+
+    public fun onTertiaryContainer(): DynamicColor
+
+    // Errors [E]
+
+    public fun error(): DynamicColor
+
+    public fun errorDim(): DynamicColor?
+
+    public fun onError(): DynamicColor
+
+    public fun errorContainer(): DynamicColor
+
+    public fun onErrorContainer(): DynamicColor
+
+    // Primary Fixed Colors [PF]
+
+    public fun primaryFixed(): DynamicColor
+
+    public fun primaryFixedDim(): DynamicColor
+
+    public fun onPrimaryFixed(): DynamicColor
+
+    public fun onPrimaryFixedVariant(): DynamicColor
+
+    // Secondary Fixed Colors [QF]
+
+    public fun secondaryFixed(): DynamicColor
+
+    public fun secondaryFixedDim(): DynamicColor
+
+    public fun onSecondaryFixed(): DynamicColor
+
+    public fun onSecondaryFixedVariant(): DynamicColor
+
+    // Tertiary Fixed Colors [TF]
+
+    public fun tertiaryFixed(): DynamicColor
+
+    public fun tertiaryFixedDim(): DynamicColor
+
+    public fun onTertiaryFixed(): DynamicColor
+
+    public fun onTertiaryFixedVariant(): DynamicColor
+
+    // Android-only Colors
+
+    public fun controlActivated(): DynamicColor
+
+    public fun controlNormal(): DynamicColor
+
+    public fun controlHighlight(): DynamicColor
+
+    public fun textPrimaryInverse(): DynamicColor
+
+    public fun textSecondaryAndTertiaryInverse(): DynamicColor
+
+    public fun textPrimaryInverseDisableOnly(): DynamicColor
+
+    public fun textSecondaryAndTertiaryInverseDisabled(): DynamicColor
+
+    public fun textHintInverse(): DynamicColor
+
+    // Other
+
+    public fun highestSurface(s: DynamicScheme): DynamicColor
+
+    // Color value calculations
+
+    public fun getHct(scheme: DynamicScheme, color: DynamicColor): Hct
+
+    public fun getTone(scheme: DynamicScheme, color: DynamicColor): Double
+
+    // Scheme Palettes
+
+    public fun getPrimaryPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: DynamicScheme.Platform,
+        contrastLevel: Double
+    ): TonalPalette
+
+    public fun getSecondaryPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: DynamicScheme.Platform,
+        contrastLevel: Double
+    ): TonalPalette
+
+    public fun getTertiaryPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: DynamicScheme.Platform,
+        contrastLevel: Double
+    ): TonalPalette
+
+    public fun getNeutralPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: DynamicScheme.Platform,
+        contrastLevel: Double
+    ): TonalPalette
+
+    public fun getNeutralVariantPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: DynamicScheme.Platform,
+        contrastLevel: Double
+    ): TonalPalette
+
+    public fun getErrorPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: DynamicScheme.Platform,
+        contrastLevel: Double
+    ): TonalPalette?
+}

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec.kt
@@ -14,7 +14,8 @@ public interface ColorSpec {
      */
     public enum class SpecVersion {
         SPEC_2021,
-        SPEC_2025;
+        SPEC_2025,
+        ;
 
         public companion object {
             public val Default: SpecVersion = SPEC_2021
@@ -181,9 +182,15 @@ public interface ColorSpec {
 
     // Color value calculations
 
-    public fun getHct(scheme: DynamicScheme, color: DynamicColor): Hct
+    public fun getHct(
+        scheme: DynamicScheme,
+        color: DynamicColor,
+    ): Hct
 
-    public fun getTone(scheme: DynamicScheme, color: DynamicColor): Double
+    public fun getTone(
+        scheme: DynamicScheme,
+        color: DynamicColor,
+    ): Double
 
     // Scheme Palettes
 
@@ -192,7 +199,7 @@ public interface ColorSpec {
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: DynamicScheme.Platform,
-        contrastLevel: Double
+        contrastLevel: Double,
     ): TonalPalette
 
     public fun getSecondaryPalette(
@@ -200,7 +207,7 @@ public interface ColorSpec {
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: DynamicScheme.Platform,
-        contrastLevel: Double
+        contrastLevel: Double,
     ): TonalPalette
 
     public fun getTertiaryPalette(
@@ -208,7 +215,7 @@ public interface ColorSpec {
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: DynamicScheme.Platform,
-        contrastLevel: Double
+        contrastLevel: Double,
     ): TonalPalette
 
     public fun getNeutralPalette(
@@ -216,7 +223,7 @@ public interface ColorSpec {
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: DynamicScheme.Platform,
-        contrastLevel: Double
+        contrastLevel: Double,
     ): TonalPalette
 
     public fun getNeutralVariantPalette(
@@ -224,7 +231,7 @@ public interface ColorSpec {
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: DynamicScheme.Platform,
-        contrastLevel: Double
+        contrastLevel: Double,
     ): TonalPalette
 
     public fun getErrorPalette(
@@ -232,6 +239,6 @@ public interface ColorSpec {
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: DynamicScheme.Platform,
-        contrastLevel: Double
+        contrastLevel: Double,
     ): TonalPalette?
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2021.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2021.kt
@@ -1017,7 +1017,9 @@ public open class ColorSpec2021 : ColorSpec {
             var fTone: Double = farther.tone(scheme)
 
             // 1st round: solve to min, each
-            if (color.background != null && nearer.contrastCurve != null && farther.contrastCurve != null) {
+            if (color.background != null && nearer.contrastCurve != null &&
+                farther.contrastCurve != null
+            ) {
                 val bg: DynamicColor? = color.background(scheme)
                 val nContrastCurve: ContrastCurve? = nearer.contrastCurve(scheme)
                 val fContrastCurve: ContrastCurve? = farther.contrastCurve(scheme)
@@ -1257,7 +1259,9 @@ public open class ColorSpec2021 : ColorSpec {
         when (variant) {
             Variant.CONTENT -> TonalPalette.fromHct(
                 DislikeAnalyzer.fixIfDisliked(
-                    TemperatureCache(sourceColorHct).getAnalogousColors(count = 3, divisions = 6)[2],
+                    TemperatureCache(
+                        sourceColorHct,
+                    ).getAnalogousColors(count = 3, divisions = 6)[2],
                 ),
             )
             Variant.FIDELITY -> TonalPalette.fromHct(
@@ -1276,8 +1280,28 @@ public open class ColorSpec2021 : ColorSpec {
             Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
                 hue = DynamicScheme.getRotatedHue(
                     sourceColorHct = sourceColorHct,
-                    hueBreakpoints = doubleArrayOf(0.0, 21.0, 51.0, 121.0, 151.0, 191.0, 271.0, 321.0, 360.0),
-                    rotations = doubleArrayOf(120.0, 120.0, 20.0, 45.0, 20.0, 15.0, 20.0, 120.0, 120.0),
+                    hueBreakpoints = doubleArrayOf(
+                        0.0,
+                        21.0,
+                        51.0,
+                        121.0,
+                        151.0,
+                        191.0,
+                        271.0,
+                        321.0,
+                        360.0,
+                    ),
+                    rotations = doubleArrayOf(
+                        120.0,
+                        120.0,
+                        20.0,
+                        45.0,
+                        20.0,
+                        15.0,
+                        20.0,
+                        120.0,
+                        120.0,
+                    ),
                 ),
                 chroma = 32.0,
             )
@@ -1285,7 +1309,17 @@ public open class ColorSpec2021 : ColorSpec {
             Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
                 hue = DynamicScheme.getRotatedHue(
                     sourceColorHct = sourceColorHct,
-                    hueBreakpoints = doubleArrayOf(0.0, 41.0, 61.0, 101.0, 131.0, 181.0, 251.0, 301.0, 360.0),
+                    hueBreakpoints = doubleArrayOf(
+                        0.0,
+                        41.0,
+                        61.0,
+                        101.0,
+                        131.0,
+                        181.0,
+                        251.0,
+                        301.0,
+                        360.0,
+                    ),
                     rotations = doubleArrayOf(35.0, 30.0, 20.0, 25.0, 30.0, 35.0, 30.0, 25.0, 25.0),
                 ),
                 chroma = 32.0,
@@ -1365,7 +1399,8 @@ public open class ColorSpec2021 : ColorSpec {
         }
 
     public companion object {
-        private fun isMonochrome(scheme: DynamicScheme): Boolean = scheme.variant == Variant.MONOCHROME
+        private fun isMonochrome(scheme: DynamicScheme): Boolean =
+            scheme.variant == Variant.MONOCHROME
 
         private fun findDesiredChromaByTone(
             hue: Double,

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2021.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2021.kt
@@ -34,254 +34,306 @@ import kotlin.math.min
 public open class ColorSpec2021 : ColorSpec {
     // Main Palettes
 
-    override fun primaryPaletteKeyColor(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("primary_palette_key_color")
-        .setPalette { s -> s.primaryPalette }
-        .setTone { s -> s.primaryPalette.keyColor.tone }
-        .build()
+    override fun primaryPaletteKeyColor(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("primary_palette_key_color")
+            .setPalette { s -> s.primaryPalette }
+            .setTone { s -> s.primaryPalette.keyColor.tone }
+            .build()
 
-    override fun secondaryPaletteKeyColor(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("secondary_palette_key_color")
-        .setPalette { s -> s.secondaryPalette }
-        .setTone { s -> s.secondaryPalette.keyColor.tone }
-        .build()
+    override fun secondaryPaletteKeyColor(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("secondary_palette_key_color")
+            .setPalette { s -> s.secondaryPalette }
+            .setTone { s -> s.secondaryPalette.keyColor.tone }
+            .build()
 
-    override fun tertiaryPaletteKeyColor(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("tertiary_palette_key_color")
-        .setPalette({ s -> s.tertiaryPalette })
-        .setTone({ s -> s.tertiaryPalette.keyColor.tone })
-        .build()
+    override fun tertiaryPaletteKeyColor(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("tertiary_palette_key_color")
+            .setPalette { s -> s.tertiaryPalette }
+            .setTone { s -> s.tertiaryPalette.keyColor.tone }
+            .build()
 
-    override fun neutralPaletteKeyColor(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("neutral_palette_key_color")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone({ s -> s.neutralPalette.keyColor.tone })
-        .build()
+    override fun neutralPaletteKeyColor(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("neutral_palette_key_color")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> s.neutralPalette.keyColor.tone }
+            .build()
 
-    override fun neutralVariantPaletteKeyColor(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("neutral_variant_palette_key_color")
-        .setPalette({ s -> s.neutralVariantPalette })
-        .setTone({ s -> s.neutralVariantPalette.keyColor.tone })
-        .build()
+    override fun neutralVariantPaletteKeyColor(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("neutral_variant_palette_key_color")
+            .setPalette { s -> s.neutralVariantPalette }
+            .setTone { s -> s.neutralVariantPalette.keyColor.tone }
+            .build()
 
-    override fun errorPaletteKeyColor(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("error_palette_key_color")
-        .setPalette { s -> s.errorPalette }
-        .setTone { s -> s.errorPalette.keyColor.tone }
-        .build()
+    override fun errorPaletteKeyColor(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("error_palette_key_color")
+            .setPalette { s -> s.errorPalette }
+            .setTone { s -> s.errorPalette.keyColor.tone }
+            .build()
 
     // Surfaces [S]
 
-    override fun background(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("background")
-        .setPalette { s -> s.neutralPalette }
-        .setTone { s -> if (s.isDark) 6.0 else 98.0 }
-        .setIsBackground(true)
-        .build()
+    override fun background(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("background")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> if (s.isDark) 6.0 else 98.0 }
+            .setIsBackground(true)
+            .build()
 
-    override fun onBackground(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_background")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone({ s -> if (s.isDark) 90.0 else 10.0 })
-        .setBackground({ s -> background() })
-        .setContrastCurve({ s -> ContrastCurve(3.0, 3.0, 4.5, 7.0) })
-        .build()
+    override fun onBackground(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_background")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> if (s.isDark) 90.0 else 10.0 }
+            .setBackground { s -> background() }
+            .setContrastCurve { s -> ContrastCurve(3.0, 3.0, 4.5, 7.0) }
+            .build()
 
-    override fun surface(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("surface")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone({ s -> if (s.isDark) 6.0 else 98.0 })
-        .setIsBackground(true)
-        .build()
+    override fun surface(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("surface")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> if (s.isDark) 6.0 else 98.0 }
+            .setIsBackground(true)
+            .build()
 
-    override fun surfaceDim(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("surface_dim")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone(
-            { s ->
-                if (s.isDark) 6.0 else ContrastCurve(
-                    low = 87.0,
-                    normal = 87.0,
-                    medium = 80.0,
-                    high = 75.0,
-                ).get(s.contrastLevel)
-            },
-        )
-        .setIsBackground(true)
-        .build()
+    override fun surfaceDim(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("surface_dim")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s ->
+                if (s.isDark) {
+                    6.0
+                } else {
+                    ContrastCurve(
+                        low = 87.0,
+                        normal = 87.0,
+                        medium = 80.0,
+                        high = 75.0,
+                    ).get(s.contrastLevel)
+                }
+            }.setIsBackground(true)
+            .build()
 
-    override fun surfaceBright(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("surface_bright")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone(
-            { s ->
-                if (s.isDark) ContrastCurve(
-                    low = 24.0,
-                    normal = 24.0,
-                    medium = 29.0,
-                    high = 34.0,
-                ).get(s.contrastLevel) else 98.0
-            },
-        )
-        .setIsBackground(true)
-        .build()
+    override fun surfaceBright(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("surface_bright")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s ->
+                if (s.isDark) {
+                    ContrastCurve(
+                        low = 24.0,
+                        normal = 24.0,
+                        medium = 29.0,
+                        high = 34.0,
+                    ).get(s.contrastLevel)
+                } else {
+                    98.0
+                }
+            }.setIsBackground(true)
+            .build()
 
-    override fun surfaceContainerLowest(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("surface_container_lowest")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone(
-            { s ->
-                if (s.isDark) ContrastCurve(
-                    low = 4.0,
-                    normal = 4.0,
-                    medium = 2.0,
-                    high = 0.0,
-                ).get(s.contrastLevel)
-                else 100.0
-            },
-        )
-        .setIsBackground(true)
-        .build()
+    override fun surfaceContainerLowest(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("surface_container_lowest")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s ->
+                if (s.isDark) {
+                    ContrastCurve(
+                        low = 4.0,
+                        normal = 4.0,
+                        medium = 2.0,
+                        high = 0.0,
+                    ).get(s.contrastLevel)
+                } else {
+                    100.0
+                }
+            }.setIsBackground(true)
+            .build()
 
-    override fun surfaceContainerLow(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("surface_container_low")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone(
-            { s ->
-                if (s.isDark) ContrastCurve(10.0, 10.0, 11.0, 12.0).get(s.contrastLevel)
-                else ContrastCurve(96.0, 96.0, 96.0, 95.0).get(s.contrastLevel)
-            },
-        )
-        .setIsBackground(true)
-        .build()
+    override fun surfaceContainerLow(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("surface_container_low")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s ->
+                if (s.isDark) {
+                    ContrastCurve(10.0, 10.0, 11.0, 12.0).get(s.contrastLevel)
+                } else {
+                    ContrastCurve(96.0, 96.0, 96.0, 95.0).get(s.contrastLevel)
+                }
+            }.setIsBackground(true)
+            .build()
 
-    override fun surfaceContainer(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("surface_container")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone(
-            { s ->
-                if (s.isDark) ContrastCurve(12.0, 12.0, 16.0, 20.0).get(s.contrastLevel)
-                else ContrastCurve(94.0, 94.0, 92.0, 90.0).get(s.contrastLevel)
-            },
-        )
-        .setIsBackground(true)
-        .build()
+    override fun surfaceContainer(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("surface_container")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s ->
+                if (s.isDark) {
+                    ContrastCurve(12.0, 12.0, 16.0, 20.0).get(s.contrastLevel)
+                } else {
+                    ContrastCurve(94.0, 94.0, 92.0, 90.0).get(s.contrastLevel)
+                }
+            }.setIsBackground(true)
+            .build()
 
-    override fun surfaceContainerHigh(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("surface_container_high")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone(
-            { s ->
-                if (s.isDark) ContrastCurve(17.0, 17.0, 21.0, 25.0).get(s.contrastLevel)
-                else ContrastCurve(92.0, 92.0, 88.0, 85.0).get(s.contrastLevel)
-            },
-        )
-        .setIsBackground(true)
-        .build()
+    override fun surfaceContainerHigh(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("surface_container_high")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s ->
+                if (s.isDark) {
+                    ContrastCurve(17.0, 17.0, 21.0, 25.0).get(s.contrastLevel)
+                } else {
+                    ContrastCurve(92.0, 92.0, 88.0, 85.0).get(s.contrastLevel)
+                }
+            }.setIsBackground(true)
+            .build()
 
-    override fun surfaceContainerHighest(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("surface_container_highest")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone(
-            { s ->
-                if (s.isDark) ContrastCurve(22.0, 22.0, 26.0, 30.0).get(s.contrastLevel)
-                else ContrastCurve(90.0, 90.0, 84.0, 80.0).get(s.contrastLevel)
-            },
-        )
-        .setIsBackground(true)
-        .build()
+    override fun surfaceContainerHighest(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("surface_container_highest")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s ->
+                if (s.isDark) {
+                    ContrastCurve(22.0, 22.0, 26.0, 30.0).get(s.contrastLevel)
+                } else {
+                    ContrastCurve(90.0, 90.0, 84.0, 80.0).get(s.contrastLevel)
+                }
+            }.setIsBackground(true)
+            .build()
 
-    override fun onSurface(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_surface")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone({ s -> if (s.isDark) 90.0 else 10.0 })
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
-        .build()
+    override fun onSurface(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_surface")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> if (s.isDark) 90.0 else 10.0 }
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) }
+            .build()
 
-    override fun surfaceVariant(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("surface_variant")
-        .setPalette({ s -> s.neutralVariantPalette })
-        .setTone({ s -> if (s.isDark) 30.0 else 90.0 })
-        .setIsBackground(true)
-        .build()
+    override fun surfaceVariant(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("surface_variant")
+            .setPalette { s -> s.neutralVariantPalette }
+            .setTone { s -> if (s.isDark) 30.0 else 90.0 }
+            .setIsBackground(true)
+            .build()
 
-    override fun onSurfaceVariant(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_surface_variant")
-        .setPalette({ s -> s.neutralVariantPalette })
-        .setTone({ s -> if (s.isDark) 80.0 else 30.0 })
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
-        .build()
+    override fun onSurfaceVariant(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_surface_variant")
+            .setPalette { s -> s.neutralVariantPalette }
+            .setTone { s -> if (s.isDark) 80.0 else 30.0 }
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) }
+            .build()
 
-    override fun inverseSurface(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("inverse_surface")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone({ s -> if (s.isDark) 90.0 else 20.0 })
-        .setIsBackground(true)
-        .build()
+    override fun inverseSurface(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("inverse_surface")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> if (s.isDark) 90.0 else 20.0 }
+            .setIsBackground(true)
+            .build()
 
-    override fun inverseOnSurface(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("inverse_on_surface")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone({ s -> if (s.isDark) 20.0 else 95.0 })
-        .setBackground({ s -> inverseSurface() })
-        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
-        .build()
+    override fun inverseOnSurface(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("inverse_on_surface")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> if (s.isDark) 20.0 else 95.0 }
+            .setBackground { s -> inverseSurface() }
+            .setContrastCurve { s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) }
+            .build()
 
-    override fun outline(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("outline")
-        .setPalette({ s -> s.neutralVariantPalette })
-        .setTone({ s -> if (s.isDark) 60.0 else 50.0 })
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(1.5, 3.0, 4.5, 7.0) })
-        .build()
+    override fun outline(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("outline")
+            .setPalette { s -> s.neutralVariantPalette }
+            .setTone { s -> if (s.isDark) 60.0 else 50.0 }
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(1.5, 3.0, 4.5, 7.0) }
+            .build()
 
-    override fun outlineVariant(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("outline_variant")
-        .setPalette({ s -> s.neutralVariantPalette })
-        .setTone({ s -> if (s.isDark) 30.0 else 80.0 })
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
-        .build()
+    override fun outlineVariant(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("outline_variant")
+            .setPalette { s -> s.neutralVariantPalette }
+            .setTone { s -> if (s.isDark) 30.0 else 80.0 }
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) }
+            .build()
 
-    override fun shadow(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("shadow")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone({ s -> 0.0 })
-        .build()
+    override fun shadow(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("shadow")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> 0.0 }
+            .build()
 
-    override fun scrim(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("scrim")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone({ s -> 0.0 })
-        .build()
+    override fun scrim(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("scrim")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> 0.0 }
+            .build()
 
-    override fun surfaceTint(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("surface_tint")
-        .setPalette({ s -> s.primaryPalette })
-        .setTone({ s -> if (s.isDark) 80.0 else 40.0 })
-        .setIsBackground(true)
-        .build()
+    override fun surfaceTint(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("surface_tint")
+            .setPalette { s -> s.primaryPalette }
+            .setTone { s -> if (s.isDark) 80.0 else 40.0 }
+            .setIsBackground(true)
+            .build()
 
     // Primaries [P]
 
-    override fun primary(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("primary")
-        .setPalette({ s -> s.primaryPalette })
-        .setTone(
-            { s ->
+    override fun primary(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("primary")
+            .setPalette { s -> s.primaryPalette }
+            .setTone { s ->
                 if (isMonochrome(s)) {
                     return@setTone if (s.isDark) 100.0 else 0.0
                 }
                 if (s.isDark) 80.0 else 40.0
-            },
-        )
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) })
-        .setToneDeltaPair(
-            { s ->
+            }.setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) }
+            .setToneDeltaPair { s ->
                 @Suppress("DEPRECATION")
                 ToneDeltaPair(
                     roleA = primaryContainer(),
@@ -290,32 +342,30 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.NEARER,
                     stayTogether = false,
                 )
-            },
-        )
-        .build()
+            }.build()
 
     override fun primaryDim(): DynamicColor? = null
 
-    override fun onPrimary(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_primary")
-        .setPalette({ s -> s.primaryPalette })
-        .setTone(
-            { s ->
+    override fun onPrimary(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_primary")
+            .setPalette { s -> s.primaryPalette }
+            .setTone { s ->
                 if (isMonochrome(s)) {
                     return@setTone if (s.isDark) 10.0 else 90.0
                 }
                 if (s.isDark) 20.0 else 100.0
-            },
-        )
-        .setBackground({ s -> primary() })
-        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
-        .build()
+            }.setBackground { s -> primary() }
+            .setContrastCurve { s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) }
+            .build()
 
-    override fun primaryContainer(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("primary_container")
-        .setPalette({ s -> s.primaryPalette })
-        .setTone(
-            { s ->
+    override fun primaryContainer(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("primary_container")
+            .setPalette { s -> s.primaryPalette }
+            .setTone { s ->
                 if (isFidelity(s)) {
                     return@setTone s.sourceColorHct.tone
                 }
@@ -323,13 +373,10 @@ public open class ColorSpec2021 : ColorSpec {
                     return@setTone if (s.isDark) 85.0 else 25.0
                 }
                 if (s.isDark) 30.0 else 90.0
-            },
-        )
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
-        .setToneDeltaPair(
-            { s ->
+            }.setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) }
+            .setToneDeltaPair { s ->
                 @Suppress("DEPRECATION")
                 ToneDeltaPair(
                     roleA = primaryContainer(),
@@ -338,15 +385,14 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.NEARER,
                     stayTogether = false,
                 )
-            },
-        )
-        .build()
+            }.build()
 
-    override fun onPrimaryContainer(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_primary_container")
-        .setPalette({ s -> s.primaryPalette })
-        .setTone(
-            { s ->
+    override fun onPrimaryContainer(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_primary_container")
+            .setPalette { s -> s.primaryPalette }
+            .setTone { s ->
                 if (isFidelity(s)) {
                     return@setTone DynamicColor.foregroundTone(
                         bgTone = primaryContainer().tone(s),
@@ -357,31 +403,32 @@ public open class ColorSpec2021 : ColorSpec {
                     return@setTone if (s.isDark) 0.0 else 100.0
                 }
                 if (s.isDark) 90.0 else 30.0
-            },
-        )
-        .setBackground({ s -> primaryContainer() })
-        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
-        .build()
+            }.setBackground { s -> primaryContainer() }
+            .setContrastCurve { s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) }
+            .build()
 
-    override fun inversePrimary(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("inverse_primary")
-        .setPalette({ s -> s.primaryPalette })
-        .setTone({ s -> if (s.isDark) 40.0 else 80.0 })
-        .setBackground({ s -> inverseSurface() })
-        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) })
-        .build()
+    override fun inversePrimary(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("inverse_primary")
+            .setPalette { s -> s.primaryPalette }
+            .setTone { s -> if (s.isDark) 40.0 else 80.0 }
+            .setBackground { s -> inverseSurface() }
+            .setContrastCurve { s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) }
+            .build()
 
     // Secondaries [Q]
 
-    override fun secondary(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("secondary")
-        .setPalette({ s -> s.secondaryPalette })
-        .setTone({ s -> if (s.isDark) 80.0 else 40.0 })
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) })
-        .setToneDeltaPair(
-            { s ->
+    override fun secondary(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("secondary")
+            .setPalette { s -> s.secondaryPalette }
+            .setTone { s -> if (s.isDark) 80.0 else 40.0 }
+            .setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) }
+            .setToneDeltaPair { s ->
                 @Suppress("DEPRECATION")
                 ToneDeltaPair(
                     roleA = secondaryContainer(),
@@ -390,32 +437,30 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.NEARER,
                     stayTogether = false,
                 )
-            },
-        )
-        .build()
+            }.build()
 
     override fun secondaryDim(): DynamicColor? = null
 
-    override fun onSecondary(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_secondary")
-        .setPalette({ s -> s.secondaryPalette })
-        .setTone(
-            { s ->
+    override fun onSecondary(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_secondary")
+            .setPalette { s -> s.secondaryPalette }
+            .setTone { s ->
                 if (isMonochrome(s)) {
                     return@setTone if (s.isDark) 10.0 else 100.0
                 }
                 if (s.isDark) 20.0 else 100.0
-            },
-        )
-        .setBackground({ s -> secondary() })
-        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
-        .build()
+            }.setBackground { s -> secondary() }
+            .setContrastCurve { s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) }
+            .build()
 
-    override fun secondaryContainer(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("secondary_container")
-        .setPalette({ s -> s.secondaryPalette })
-        .setTone(
-            { s ->
+    override fun secondaryContainer(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("secondary_container")
+            .setPalette { s -> s.secondaryPalette }
+            .setTone { s ->
                 val initialTone = if (s.isDark) 30.0 else 90.0
                 if (isMonochrome(s)) {
                     return@setTone if (s.isDark) 30.0 else 85.0
@@ -429,13 +474,10 @@ public open class ColorSpec2021 : ColorSpec {
                     tone = initialTone,
                     byDecreasingTone = !s.isDark,
                 )
-            },
-        )
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
-        .setToneDeltaPair(
-            { s ->
+            }.setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) }
+            .setToneDeltaPair { s ->
                 @Suppress("DEPRECATION")
                 ToneDeltaPair(
                     roleA = secondaryContainer(),
@@ -444,15 +486,14 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.NEARER,
                     stayTogether = false,
                 )
-            },
-        )
-        .build()
+            }.build()
 
-    override fun onSecondaryContainer(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_secondary_container")
-        .setPalette({ s -> s.secondaryPalette })
-        .setTone(
-            { s ->
+    override fun onSecondaryContainer(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_secondary_container")
+            .setPalette { s -> s.secondaryPalette }
+            .setTone { s ->
                 if (isMonochrome(s)) {
                     return@setTone if (s.isDark) 90.0 else 10.0
                 }
@@ -460,30 +501,26 @@ public open class ColorSpec2021 : ColorSpec {
                     return@setTone if (s.isDark) 90.0 else 30.0
                 }
                 DynamicColor.foregroundTone(secondaryContainer().tone(s), 4.5)
-            },
-        )
-        .setBackground({ s -> secondaryContainer() })
-        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
-        .build()
+            }.setBackground { s -> secondaryContainer() }
+            .setContrastCurve { s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) }
+            .build()
 
     // Tertiaries [T]
 
-    override fun tertiary(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("tertiary")
-        .setPalette({ s -> s.tertiaryPalette })
-        .setTone(
-            { s ->
+    override fun tertiary(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("tertiary")
+            .setPalette { s -> s.tertiaryPalette }
+            .setTone { s ->
                 if (isMonochrome(s)) {
                     return@setTone if (s.isDark) 90.0 else 25.0
                 }
                 if (s.isDark) 80.0 else 40.0
-            },
-        )
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) })
-        .setToneDeltaPair(
-            { s ->
+            }.setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) }
+            .setToneDeltaPair { s ->
                 @Suppress("DEPRECATION")
                 ToneDeltaPair(
                     roleA = tertiaryContainer(),
@@ -492,32 +529,30 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.NEARER,
                     stayTogether = false,
                 )
-            },
-        )
-        .build()
+            }.build()
 
     override fun tertiaryDim(): DynamicColor? = null
 
-    override fun onTertiary(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_tertiary")
-        .setPalette({ s -> s.tertiaryPalette })
-        .setTone(
-            { s ->
+    override fun onTertiary(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_tertiary")
+            .setPalette { s -> s.tertiaryPalette }
+            .setTone { s ->
                 if (isMonochrome(s)) {
                     return@setTone if (s.isDark) 10.0 else 90.0
                 }
                 if (s.isDark) 20.0 else 100.0
-            },
-        )
-        .setBackground({ s -> tertiary() })
-        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
-        .build()
+            }.setBackground { s -> tertiary() }
+            .setContrastCurve { s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) }
+            .build()
 
-    override fun tertiaryContainer(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("tertiary_container")
-        .setPalette({ s -> s.tertiaryPalette })
-        .setTone(
-            { s ->
+    override fun tertiaryContainer(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("tertiary_container")
+            .setPalette { s -> s.tertiaryPalette }
+            .setTone { s ->
                 if (isMonochrome(s)) {
                     return@setTone if (s.isDark) 60.0 else 49.0
                 }
@@ -526,13 +561,10 @@ public open class ColorSpec2021 : ColorSpec {
                 }
                 val proposedHct = s.tertiaryPalette.getHct(s.sourceColorHct.tone)
                 DislikeAnalyzer.fixIfDisliked(proposedHct).tone
-            },
-        )
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
-        .setToneDeltaPair(
-            { s ->
+            }.setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) }
+            .setToneDeltaPair { s ->
                 @Suppress("DEPRECATION")
                 ToneDeltaPair(
                     roleA = tertiaryContainer(),
@@ -541,15 +573,14 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.NEARER,
                     stayTogether = false,
                 )
-            },
-        )
-        .build()
+            }.build()
 
-    override fun onTertiaryContainer(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_tertiary_container")
-        .setPalette({ s -> s.tertiaryPalette })
-        .setTone(
-            { s ->
+    override fun onTertiaryContainer(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_tertiary_container")
+            .setPalette { s -> s.tertiaryPalette }
+            .setTone { s ->
                 if (isMonochrome(s)) {
                     return@setTone if (s.isDark) 0.0 else 100.0
                 }
@@ -557,23 +588,22 @@ public open class ColorSpec2021 : ColorSpec {
                     return@setTone if (s.isDark) 90.0 else 30.0
                 }
                 DynamicColor.foregroundTone(tertiaryContainer().tone(s), 4.5)
-            },
-        )
-        .setBackground({ s -> tertiaryContainer() })
-        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
-        .build()
+            }.setBackground { s -> tertiaryContainer() }
+            .setContrastCurve { s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) }
+            .build()
 
     // Errors [E]
 
-    override fun error(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("error")
-        .setPalette({ s -> s.errorPalette })
-        .setTone({ s -> if (s.isDark) 80.0 else 40.0 })
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) })
-        .setToneDeltaPair(
-            { s ->
+    override fun error(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("error")
+            .setPalette { s -> s.errorPalette }
+            .setTone { s -> if (s.isDark) 80.0 else 40.0 }
+            .setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) }
+            .setToneDeltaPair { s ->
                 @Suppress("DEPRECATION")
                 ToneDeltaPair(
                     roleA = errorContainer(),
@@ -582,29 +612,30 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.NEARER,
                     stayTogether = false,
                 )
-            },
-        )
-        .build()
+            }.build()
 
     override fun errorDim(): DynamicColor? = null
 
-    override fun onError(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_error")
-        .setPalette({ s -> s.errorPalette })
-        .setTone({ s -> if (s.isDark) 20.0 else 100.0 })
-        .setBackground({ s -> error() })
-        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
-        .build()
+    override fun onError(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_error")
+            .setPalette { s -> s.errorPalette }
+            .setTone { s -> if (s.isDark) 20.0 else 100.0 }
+            .setBackground { s -> error() }
+            .setContrastCurve { s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) }
+            .build()
 
-    override fun errorContainer(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("error_container")
-        .setPalette({ s -> s.errorPalette })
-        .setTone({ s -> if (s.isDark) 30.0 else 90.0 })
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
-        .setToneDeltaPair(
-            { s ->
+    override fun errorContainer(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("error_container")
+            .setPalette { s -> s.errorPalette }
+            .setTone { s -> if (s.isDark) 30.0 else 90.0 }
+            .setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) }
+            .setToneDeltaPair { s ->
                 @Suppress("DEPRECATION")
                 ToneDeltaPair(
                     roleA = errorContainer(),
@@ -613,36 +644,34 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.NEARER,
                     stayTogether = false,
                 )
-            },
-        )
-        .build()
+            }.build()
 
-    override fun onErrorContainer(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_error_container")
-        .setPalette({ s -> s.errorPalette })
-        .setTone(
-            { s ->
+    override fun onErrorContainer(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_error_container")
+            .setPalette { s -> s.errorPalette }
+            .setTone { s ->
                 if (isMonochrome(s)) {
                     return@setTone if (s.isDark) 90.0 else 10.0
                 }
                 if (s.isDark) 90.0 else 30.0
-            },
-        )
-        .setBackground({ s -> errorContainer() })
-        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
-        .build()
+            }.setBackground { s -> errorContainer() }
+            .setContrastCurve { s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) }
+            .build()
 
     // Primary Fixed Colors [PF]
 
-    override fun primaryFixed(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("primary_fixed")
-        .setPalette({ s -> s.primaryPalette })
-        .setTone({ s -> if (isMonochrome(s)) 40.0 else 90.0 })
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
-        .setToneDeltaPair(
-            { s ->
+    override fun primaryFixed(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("primary_fixed")
+            .setPalette { s -> s.primaryPalette }
+            .setTone { s -> if (isMonochrome(s)) 40.0 else 90.0 }
+            .setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) }
+            .setToneDeltaPair { s ->
                 ToneDeltaPair(
                     roleA = this.primaryFixed(),
                     roleB = this.primaryFixedDim(),
@@ -650,19 +679,18 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.LIGHTER,
                     stayTogether = true,
                 )
-            },
-        )
-        .build()
+            }.build()
 
-    override fun primaryFixedDim(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("primary_fixed_dim")
-        .setPalette({ s -> s.primaryPalette })
-        .setTone({ s -> if (isMonochrome(s)) 30.0 else 80.0 })
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
-        .setToneDeltaPair(
-            { s ->
+    override fun primaryFixedDim(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("primary_fixed_dim")
+            .setPalette { s -> s.primaryPalette }
+            .setTone { s -> if (isMonochrome(s)) 30.0 else 80.0 }
+            .setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) }
+            .setToneDeltaPair { s ->
                 ToneDeltaPair(
                     roleA = primaryFixed(),
                     roleB = primaryFixedDim(),
@@ -670,39 +698,42 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.LIGHTER,
                     stayTogether = true,
                 )
-            },
-        )
-        .build()
+            }.build()
 
-    override fun onPrimaryFixed(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_primary_fixed")
-        .setPalette({ s -> s.primaryPalette })
-        .setTone({ s -> if (isMonochrome(s)) 100.0 else 10.0 })
-        .setBackground({ s -> primaryFixedDim() })
-        .setSecondBackground({ s -> primaryFixed() })
-        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
-        .build()
+    override fun onPrimaryFixed(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_primary_fixed")
+            .setPalette { s -> s.primaryPalette }
+            .setTone { s -> if (isMonochrome(s)) 100.0 else 10.0 }
+            .setBackground { s -> primaryFixedDim() }
+            .setSecondBackground { s -> primaryFixed() }
+            .setContrastCurve { s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) }
+            .build()
 
-    override fun onPrimaryFixedVariant(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_primary_fixed_variant")
-        .setPalette({ s -> s.primaryPalette })
-        .setTone({ s -> if (isMonochrome(s)) 90.0 else 30.0 })
-        .setBackground({ s -> primaryFixedDim() })
-        .setSecondBackground({ s -> primaryFixed() })
-        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
-        .build()
+    override fun onPrimaryFixedVariant(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_primary_fixed_variant")
+            .setPalette { s -> s.primaryPalette }
+            .setTone { s -> if (isMonochrome(s)) 90.0 else 30.0 }
+            .setBackground { s -> primaryFixedDim() }
+            .setSecondBackground { s -> primaryFixed() }
+            .setContrastCurve { s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) }
+            .build()
 
     // Secondary Fixed Colors [QF]
 
-    override fun secondaryFixed(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("secondary_fixed")
-        .setPalette({ s -> s.secondaryPalette })
-        .setTone({ s -> if (isMonochrome(s)) 80.0 else 90.0 })
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
-        .setToneDeltaPair(
-            { s ->
+    override fun secondaryFixed(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("secondary_fixed")
+            .setPalette { s -> s.secondaryPalette }
+            .setTone { s -> if (isMonochrome(s)) 80.0 else 90.0 }
+            .setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) }
+            .setToneDeltaPair { s ->
                 ToneDeltaPair(
                     roleA = secondaryFixed(),
                     roleB = secondaryFixedDim(),
@@ -710,19 +741,18 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.LIGHTER,
                     stayTogether = true,
                 )
-            },
-        )
-        .build()
+            }.build()
 
-    override fun secondaryFixedDim(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("secondary_fixed_dim")
-        .setPalette({ s -> s.secondaryPalette })
-        .setTone({ s -> if (isMonochrome(s)) 70.0 else 80.0 })
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
-        .setToneDeltaPair(
-            { s ->
+    override fun secondaryFixedDim(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("secondary_fixed_dim")
+            .setPalette { s -> s.secondaryPalette }
+            .setTone { s -> if (isMonochrome(s)) 70.0 else 80.0 }
+            .setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) }
+            .setToneDeltaPair { s ->
                 ToneDeltaPair(
                     roleA = secondaryFixed(),
                     roleB = secondaryFixedDim(),
@@ -730,39 +760,42 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.LIGHTER,
                     stayTogether = true,
                 )
-            },
-        )
-        .build()
+            }.build()
 
-    override fun onSecondaryFixed(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_secondary_fixed")
-        .setPalette({ s -> s.secondaryPalette })
-        .setTone({ s -> 10.0 })
-        .setBackground({ s -> secondaryFixedDim() })
-        .setSecondBackground({ s -> secondaryFixed() })
-        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
-        .build()
+    override fun onSecondaryFixed(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_secondary_fixed")
+            .setPalette { s -> s.secondaryPalette }
+            .setTone { s -> 10.0 }
+            .setBackground { s -> secondaryFixedDim() }
+            .setSecondBackground { s -> secondaryFixed() }
+            .setContrastCurve { s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) }
+            .build()
 
-    override fun onSecondaryFixedVariant(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_secondary_fixed_variant")
-        .setPalette({ s -> s.secondaryPalette })
-        .setTone({ s -> if (isMonochrome(s)) 25.0 else 30.0 })
-        .setBackground({ s -> secondaryFixedDim() })
-        .setSecondBackground({ s -> secondaryFixed() })
-        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
-        .build()
+    override fun onSecondaryFixedVariant(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_secondary_fixed_variant")
+            .setPalette { s -> s.secondaryPalette }
+            .setTone { s -> if (isMonochrome(s)) 25.0 else 30.0 }
+            .setBackground { s -> secondaryFixedDim() }
+            .setSecondBackground { s -> secondaryFixed() }
+            .setContrastCurve { s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) }
+            .build()
 
     // Tertiary Fixed Colors [TF]
 
-    override fun tertiaryFixed(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("tertiary_fixed")
-        .setPalette({ s -> s.tertiaryPalette })
-        .setTone({ s -> if (isMonochrome(s)) 40.0 else 90.0 })
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
-        .setToneDeltaPair(
-            { s ->
+    override fun tertiaryFixed(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("tertiary_fixed")
+            .setPalette { s -> s.tertiaryPalette }
+            .setTone { s -> if (isMonochrome(s)) 40.0 else 90.0 }
+            .setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) }
+            .setToneDeltaPair { s ->
                 ToneDeltaPair(
                     roleA = tertiaryFixed(),
                     roleB = tertiaryFixedDim(),
@@ -770,19 +803,18 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.LIGHTER,
                     stayTogether = true,
                 )
-            },
-        )
-        .build()
+            }.build()
 
-    override fun tertiaryFixedDim(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("tertiary_fixed_dim")
-        .setPalette({ s -> s.tertiaryPalette })
-        .setTone({ s -> if (isMonochrome(s)) 30.0 else 80.0 })
-        .setIsBackground(true)
-        .setBackground(this::highestSurface)
-        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
-        .setToneDeltaPair(
-            { s ->
+    override fun tertiaryFixedDim(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("tertiary_fixed_dim")
+            .setPalette { s -> s.tertiaryPalette }
+            .setTone { s -> if (isMonochrome(s)) 30.0 else 80.0 }
+            .setIsBackground(true)
+            .setBackground(this::highestSurface)
+            .setContrastCurve { s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) }
+            .setToneDeltaPair { s ->
                 ToneDeltaPair(
                     roleA = tertiaryFixed(),
                     roleB = tertiaryFixedDim(),
@@ -790,27 +822,29 @@ public open class ColorSpec2021 : ColorSpec {
                     polarity = TonePolarity.LIGHTER,
                     stayTogether = true,
                 )
-            },
-        )
-        .build()
+            }.build()
 
-    override fun onTertiaryFixed(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_tertiary_fixed")
-        .setPalette({ s -> s.tertiaryPalette })
-        .setTone({ s -> if (isMonochrome(s)) 100.0 else 10.0 })
-        .setBackground({ s -> tertiaryFixedDim() })
-        .setSecondBackground({ s -> tertiaryFixed() })
-        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
-        .build()
+    override fun onTertiaryFixed(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_tertiary_fixed")
+            .setPalette { s -> s.tertiaryPalette }
+            .setTone { s -> if (isMonochrome(s)) 100.0 else 10.0 }
+            .setBackground { s -> tertiaryFixedDim() }
+            .setSecondBackground { s -> tertiaryFixed() }
+            .setContrastCurve { s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) }
+            .build()
 
-    override fun onTertiaryFixedVariant(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("on_tertiary_fixed_variant")
-        .setPalette({ s -> s.tertiaryPalette })
-        .setTone({ s -> if (isMonochrome(s)) 90.0 else 30.0 })
-        .setBackground({ s -> tertiaryFixedDim() })
-        .setSecondBackground({ s -> tertiaryFixed() })
-        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
-        .build()
+    override fun onTertiaryFixedVariant(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("on_tertiary_fixed_variant")
+            .setPalette { s -> s.tertiaryPalette }
+            .setTone { s -> if (isMonochrome(s)) 90.0 else 30.0 }
+            .setBackground { s -> tertiaryFixedDim() }
+            .setSecondBackground { s -> tertiaryFixed() }
+            .setContrastCurve { s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) }
+            .build()
 
     /*
      * Android-only Colors
@@ -830,23 +864,27 @@ public open class ColorSpec2021 : ColorSpec {
      * Android used Material's Container as Primary/Secondary/Tertiary at launch.
      * Therefore, this is a duplicated version of Primary Container.
      */
-    override fun controlActivated(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("control_activated")
-        .setPalette({ s -> s.primaryPalette })
-        .setTone({ s -> if (s.isDark) 30.0 else 90.0 })
-        .setIsBackground(true)
-        .build()
+    override fun controlActivated(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("control_activated")
+            .setPalette { s -> s.primaryPalette }
+            .setTone { s -> if (s.isDark) 30.0 else 90.0 }
+            .setIsBackground(true)
+            .build()
 
     /**
      * colorControlNormal documented as textColorSecondary in M3 & GM3.
      * In Material, textColorSecondary points to onSurfaceVariant in the non-disabled state,
      * which is Neutral Variant T30/80 in light/dark.
      */
-    override fun controlNormal(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("control_normal")
-        .setPalette({ s -> s.neutralVariantPalette })
-        .setTone({ s -> if (s.isDark) 80.0 else 30.0 })
-        .build()
+    override fun controlNormal(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("control_normal")
+            .setPalette { s -> s.neutralVariantPalette }
+            .setTone { s -> if (s.isDark) 80.0 else 30.0 }
+            .build()
 
     /**
      * colorControlHighlight documented, in both M3 & GM3:
@@ -858,59 +896,71 @@ public open class ColorSpec2021 : ColorSpec {
      * depending on how MDC resolved alpha for the other cases.
      * Returning black in dark mode, white in light mode.
      */
-    override fun controlHighlight(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("control_highlight")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone({ s -> if (s.isDark) 100.0 else 0.0 })
-        .setOpacity({ s -> if (s.isDark) 0.20 else 0.12 })
-        .build()
+    override fun controlHighlight(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("control_highlight")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> if (s.isDark) 100.0 else 0.0 }
+            .setOpacity { s -> if (s.isDark) 0.20 else 0.12 }
+            .build()
 
     /**
      * textColorPrimaryInverse documented, in both M3 & GM3, documented as N10/N90.
      */
-    override fun textPrimaryInverse(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("text_primary_inverse")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone({ s -> if (s.isDark) 10.0 else 90.0 })
-        .build()
+    override fun textPrimaryInverse(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("text_primary_inverse")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> if (s.isDark) 10.0 else 90.0 }
+            .build()
 
     /**
      * textColorSecondaryInverse and textColorTertiaryInverse both documented, in both M3 & GM3, as
      * NV30/NV80
      */
-    override fun textSecondaryAndTertiaryInverse(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("text_secondary_and_tertiary_inverse")
-        .setPalette({ s -> s.neutralVariantPalette })
-        .setTone({ s -> if (s.isDark) 30.0 else 80.0 })
-        .build()
+    override fun textSecondaryAndTertiaryInverse(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("text_secondary_and_tertiary_inverse")
+            .setPalette { s -> s.neutralVariantPalette }
+            .setTone { s -> if (s.isDark) 30.0 else 80.0 }
+            .build()
 
     /**
      * textColorPrimaryInverseDisableOnly documented, in both M3 & GM3, as N10/N90
      */
-    override fun textPrimaryInverseDisableOnly(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("text_primary_inverse_disable_only")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone({ s -> if (s.isDark) 10.0 else 90.0 })
-        .build()
+    override fun textPrimaryInverseDisableOnly(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("text_primary_inverse_disable_only")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> if (s.isDark) 10.0 else 90.0 }
+            .build()
 
     /**
      * textColorSecondaryInverse and textColorTertiaryInverse in disabled state both documented,
      * in both M3 & GM3, as N10/N90
      */
-    override fun textSecondaryAndTertiaryInverseDisabled(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("text_secondary_and_tertiary_inverse_disabled")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone({ s -> if (s.isDark) 10.0 else 90.0 })
-        .build()
+    override fun textSecondaryAndTertiaryInverseDisabled(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("text_secondary_and_tertiary_inverse_disabled")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> if (s.isDark) 10.0 else 90.0 }
+            .build()
 
     /**
      * textColorHintInverse documented, in both M3 & GM3, as N10/N90
      */
-    override fun textHintInverse(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("text_hint_inverse")
-        .setPalette({ s -> s.neutralPalette })
-        .setTone({ s -> if (s.isDark) 10.0 else 90.0 })
-        .build()
+    override fun textHintInverse(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("text_hint_inverse")
+            .setPalette { s -> s.neutralPalette }
+            .setTone { s -> if (s.isDark) 10.0 else 90.0 }
+            .build()
 
     // Other
 
@@ -922,7 +972,10 @@ public open class ColorSpec2021 : ColorSpec {
 
     // Color value calculations
 
-    override fun getHct(scheme: DynamicScheme, color: DynamicColor): Hct {
+    override fun getHct(
+        scheme: DynamicScheme,
+        color: DynamicColor,
+    ): Hct {
         // This is crucial for aesthetics: we aren't simply the taking the standard color
         // and changing its tone for contrast. Rather, we find the tone for contrast, then
         // use the specified chroma from the palette to construct a new color.
@@ -933,7 +986,10 @@ public open class ColorSpec2021 : ColorSpec {
         return color.palette.invoke(scheme).getHct(tone)
     }
 
-    override fun getTone(scheme: DynamicScheme, color: DynamicColor): Double {
+    override fun getTone(
+        scheme: DynamicScheme,
+        color: DynamicColor,
+    ): Double {
         val decreasingContrast = scheme.contrastLevel < 0
         val toneDeltaPair: ToneDeltaPair? =
             if (color.toneDeltaPair == null) null else color.toneDeltaPair(scheme)
@@ -948,11 +1004,14 @@ public open class ColorSpec2021 : ColorSpec {
 
             @Suppress("DEPRECATION")
             val aIsNearer =
-                (polarity == TonePolarity.NEARER || (polarity == TonePolarity.LIGHTER && !scheme.isDark)
-                    || (polarity == TonePolarity.DARKER && !scheme.isDark))
+                (
+                    polarity == TonePolarity.NEARER ||
+                        (polarity == TonePolarity.LIGHTER && !scheme.isDark) ||
+                        (polarity == TonePolarity.DARKER && !scheme.isDark)
+                )
             val nearer = if (aIsNearer) roleA else roleB
             val farther = if (aIsNearer) roleB else roleA
-            val amNearer = color.name.equals(nearer.name)
+            val amNearer = color.name == nearer.name
             val expansionDir = (if (scheme.isDark) 1 else -1).toDouble()
             var nTone: Double = nearer.tone(scheme)
             var fTone: Double = farther.tone(scheme)
@@ -1021,10 +1080,10 @@ public open class ColorSpec2021 : ColorSpec {
                     }
                 } else {
                     // Not required to stay together; fixes just one.
-                    if (expansionDir > 0) {
-                        fTone = 60.0
+                    fTone = if (expansionDir > 0) {
+                        60.0
                     } else {
-                        fTone = 49.0
+                        49.0
                     }
                 }
             }
@@ -1055,10 +1114,10 @@ public open class ColorSpec2021 : ColorSpec {
 
             if (color.isBackground && 50 <= answer && answer < 60) {
                 // Must adjust
-                if (Contrast.ratioOfTones(49.0, bgTone) >= desiredRatio) {
-                    answer = 49.0
+                answer = if (Contrast.ratioOfTones(49.0, bgTone) >= desiredRatio) {
+                    49.0
                 } else {
-                    answer = 60.0
+                    60.0
                 }
             }
 
@@ -1073,8 +1132,8 @@ public open class ColorSpec2021 : ColorSpec {
             val upper: Double = max(bgTone1, bgTone2)
             val lower: Double = min(bgTone1, bgTone2)
 
-            if (Contrast.ratioOfTones(upper, answer) >= desiredRatio
-                && Contrast.ratioOfTones(lower, answer) >= desiredRatio
+            if (Contrast.ratioOfTones(upper, answer) >= desiredRatio &&
+                Contrast.ratioOfTones(lower, answer) >= desiredRatio
             ) {
                 return answer
             }
@@ -1097,8 +1156,8 @@ public open class ColorSpec2021 : ColorSpec {
             }
 
             val prefersLight =
-                DynamicColor.tonePrefersLightForeground(bgTone1)
-                    || DynamicColor.tonePrefersLightForeground(bgTone2)
+                DynamicColor.tonePrefersLightForeground(bgTone1) ||
+                    DynamicColor.tonePrefersLightForeground(bgTone2)
 
             if (prefersLight) {
                 return if (lightOption == -1.0) 100.0 else lightOption
@@ -1118,34 +1177,36 @@ public open class ColorSpec2021 : ColorSpec {
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: Platform,
-        contrastLevel: Double
-    ): TonalPalette = when (variant) {
-        Variant.CONTENT,
-        Variant.FIDELITY -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = sourceColorHct.chroma,
-        )
-        Variant.FRUIT_SALAD -> TonalPalette.fromHueAndChroma(
-            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue - 50.0),
-            chroma = 48.0,
-        )
-        Variant.MONOCHROME -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
-        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 12.0)
-        Variant.RAINBOW -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 48.0)
-        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 36.0)
-        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
-            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 240),
-            chroma = 40.0,
-        )
-        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 200.0)
-    }
+        contrastLevel: Double,
+    ): TonalPalette =
+        when (variant) {
+            Variant.CONTENT,
+            Variant.FIDELITY,
+            -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = sourceColorHct.chroma,
+            )
+            Variant.FRUIT_SALAD -> TonalPalette.fromHueAndChroma(
+                hue = MathUtils.sanitizeDegrees(sourceColorHct.hue - 50.0),
+                chroma = 48.0,
+            )
+            Variant.MONOCHROME -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
+            Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 12.0)
+            Variant.RAINBOW -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 48.0)
+            Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 36.0)
+            Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+                hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 240),
+                chroma = 40.0,
+            )
+            Variant.VIBRANT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 200.0)
+        }
 
     public override fun getSecondaryPalette(
         variant: Variant,
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: Platform,
-        contrastLevel: Double
+        contrastLevel: Double,
     ): TonalPalette {
         when (variant) {
             Variant.CONTENT, Variant.FIDELITY -> return TonalPalette.fromHueAndChroma(
@@ -1154,7 +1215,8 @@ public open class ColorSpec2021 : ColorSpec {
             )
 
             Variant.FRUIT_SALAD -> return TonalPalette.fromHueAndChroma(
-                MathUtils.sanitizeDegrees(sourceColorHct.hue - 50.0), 36.0,
+                MathUtils.sanitizeDegrees(sourceColorHct.hue - 50.0),
+                36.0,
             )
 
             Variant.MONOCHROME -> return TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
@@ -1190,112 +1252,117 @@ public open class ColorSpec2021 : ColorSpec {
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: Platform,
-        contrastLevel: Double
-    ): TonalPalette = when (variant) {
-        Variant.CONTENT -> TonalPalette.fromHct(
-            DislikeAnalyzer.fixIfDisliked(
-                TemperatureCache(sourceColorHct).getAnalogousColors(count = 3, divisions = 6)[2],
-            ),
-        )
-        Variant.FIDELITY -> TonalPalette.fromHct(
-            DislikeAnalyzer.fixIfDisliked(TemperatureCache(sourceColorHct).complement),
-        )
-        Variant.FRUIT_SALAD -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = 36.0,
-        )
-        Variant.MONOCHROME -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
-        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 16.0)
-        Variant.RAINBOW, Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
-            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 60.0),
-            chroma = 24.0,
-        )
-        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
-            hue = DynamicScheme.getRotatedHue(
-                sourceColorHct = sourceColorHct,
-                hueBreakpoints = doubleArrayOf(0.0, 21.0, 51.0, 121.0, 151.0, 191.0, 271.0, 321.0, 360.0),
-                rotations = doubleArrayOf(120.0, 120.0, 20.0, 45.0, 20.0, 15.0, 20.0, 120.0, 120.0),
-            ),
-            chroma = 32.0,
-        )
+        contrastLevel: Double,
+    ): TonalPalette =
+        when (variant) {
+            Variant.CONTENT -> TonalPalette.fromHct(
+                DislikeAnalyzer.fixIfDisliked(
+                    TemperatureCache(sourceColorHct).getAnalogousColors(count = 3, divisions = 6)[2],
+                ),
+            )
+            Variant.FIDELITY -> TonalPalette.fromHct(
+                DislikeAnalyzer.fixIfDisliked(TemperatureCache(sourceColorHct).complement),
+            )
+            Variant.FRUIT_SALAD -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = 36.0,
+            )
+            Variant.MONOCHROME -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
+            Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 16.0)
+            Variant.RAINBOW, Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
+                hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 60.0),
+                chroma = 24.0,
+            )
+            Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+                hue = DynamicScheme.getRotatedHue(
+                    sourceColorHct = sourceColorHct,
+                    hueBreakpoints = doubleArrayOf(0.0, 21.0, 51.0, 121.0, 151.0, 191.0, 271.0, 321.0, 360.0),
+                    rotations = doubleArrayOf(120.0, 120.0, 20.0, 45.0, 20.0, 15.0, 20.0, 120.0, 120.0),
+                ),
+                chroma = 32.0,
+            )
 
-        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
-            hue = DynamicScheme.getRotatedHue(
-                sourceColorHct = sourceColorHct,
-                hueBreakpoints = doubleArrayOf(0.0, 41.0, 61.0, 101.0, 131.0, 181.0, 251.0, 301.0, 360.0),
-                rotations = doubleArrayOf(35.0, 30.0, 20.0, 25.0, 30.0, 35.0, 30.0, 25.0, 25.0),
-            ),
-            chroma = 32.0,
-        )
-    }
+            Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
+                hue = DynamicScheme.getRotatedHue(
+                    sourceColorHct = sourceColorHct,
+                    hueBreakpoints = doubleArrayOf(0.0, 41.0, 61.0, 101.0, 131.0, 181.0, 251.0, 301.0, 360.0),
+                    rotations = doubleArrayOf(35.0, 30.0, 20.0, 25.0, 30.0, 35.0, 30.0, 25.0, 25.0),
+                ),
+                chroma = 32.0,
+            )
+        }
 
     public override fun getNeutralPalette(
         variant: Variant,
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: Platform,
-        contrastLevel: Double
-    ): TonalPalette = when (variant) {
-        Variant.CONTENT, Variant.FIDELITY -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = sourceColorHct.chroma / 8.0,
-        )
-        Variant.FRUIT_SALAD -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 10.0)
-        Variant.MONOCHROME -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
-        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 2.0)
-        Variant.RAINBOW -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
-        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 6.0)
-        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
-            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 15),
-            chroma = 8.0,
-        )
-        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 10.0)
-    }
+        contrastLevel: Double,
+    ): TonalPalette =
+        when (variant) {
+            Variant.CONTENT, Variant.FIDELITY -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = sourceColorHct.chroma / 8.0,
+            )
+            Variant.FRUIT_SALAD -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 10.0)
+            Variant.MONOCHROME -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
+            Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 2.0)
+            Variant.RAINBOW -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
+            Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 6.0)
+            Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+                hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 15),
+                chroma = 8.0,
+            )
+            Variant.VIBRANT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 10.0)
+        }
 
     public override fun getNeutralVariantPalette(
         variant: Variant,
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: Platform,
-        contrastLevel: Double
-    ): TonalPalette = when (variant) {
-        Variant.CONTENT -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = (sourceColorHct.chroma / 8.0) + 4.0,
-        )
-        Variant.FIDELITY -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = (sourceColorHct.chroma / 8.0) + 4.0,
-        )
-        Variant.FRUIT_SALAD -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 16.0)
-        Variant.MONOCHROME -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
-        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 2.0)
-        Variant.RAINBOW -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
-        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 8.0)
-        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
-            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 15),
-            chroma = 12.0,
-        )
-        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 12.0)
-    }
+        contrastLevel: Double,
+    ): TonalPalette =
+        when (variant) {
+            Variant.CONTENT -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = (sourceColorHct.chroma / 8.0) + 4.0,
+            )
+            Variant.FIDELITY -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = (sourceColorHct.chroma / 8.0) + 4.0,
+            )
+            Variant.FRUIT_SALAD -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 16.0)
+            Variant.MONOCHROME -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
+            Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 2.0)
+            Variant.RAINBOW -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
+            Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 8.0)
+            Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+                hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 15),
+                chroma = 12.0,
+            )
+            Variant.VIBRANT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 12.0)
+        }
 
     public override fun getErrorPalette(
         variant: Variant,
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: Platform,
-        contrastLevel: Double
-    ): TonalPalette? = when (variant) {
-        Variant.CONTENT,
-        Variant.FIDELITY,
-        Variant.FRUIT_SALAD,
-        Variant.MONOCHROME,
-        Variant.NEUTRAL,
-        Variant.RAINBOW,
-        Variant.TONAL_SPOT,
-        Variant.EXPRESSIVE,
-        Variant.VIBRANT -> null
-    }
+        contrastLevel: Double,
+    ): TonalPalette? =
+        when (variant) {
+            Variant.CONTENT,
+            Variant.FIDELITY,
+            Variant.FRUIT_SALAD,
+            Variant.MONOCHROME,
+            Variant.NEUTRAL,
+            Variant.RAINBOW,
+            Variant.TONAL_SPOT,
+            Variant.EXPRESSIVE,
+            Variant.VIBRANT,
+            -> null
+        }
 
     public companion object {
         private fun isMonochrome(scheme: DynamicScheme): Boolean = scheme.variant == Variant.MONOCHROME

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2021.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2021.kt
@@ -1,0 +1,1336 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.materialkolor.dynamiccolor
+
+import com.materialkolor.contrast.Contrast
+import com.materialkolor.dislike.DislikeAnalyzer
+import com.materialkolor.hct.Hct
+import com.materialkolor.palettes.TonalPalette
+import com.materialkolor.scheme.DynamicScheme
+import com.materialkolor.scheme.DynamicScheme.Platform
+import com.materialkolor.scheme.Variant
+import com.materialkolor.temperature.TemperatureCache
+import com.materialkolor.utils.MathUtils
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * [ColorSpec] implementation for the 2021 spec.
+ */
+public open class ColorSpec2021 : ColorSpec {
+    // Main Palettes
+
+    override fun primaryPaletteKeyColor(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("primary_palette_key_color")
+        .setPalette { s -> s.primaryPalette }
+        .setTone { s -> s.primaryPalette.keyColor.tone }
+        .build()
+
+    override fun secondaryPaletteKeyColor(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("secondary_palette_key_color")
+        .setPalette { s -> s.secondaryPalette }
+        .setTone { s -> s.secondaryPalette.keyColor.tone }
+        .build()
+
+    override fun tertiaryPaletteKeyColor(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("tertiary_palette_key_color")
+        .setPalette({ s -> s.tertiaryPalette })
+        .setTone({ s -> s.tertiaryPalette.keyColor.tone })
+        .build()
+
+    override fun neutralPaletteKeyColor(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("neutral_palette_key_color")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone({ s -> s.neutralPalette.keyColor.tone })
+        .build()
+
+    override fun neutralVariantPaletteKeyColor(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("neutral_variant_palette_key_color")
+        .setPalette({ s -> s.neutralVariantPalette })
+        .setTone({ s -> s.neutralVariantPalette.keyColor.tone })
+        .build()
+
+    override fun errorPaletteKeyColor(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("error_palette_key_color")
+        .setPalette { s -> s.errorPalette }
+        .setTone { s -> s.errorPalette.keyColor.tone }
+        .build()
+
+    // Surfaces [S]
+
+    override fun background(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("background")
+        .setPalette { s -> s.neutralPalette }
+        .setTone { s -> if (s.isDark) 6.0 else 98.0 }
+        .setIsBackground(true)
+        .build()
+
+    override fun onBackground(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_background")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone({ s -> if (s.isDark) 90.0 else 10.0 })
+        .setBackground({ s -> background() })
+        .setContrastCurve({ s -> ContrastCurve(3.0, 3.0, 4.5, 7.0) })
+        .build()
+
+    override fun surface(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("surface")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone({ s -> if (s.isDark) 6.0 else 98.0 })
+        .setIsBackground(true)
+        .build()
+
+    override fun surfaceDim(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("surface_dim")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone(
+            { s ->
+                if (s.isDark) 6.0 else ContrastCurve(
+                    low = 87.0,
+                    normal = 87.0,
+                    medium = 80.0,
+                    high = 75.0,
+                ).get(s.contrastLevel)
+            },
+        )
+        .setIsBackground(true)
+        .build()
+
+    override fun surfaceBright(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("surface_bright")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone(
+            { s ->
+                if (s.isDark) ContrastCurve(
+                    low = 24.0,
+                    normal = 24.0,
+                    medium = 29.0,
+                    high = 34.0,
+                ).get(s.contrastLevel) else 98.0
+            },
+        )
+        .setIsBackground(true)
+        .build()
+
+    override fun surfaceContainerLowest(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("surface_container_lowest")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone(
+            { s ->
+                if (s.isDark) ContrastCurve(
+                    low = 4.0,
+                    normal = 4.0,
+                    medium = 2.0,
+                    high = 0.0,
+                ).get(s.contrastLevel)
+                else 100.0
+            },
+        )
+        .setIsBackground(true)
+        .build()
+
+    override fun surfaceContainerLow(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("surface_container_low")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone(
+            { s ->
+                if (s.isDark) ContrastCurve(10.0, 10.0, 11.0, 12.0).get(s.contrastLevel)
+                else ContrastCurve(96.0, 96.0, 96.0, 95.0).get(s.contrastLevel)
+            },
+        )
+        .setIsBackground(true)
+        .build()
+
+    override fun surfaceContainer(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("surface_container")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone(
+            { s ->
+                if (s.isDark) ContrastCurve(12.0, 12.0, 16.0, 20.0).get(s.contrastLevel)
+                else ContrastCurve(94.0, 94.0, 92.0, 90.0).get(s.contrastLevel)
+            },
+        )
+        .setIsBackground(true)
+        .build()
+
+    override fun surfaceContainerHigh(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("surface_container_high")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone(
+            { s ->
+                if (s.isDark) ContrastCurve(17.0, 17.0, 21.0, 25.0).get(s.contrastLevel)
+                else ContrastCurve(92.0, 92.0, 88.0, 85.0).get(s.contrastLevel)
+            },
+        )
+        .setIsBackground(true)
+        .build()
+
+    override fun surfaceContainerHighest(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("surface_container_highest")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone(
+            { s ->
+                if (s.isDark) ContrastCurve(22.0, 22.0, 26.0, 30.0).get(s.contrastLevel)
+                else ContrastCurve(90.0, 90.0, 84.0, 80.0).get(s.contrastLevel)
+            },
+        )
+        .setIsBackground(true)
+        .build()
+
+    override fun onSurface(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_surface")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone({ s -> if (s.isDark) 90.0 else 10.0 })
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
+        .build()
+
+    override fun surfaceVariant(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("surface_variant")
+        .setPalette({ s -> s.neutralVariantPalette })
+        .setTone({ s -> if (s.isDark) 30.0 else 90.0 })
+        .setIsBackground(true)
+        .build()
+
+    override fun onSurfaceVariant(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_surface_variant")
+        .setPalette({ s -> s.neutralVariantPalette })
+        .setTone({ s -> if (s.isDark) 80.0 else 30.0 })
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
+        .build()
+
+    override fun inverseSurface(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("inverse_surface")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone({ s -> if (s.isDark) 90.0 else 20.0 })
+        .setIsBackground(true)
+        .build()
+
+    override fun inverseOnSurface(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("inverse_on_surface")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone({ s -> if (s.isDark) 20.0 else 95.0 })
+        .setBackground({ s -> inverseSurface() })
+        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
+        .build()
+
+    override fun outline(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("outline")
+        .setPalette({ s -> s.neutralVariantPalette })
+        .setTone({ s -> if (s.isDark) 60.0 else 50.0 })
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(1.5, 3.0, 4.5, 7.0) })
+        .build()
+
+    override fun outlineVariant(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("outline_variant")
+        .setPalette({ s -> s.neutralVariantPalette })
+        .setTone({ s -> if (s.isDark) 30.0 else 80.0 })
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
+        .build()
+
+    override fun shadow(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("shadow")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone({ s -> 0.0 })
+        .build()
+
+    override fun scrim(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("scrim")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone({ s -> 0.0 })
+        .build()
+
+    override fun surfaceTint(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("surface_tint")
+        .setPalette({ s -> s.primaryPalette })
+        .setTone({ s -> if (s.isDark) 80.0 else 40.0 })
+        .setIsBackground(true)
+        .build()
+
+    // Primaries [P]
+
+    override fun primary(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("primary")
+        .setPalette({ s -> s.primaryPalette })
+        .setTone(
+            { s ->
+                if (isMonochrome(s)) {
+                    return@setTone if (s.isDark) 100.0 else 0.0
+                }
+                if (s.isDark) 80.0 else 40.0
+            },
+        )
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) })
+        .setToneDeltaPair(
+            { s ->
+                @Suppress("DEPRECATION")
+                ToneDeltaPair(
+                    roleA = primaryContainer(),
+                    roleB = primary(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            },
+        )
+        .build()
+
+    override fun primaryDim(): DynamicColor? = null
+
+    override fun onPrimary(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_primary")
+        .setPalette({ s -> s.primaryPalette })
+        .setTone(
+            { s ->
+                if (isMonochrome(s)) {
+                    return@setTone if (s.isDark) 10.0 else 90.0
+                }
+                if (s.isDark) 20.0 else 100.0
+            },
+        )
+        .setBackground({ s -> primary() })
+        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
+        .build()
+
+    override fun primaryContainer(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("primary_container")
+        .setPalette({ s -> s.primaryPalette })
+        .setTone(
+            { s ->
+                if (isFidelity(s)) {
+                    return@setTone s.sourceColorHct.tone
+                }
+                if (isMonochrome(s)) {
+                    return@setTone if (s.isDark) 85.0 else 25.0
+                }
+                if (s.isDark) 30.0 else 90.0
+            },
+        )
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
+        .setToneDeltaPair(
+            { s ->
+                @Suppress("DEPRECATION")
+                ToneDeltaPair(
+                    roleA = primaryContainer(),
+                    roleB = primary(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            },
+        )
+        .build()
+
+    override fun onPrimaryContainer(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_primary_container")
+        .setPalette({ s -> s.primaryPalette })
+        .setTone(
+            { s ->
+                if (isFidelity(s)) {
+                    return@setTone DynamicColor.foregroundTone(
+                        bgTone = primaryContainer().tone(s),
+                        ratio = 4.5,
+                    )
+                }
+                if (isMonochrome(s)) {
+                    return@setTone if (s.isDark) 0.0 else 100.0
+                }
+                if (s.isDark) 90.0 else 30.0
+            },
+        )
+        .setBackground({ s -> primaryContainer() })
+        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
+        .build()
+
+    override fun inversePrimary(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("inverse_primary")
+        .setPalette({ s -> s.primaryPalette })
+        .setTone({ s -> if (s.isDark) 40.0 else 80.0 })
+        .setBackground({ s -> inverseSurface() })
+        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) })
+        .build()
+
+    // Secondaries [Q]
+
+    override fun secondary(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("secondary")
+        .setPalette({ s -> s.secondaryPalette })
+        .setTone({ s -> if (s.isDark) 80.0 else 40.0 })
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) })
+        .setToneDeltaPair(
+            { s ->
+                @Suppress("DEPRECATION")
+                ToneDeltaPair(
+                    roleA = secondaryContainer(),
+                    roleB = secondary(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            },
+        )
+        .build()
+
+    override fun secondaryDim(): DynamicColor? = null
+
+    override fun onSecondary(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_secondary")
+        .setPalette({ s -> s.secondaryPalette })
+        .setTone(
+            { s ->
+                if (isMonochrome(s)) {
+                    return@setTone if (s.isDark) 10.0 else 100.0
+                }
+                if (s.isDark) 20.0 else 100.0
+            },
+        )
+        .setBackground({ s -> secondary() })
+        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
+        .build()
+
+    override fun secondaryContainer(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("secondary_container")
+        .setPalette({ s -> s.secondaryPalette })
+        .setTone(
+            { s ->
+                val initialTone = if (s.isDark) 30.0 else 90.0
+                if (isMonochrome(s)) {
+                    return@setTone if (s.isDark) 30.0 else 85.0
+                }
+                if (!isFidelity(s)) {
+                    return@setTone initialTone
+                }
+                findDesiredChromaByTone(
+                    hue = s.secondaryPalette.hue,
+                    chroma = s.secondaryPalette.chroma,
+                    tone = initialTone,
+                    byDecreasingTone = !s.isDark,
+                )
+            },
+        )
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
+        .setToneDeltaPair(
+            { s ->
+                @Suppress("DEPRECATION")
+                ToneDeltaPair(
+                    roleA = secondaryContainer(),
+                    roleB = secondary(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            },
+        )
+        .build()
+
+    override fun onSecondaryContainer(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_secondary_container")
+        .setPalette({ s -> s.secondaryPalette })
+        .setTone(
+            { s ->
+                if (isMonochrome(s)) {
+                    return@setTone if (s.isDark) 90.0 else 10.0
+                }
+                if (!isFidelity(s)) {
+                    return@setTone if (s.isDark) 90.0 else 30.0
+                }
+                DynamicColor.foregroundTone(secondaryContainer().tone(s), 4.5)
+            },
+        )
+        .setBackground({ s -> secondaryContainer() })
+        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
+        .build()
+
+    // Tertiaries [T]
+
+    override fun tertiary(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("tertiary")
+        .setPalette({ s -> s.tertiaryPalette })
+        .setTone(
+            { s ->
+                if (isMonochrome(s)) {
+                    return@setTone if (s.isDark) 90.0 else 25.0
+                }
+                if (s.isDark) 80.0 else 40.0
+            },
+        )
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) })
+        .setToneDeltaPair(
+            { s ->
+                @Suppress("DEPRECATION")
+                ToneDeltaPair(
+                    roleA = tertiaryContainer(),
+                    roleB = tertiary(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            },
+        )
+        .build()
+
+    override fun tertiaryDim(): DynamicColor? = null
+
+    override fun onTertiary(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_tertiary")
+        .setPalette({ s -> s.tertiaryPalette })
+        .setTone(
+            { s ->
+                if (isMonochrome(s)) {
+                    return@setTone if (s.isDark) 10.0 else 90.0
+                }
+                if (s.isDark) 20.0 else 100.0
+            },
+        )
+        .setBackground({ s -> tertiary() })
+        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
+        .build()
+
+    override fun tertiaryContainer(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("tertiary_container")
+        .setPalette({ s -> s.tertiaryPalette })
+        .setTone(
+            { s ->
+                if (isMonochrome(s)) {
+                    return@setTone if (s.isDark) 60.0 else 49.0
+                }
+                if (!isFidelity(s)) {
+                    return@setTone if (s.isDark) 30.0 else 90.0
+                }
+                val proposedHct = s.tertiaryPalette.getHct(s.sourceColorHct.tone)
+                DislikeAnalyzer.fixIfDisliked(proposedHct).tone
+            },
+        )
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
+        .setToneDeltaPair(
+            { s ->
+                @Suppress("DEPRECATION")
+                ToneDeltaPair(
+                    roleA = tertiaryContainer(),
+                    roleB = tertiary(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            },
+        )
+        .build()
+
+    override fun onTertiaryContainer(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_tertiary_container")
+        .setPalette({ s -> s.tertiaryPalette })
+        .setTone(
+            { s ->
+                if (isMonochrome(s)) {
+                    return@setTone if (s.isDark) 0.0 else 100.0
+                }
+                if (!isFidelity(s)) {
+                    return@setTone if (s.isDark) 90.0 else 30.0
+                }
+                DynamicColor.foregroundTone(tertiaryContainer().tone(s), 4.5)
+            },
+        )
+        .setBackground({ s -> tertiaryContainer() })
+        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
+        .build()
+
+    // Errors [E]
+
+    override fun error(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("error")
+        .setPalette({ s -> s.errorPalette })
+        .setTone({ s -> if (s.isDark) 80.0 else 40.0 })
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 7.0) })
+        .setToneDeltaPair(
+            { s ->
+                @Suppress("DEPRECATION")
+                ToneDeltaPair(
+                    roleA = errorContainer(),
+                    roleB = error(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            },
+        )
+        .build()
+
+    override fun errorDim(): DynamicColor? = null
+
+    override fun onError(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_error")
+        .setPalette({ s -> s.errorPalette })
+        .setTone({ s -> if (s.isDark) 20.0 else 100.0 })
+        .setBackground({ s -> error() })
+        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
+        .build()
+
+    override fun errorContainer(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("error_container")
+        .setPalette({ s -> s.errorPalette })
+        .setTone({ s -> if (s.isDark) 30.0 else 90.0 })
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
+        .setToneDeltaPair(
+            { s ->
+                @Suppress("DEPRECATION")
+                ToneDeltaPair(
+                    roleA = errorContainer(),
+                    roleB = error(),
+                    delta = 10.0,
+                    polarity = TonePolarity.NEARER,
+                    stayTogether = false,
+                )
+            },
+        )
+        .build()
+
+    override fun onErrorContainer(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_error_container")
+        .setPalette({ s -> s.errorPalette })
+        .setTone(
+            { s ->
+                if (isMonochrome(s)) {
+                    return@setTone if (s.isDark) 90.0 else 10.0
+                }
+                if (s.isDark) 90.0 else 30.0
+            },
+        )
+        .setBackground({ s -> errorContainer() })
+        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
+        .build()
+
+    // Primary Fixed Colors [PF]
+
+    override fun primaryFixed(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("primary_fixed")
+        .setPalette({ s -> s.primaryPalette })
+        .setTone({ s -> if (isMonochrome(s)) 40.0 else 90.0 })
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
+        .setToneDeltaPair(
+            { s ->
+                ToneDeltaPair(
+                    roleA = this.primaryFixed(),
+                    roleB = this.primaryFixedDim(),
+                    delta = 10.0,
+                    polarity = TonePolarity.LIGHTER,
+                    stayTogether = true,
+                )
+            },
+        )
+        .build()
+
+    override fun primaryFixedDim(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("primary_fixed_dim")
+        .setPalette({ s -> s.primaryPalette })
+        .setTone({ s -> if (isMonochrome(s)) 30.0 else 80.0 })
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
+        .setToneDeltaPair(
+            { s ->
+                ToneDeltaPair(
+                    roleA = primaryFixed(),
+                    roleB = primaryFixedDim(),
+                    delta = 10.0,
+                    polarity = TonePolarity.LIGHTER,
+                    stayTogether = true,
+                )
+            },
+        )
+        .build()
+
+    override fun onPrimaryFixed(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_primary_fixed")
+        .setPalette({ s -> s.primaryPalette })
+        .setTone({ s -> if (isMonochrome(s)) 100.0 else 10.0 })
+        .setBackground({ s -> primaryFixedDim() })
+        .setSecondBackground({ s -> primaryFixed() })
+        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
+        .build()
+
+    override fun onPrimaryFixedVariant(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_primary_fixed_variant")
+        .setPalette({ s -> s.primaryPalette })
+        .setTone({ s -> if (isMonochrome(s)) 90.0 else 30.0 })
+        .setBackground({ s -> primaryFixedDim() })
+        .setSecondBackground({ s -> primaryFixed() })
+        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
+        .build()
+
+    // Secondary Fixed Colors [QF]
+
+    override fun secondaryFixed(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("secondary_fixed")
+        .setPalette({ s -> s.secondaryPalette })
+        .setTone({ s -> if (isMonochrome(s)) 80.0 else 90.0 })
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
+        .setToneDeltaPair(
+            { s ->
+                ToneDeltaPair(
+                    roleA = secondaryFixed(),
+                    roleB = secondaryFixedDim(),
+                    delta = 10.0,
+                    polarity = TonePolarity.LIGHTER,
+                    stayTogether = true,
+                )
+            },
+        )
+        .build()
+
+    override fun secondaryFixedDim(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("secondary_fixed_dim")
+        .setPalette({ s -> s.secondaryPalette })
+        .setTone({ s -> if (isMonochrome(s)) 70.0 else 80.0 })
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
+        .setToneDeltaPair(
+            { s ->
+                ToneDeltaPair(
+                    roleA = secondaryFixed(),
+                    roleB = secondaryFixedDim(),
+                    delta = 10.0,
+                    polarity = TonePolarity.LIGHTER,
+                    stayTogether = true,
+                )
+            },
+        )
+        .build()
+
+    override fun onSecondaryFixed(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_secondary_fixed")
+        .setPalette({ s -> s.secondaryPalette })
+        .setTone({ s -> 10.0 })
+        .setBackground({ s -> secondaryFixedDim() })
+        .setSecondBackground({ s -> secondaryFixed() })
+        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
+        .build()
+
+    override fun onSecondaryFixedVariant(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_secondary_fixed_variant")
+        .setPalette({ s -> s.secondaryPalette })
+        .setTone({ s -> if (isMonochrome(s)) 25.0 else 30.0 })
+        .setBackground({ s -> secondaryFixedDim() })
+        .setSecondBackground({ s -> secondaryFixed() })
+        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
+        .build()
+
+    // Tertiary Fixed Colors [TF]
+
+    override fun tertiaryFixed(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("tertiary_fixed")
+        .setPalette({ s -> s.tertiaryPalette })
+        .setTone({ s -> if (isMonochrome(s)) 40.0 else 90.0 })
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
+        .setToneDeltaPair(
+            { s ->
+                ToneDeltaPair(
+                    roleA = tertiaryFixed(),
+                    roleB = tertiaryFixedDim(),
+                    delta = 10.0,
+                    polarity = TonePolarity.LIGHTER,
+                    stayTogether = true,
+                )
+            },
+        )
+        .build()
+
+    override fun tertiaryFixedDim(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("tertiary_fixed_dim")
+        .setPalette({ s -> s.tertiaryPalette })
+        .setTone({ s -> if (isMonochrome(s)) 30.0 else 80.0 })
+        .setIsBackground(true)
+        .setBackground(this::highestSurface)
+        .setContrastCurve({ s -> ContrastCurve(1.0, 1.0, 3.0, 4.5) })
+        .setToneDeltaPair(
+            { s ->
+                ToneDeltaPair(
+                    roleA = tertiaryFixed(),
+                    roleB = tertiaryFixedDim(),
+                    delta = 10.0,
+                    polarity = TonePolarity.LIGHTER,
+                    stayTogether = true,
+                )
+            },
+        )
+        .build()
+
+    override fun onTertiaryFixed(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_tertiary_fixed")
+        .setPalette({ s -> s.tertiaryPalette })
+        .setTone({ s -> if (isMonochrome(s)) 100.0 else 10.0 })
+        .setBackground({ s -> tertiaryFixedDim() })
+        .setSecondBackground({ s -> tertiaryFixed() })
+        .setContrastCurve({ s -> ContrastCurve(4.5, 7.0, 11.0, 21.0) })
+        .build()
+
+    override fun onTertiaryFixedVariant(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("on_tertiary_fixed_variant")
+        .setPalette({ s -> s.tertiaryPalette })
+        .setTone({ s -> if (isMonochrome(s)) 90.0 else 30.0 })
+        .setBackground({ s -> tertiaryFixedDim() })
+        .setSecondBackground({ s -> tertiaryFixed() })
+        .setContrastCurve({ s -> ContrastCurve(3.0, 4.5, 7.0, 11.0) })
+        .build()
+
+    /*
+     * Android-only Colors
+     * These colors were present in Android framework before Android U, and used by MDC controls. They
+     * should be avoided, if possible. It's unclear if they're used on multiple backgrounds, and if
+     * they are, they can't be adjusted for contrast.* For now, they will be set with no background,
+     * and those won't adjust for contrast, avoiding issues.
+     *
+     *
+     * For example, if the same color is on a white background _and_ black background, there's no
+     * way to increase contrast with either without losing contrast with the other.
+     */
+
+    /**
+     * colorControlActivated documented as colorAccent in M3 & GM3.
+     * colorAccent documented as colorSecondary in M3 and colorPrimary in GM3.
+     * Android used Material's Container as Primary/Secondary/Tertiary at launch.
+     * Therefore, this is a duplicated version of Primary Container.
+     */
+    override fun controlActivated(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("control_activated")
+        .setPalette({ s -> s.primaryPalette })
+        .setTone({ s -> if (s.isDark) 30.0 else 90.0 })
+        .setIsBackground(true)
+        .build()
+
+    /**
+     * colorControlNormal documented as textColorSecondary in M3 & GM3.
+     * In Material, textColorSecondary points to onSurfaceVariant in the non-disabled state,
+     * which is Neutral Variant T30/80 in light/dark.
+     */
+    override fun controlNormal(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("control_normal")
+        .setPalette({ s -> s.neutralVariantPalette })
+        .setTone({ s -> if (s.isDark) 80.0 else 30.0 })
+        .build()
+
+    /**
+     * colorControlHighlight documented, in both M3 & GM3:
+     * Light mode: #1f000000 dark mode: #33ffffff.
+     * These are black and white with some alpha.
+     * 1F hex = 31 decimal; 31 / 255 = 12% alpha.
+     * 33 hex = 51 decimal; 51 / 255 = 20% alpha.
+     * DynamicColors do not support alpha currently, and _may_ not need it for this use case,
+     * depending on how MDC resolved alpha for the other cases.
+     * Returning black in dark mode, white in light mode.
+     */
+    override fun controlHighlight(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("control_highlight")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone({ s -> if (s.isDark) 100.0 else 0.0 })
+        .setOpacity({ s -> if (s.isDark) 0.20 else 0.12 })
+        .build()
+
+    /**
+     * textColorPrimaryInverse documented, in both M3 & GM3, documented as N10/N90.
+     */
+    override fun textPrimaryInverse(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("text_primary_inverse")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone({ s -> if (s.isDark) 10.0 else 90.0 })
+        .build()
+
+    /**
+     * textColorSecondaryInverse and textColorTertiaryInverse both documented, in both M3 & GM3, as
+     * NV30/NV80
+     */
+    override fun textSecondaryAndTertiaryInverse(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("text_secondary_and_tertiary_inverse")
+        .setPalette({ s -> s.neutralVariantPalette })
+        .setTone({ s -> if (s.isDark) 30.0 else 80.0 })
+        .build()
+
+    /**
+     * textColorPrimaryInverseDisableOnly documented, in both M3 & GM3, as N10/N90
+     */
+    override fun textPrimaryInverseDisableOnly(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("text_primary_inverse_disable_only")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone({ s -> if (s.isDark) 10.0 else 90.0 })
+        .build()
+
+    /**
+     * textColorSecondaryInverse and textColorTertiaryInverse in disabled state both documented,
+     * in both M3 & GM3, as N10/N90
+     */
+    override fun textSecondaryAndTertiaryInverseDisabled(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("text_secondary_and_tertiary_inverse_disabled")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone({ s -> if (s.isDark) 10.0 else 90.0 })
+        .build()
+
+    /**
+     * textColorHintInverse documented, in both M3 & GM3, as N10/N90
+     */
+    override fun textHintInverse(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("text_hint_inverse")
+        .setPalette({ s -> s.neutralPalette })
+        .setTone({ s -> if (s.isDark) 10.0 else 90.0 })
+        .build()
+
+    // Other
+
+    override fun highestSurface(s: DynamicScheme): DynamicColor =
+        if (s.isDark) surfaceBright() else surfaceDim()
+
+    private fun isFidelity(scheme: DynamicScheme): Boolean =
+        scheme.variant == Variant.FIDELITY || scheme.variant == Variant.CONTENT
+
+    // Color value calculations
+
+    override fun getHct(scheme: DynamicScheme, color: DynamicColor): Hct {
+        // This is crucial for aesthetics: we aren't simply the taking the standard color
+        // and changing its tone for contrast. Rather, we find the tone for contrast, then
+        // use the specified chroma from the palette to construct a new color.
+        //
+        // For example, this enables colors with standard tone of T90, which has limited chroma, to
+        // "recover" intended chroma as contrast increases.
+        val tone = getTone(scheme, color)
+        return color.palette.invoke(scheme).getHct(tone)
+    }
+
+    override fun getTone(scheme: DynamicScheme, color: DynamicColor): Double {
+        val decreasingContrast = scheme.contrastLevel < 0
+        val toneDeltaPair: ToneDeltaPair? =
+            if (color.toneDeltaPair == null) null else color.toneDeltaPair(scheme)
+
+        // Case 1: dual foreground, pair of colors with delta constraint.
+        if (toneDeltaPair != null) {
+            val roleA = toneDeltaPair.roleA
+            val roleB = toneDeltaPair.roleB
+            val delta = toneDeltaPair.delta
+            val polarity = toneDeltaPair.polarity
+            val stayTogether = toneDeltaPair.stayTogether
+
+            @Suppress("DEPRECATION")
+            val aIsNearer =
+                (polarity == TonePolarity.NEARER || (polarity == TonePolarity.LIGHTER && !scheme.isDark)
+                    || (polarity == TonePolarity.DARKER && !scheme.isDark))
+            val nearer = if (aIsNearer) roleA else roleB
+            val farther = if (aIsNearer) roleB else roleA
+            val amNearer = color.name.equals(nearer.name)
+            val expansionDir = (if (scheme.isDark) 1 else -1).toDouble()
+            var nTone: Double = nearer.tone(scheme)
+            var fTone: Double = farther.tone(scheme)
+
+            // 1st round: solve to min, each
+            if (color.background != null && nearer.contrastCurve != null && farther.contrastCurve != null) {
+                val bg: DynamicColor? = color.background(scheme)
+                val nContrastCurve: ContrastCurve? = nearer.contrastCurve(scheme)
+                val fContrastCurve: ContrastCurve? = farther.contrastCurve(scheme)
+                if (bg != null && nContrastCurve != null && fContrastCurve != null) {
+                    val nContrast = nContrastCurve.get(scheme.contrastLevel)
+                    val fContrast = fContrastCurve.get(scheme.contrastLevel)
+                    val bgTone = bg.getTone(scheme)
+
+                    // If a color is good enough, it is not adjusted.
+                    // Initial and adjusted tones for `nearer`
+                    if (Contrast.ratioOfTones(bgTone, nTone) < nContrast) {
+                        nTone = DynamicColor.foregroundTone(bgTone, nContrast)
+                    }
+                    // Initial and adjusted tones for `farther`
+                    if (Contrast.ratioOfTones(bgTone, fTone) < fContrast) {
+                        fTone = DynamicColor.foregroundTone(bgTone, fContrast)
+                    }
+
+                    if (decreasingContrast) {
+                        // If decreasing contrast, adjust color to the "bare minimum"
+                        // that satisfies contrast.
+                        nTone = DynamicColor.foregroundTone(bgTone, nContrast)
+                        fTone = DynamicColor.foregroundTone(bgTone, fContrast)
+                    }
+                }
+            }
+
+            // If constraint is not satisfied, try another round.
+            if ((fTone - nTone) * expansionDir < delta) {
+                // 2nd round: expand farther to match delta.
+                fTone = (nTone + delta * expansionDir).coerceIn(0.0, 100.0)
+                // If constraint is not satisfied, try another round.
+                if ((fTone - nTone) * expansionDir < delta) {
+                    // 3rd round: contract nearer to match delta.
+                    nTone = (fTone - delta * expansionDir).coerceIn(0.0, 100.0)
+                }
+            }
+
+            // Avoids the 50-59 awkward zone.
+            if (50 <= nTone && nTone < 60) {
+                // If `nearer` is in the awkward zone, move it away, together with
+                // `farther`.
+                if (expansionDir > 0) {
+                    nTone = 60.0
+                    fTone = max(fTone, nTone + delta * expansionDir)
+                } else {
+                    nTone = 49.0
+                    fTone = min(fTone, nTone + delta * expansionDir)
+                }
+            } else if (50 <= fTone && fTone < 60) {
+                if (stayTogether) {
+                    // Fixes both, to avoid two colors on opposite sides of the "awkward
+                    // zone".
+                    if (expansionDir > 0) {
+                        nTone = 60.0
+                        fTone = max(fTone, nTone + delta * expansionDir)
+                    } else {
+                        nTone = 49.0
+                        fTone = min(fTone, nTone + delta * expansionDir)
+                    }
+                } else {
+                    // Not required to stay together; fixes just one.
+                    if (expansionDir > 0) {
+                        fTone = 60.0
+                    } else {
+                        fTone = 49.0
+                    }
+                }
+            }
+
+            // Returns `nTone` if this color is `nearer`, otherwise `fTone`.
+            return if (amNearer) nTone else fTone
+        } else {
+            // Case 2: No contrast pair; just solve for itself.
+            var answer: Double = color.tone(scheme)
+
+            if (color.background == null || color.contrastCurve == null) {
+                return answer // No adjustment for colors with no background.
+            }
+
+            val bgTone = color.background(scheme)?.getTone(scheme) ?: 0.0
+            val desiredRatio = color.contrastCurve(scheme)?.get(scheme.contrastLevel) ?: 0.0
+
+            if (Contrast.ratioOfTones(bgTone, answer) >= desiredRatio) {
+                // Don't "improve" what's good enough.
+            } else {
+                // Rough improvement.
+                answer = DynamicColor.foregroundTone(bgTone, desiredRatio)
+            }
+
+            if (decreasingContrast) {
+                answer = DynamicColor.foregroundTone(bgTone, desiredRatio)
+            }
+
+            if (color.isBackground && 50 <= answer && answer < 60) {
+                // Must adjust
+                if (Contrast.ratioOfTones(49.0, bgTone) >= desiredRatio) {
+                    answer = 49.0
+                } else {
+                    answer = 60.0
+                }
+            }
+
+            if (color.secondBackground == null) {
+                return answer
+            }
+
+            // Case 3: Adjust for dual backgrounds.
+            val bgTone1 = color.background(scheme)?.getTone(scheme) ?: 0.0
+            val bgTone2 = color.secondBackground(scheme)?.getTone(scheme) ?: 0.0
+
+            val upper: Double = max(bgTone1, bgTone2)
+            val lower: Double = min(bgTone1, bgTone2)
+
+            if (Contrast.ratioOfTones(upper, answer) >= desiredRatio
+                && Contrast.ratioOfTones(lower, answer) >= desiredRatio
+            ) {
+                return answer
+            }
+
+            // The darkest light tone that satisfies the desired ratio,
+            // or -1 if such ratio cannot be reached.
+            val lightOption: Double = Contrast.lighter(upper, desiredRatio)
+
+            // The lightest dark tone that satisfies the desired ratio,
+            // or -1 if such ratio cannot be reached.
+            val darkOption: Double = Contrast.darker(lower, desiredRatio)
+
+            // Tones suitable for the foreground.
+            val availables = mutableListOf<Double>()
+            if (lightOption != -1.0) {
+                availables.add(lightOption)
+            }
+            if (darkOption != -1.0) {
+                availables.add(darkOption)
+            }
+
+            val prefersLight =
+                DynamicColor.tonePrefersLightForeground(bgTone1)
+                    || DynamicColor.tonePrefersLightForeground(bgTone2)
+
+            if (prefersLight) {
+                return if (lightOption == -1.0) 100.0 else lightOption
+            }
+
+            if (availables.size == 1) {
+                return availables.first()
+            }
+            return if (darkOption == -1.0) 0.0 else darkOption
+        }
+    }
+
+    // Scheme Palettes
+
+    public override fun getPrimaryPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: Platform,
+        contrastLevel: Double
+    ): TonalPalette = when (variant) {
+        Variant.CONTENT,
+        Variant.FIDELITY -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = sourceColorHct.chroma,
+        )
+        Variant.FRUIT_SALAD -> TonalPalette.fromHueAndChroma(
+            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue - 50.0),
+            chroma = 48.0,
+        )
+        Variant.MONOCHROME -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
+        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 12.0)
+        Variant.RAINBOW -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 48.0)
+        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 36.0)
+        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 240),
+            chroma = 40.0,
+        )
+        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 200.0)
+    }
+
+    public override fun getSecondaryPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: Platform,
+        contrastLevel: Double
+    ): TonalPalette {
+        when (variant) {
+            Variant.CONTENT, Variant.FIDELITY -> return TonalPalette.fromHueAndChroma(
+                sourceColorHct.hue,
+                max(sourceColorHct.chroma - 32.0, sourceColorHct.chroma * 0.5),
+            )
+
+            Variant.FRUIT_SALAD -> return TonalPalette.fromHueAndChroma(
+                MathUtils.sanitizeDegrees(sourceColorHct.hue - 50.0), 36.0,
+            )
+
+            Variant.MONOCHROME -> return TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
+            Variant.NEUTRAL -> return TonalPalette.fromHueAndChroma(sourceColorHct.hue, 8.0)
+            Variant.RAINBOW -> return TonalPalette.fromHueAndChroma(sourceColorHct.hue, 16.0)
+            Variant.TONAL_SPOT -> return TonalPalette.fromHueAndChroma(
+                sourceColorHct.hue,
+                16.0,
+            )
+
+            Variant.EXPRESSIVE -> return TonalPalette.fromHueAndChroma(
+                DynamicScheme.getRotatedHue(
+                    sourceColorHct,
+                    doubleArrayOf(0.0, 21.0, 51.0, 121.0, 151.0, 191.0, 271.0, 321.0, 360.0),
+                    doubleArrayOf(45.0, 95.0, 45.0, 20.0, 45.0, 90.0, 45.0, 45.0, 45.0),
+                ),
+                24.0,
+            )
+
+            Variant.VIBRANT -> return TonalPalette.fromHueAndChroma(
+                DynamicScheme.getRotatedHue(
+                    sourceColorHct,
+                    doubleArrayOf(0.0, 41.0, 61.0, 101.0, 131.0, 181.0, 251.0, 301.0, 360.0),
+                    doubleArrayOf(18.0, 15.0, 10.0, 12.0, 15.0, 18.0, 15.0, 12.0, 12.0),
+                ),
+                24.0,
+            )
+        }
+    }
+
+    public override fun getTertiaryPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: Platform,
+        contrastLevel: Double
+    ): TonalPalette = when (variant) {
+        Variant.CONTENT -> TonalPalette.fromHct(
+            DislikeAnalyzer.fixIfDisliked(
+                TemperatureCache(sourceColorHct).getAnalogousColors(count = 3, divisions = 6)[2],
+            ),
+        )
+        Variant.FIDELITY -> TonalPalette.fromHct(
+            DislikeAnalyzer.fixIfDisliked(TemperatureCache(sourceColorHct).complement),
+        )
+        Variant.FRUIT_SALAD -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = 36.0,
+        )
+        Variant.MONOCHROME -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
+        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 16.0)
+        Variant.RAINBOW, Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
+            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 60.0),
+            chroma = 24.0,
+        )
+        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+            hue = DynamicScheme.getRotatedHue(
+                sourceColorHct = sourceColorHct,
+                hueBreakpoints = doubleArrayOf(0.0, 21.0, 51.0, 121.0, 151.0, 191.0, 271.0, 321.0, 360.0),
+                rotations = doubleArrayOf(120.0, 120.0, 20.0, 45.0, 20.0, 15.0, 20.0, 120.0, 120.0),
+            ),
+            chroma = 32.0,
+        )
+
+        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
+            hue = DynamicScheme.getRotatedHue(
+                sourceColorHct = sourceColorHct,
+                hueBreakpoints = doubleArrayOf(0.0, 41.0, 61.0, 101.0, 131.0, 181.0, 251.0, 301.0, 360.0),
+                rotations = doubleArrayOf(35.0, 30.0, 20.0, 25.0, 30.0, 35.0, 30.0, 25.0, 25.0),
+            ),
+            chroma = 32.0,
+        )
+    }
+
+    public override fun getNeutralPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: Platform,
+        contrastLevel: Double
+    ): TonalPalette = when (variant) {
+        Variant.CONTENT, Variant.FIDELITY -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = sourceColorHct.chroma / 8.0,
+        )
+        Variant.FRUIT_SALAD -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 10.0)
+        Variant.MONOCHROME -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
+        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 2.0)
+        Variant.RAINBOW -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
+        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 6.0)
+        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 15),
+            chroma = 8.0,
+        )
+        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 10.0)
+    }
+
+    public override fun getNeutralVariantPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: Platform,
+        contrastLevel: Double
+    ): TonalPalette = when (variant) {
+        Variant.CONTENT -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = (sourceColorHct.chroma / 8.0) + 4.0,
+        )
+        Variant.FIDELITY -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = (sourceColorHct.chroma / 8.0) + 4.0,
+        )
+        Variant.FRUIT_SALAD -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 16.0)
+        Variant.MONOCHROME -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
+        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 2.0)
+        Variant.RAINBOW -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 0.0)
+        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 8.0)
+        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 15),
+            chroma = 12.0,
+        )
+        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 12.0)
+    }
+
+    public override fun getErrorPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: Platform,
+        contrastLevel: Double
+    ): TonalPalette? = when (variant) {
+        Variant.CONTENT,
+        Variant.FIDELITY,
+        Variant.FRUIT_SALAD,
+        Variant.MONOCHROME,
+        Variant.NEUTRAL,
+        Variant.RAINBOW,
+        Variant.TONAL_SPOT,
+        Variant.EXPRESSIVE,
+        Variant.VIBRANT -> null
+    }
+
+    public companion object {
+        private fun isMonochrome(scheme: DynamicScheme): Boolean = scheme.variant == Variant.MONOCHROME
+
+        private fun findDesiredChromaByTone(
+            hue: Double,
+            chroma: Double,
+            tone: Double,
+            byDecreasingTone: Boolean,
+        ): Double {
+            var answer = tone
+
+            var closestToChroma: Hct = Hct.from(hue, chroma, tone)
+            if (closestToChroma.chroma < chroma) {
+                var chromaPeak: Double = closestToChroma.chroma
+                while (closestToChroma.chroma < chroma) {
+                    answer += if (byDecreasingTone) -1.0 else 1.0
+                    val potentialSolution: Hct = Hct.from(hue, chroma, answer)
+                    if (chromaPeak > potentialSolution.chroma) {
+                        break
+                    }
+                    if (abs(potentialSolution.chroma - chroma) < 0.4) {
+                        break
+                    }
+
+                    val potentialDelta: Double = abs(potentialSolution.chroma - chroma)
+                    val currentDelta: Double = abs(closestToChroma.chroma - chroma)
+                    if (potentialDelta < currentDelta) {
+                        closestToChroma = potentialSolution
+                    }
+                    chromaPeak = max(chromaPeak, potentialSolution.chroma)
+                }
+            }
+
+            return answer
+        }
+    }
+}

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2025.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2025.kt
@@ -1,0 +1,2136 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.materialkolor.dynamiccolor
+
+import com.materialkolor.contrast.Contrast
+import com.materialkolor.dynamiccolor.ToneDeltaPair.DeltaConstraint
+import com.materialkolor.hct.Hct
+import com.materialkolor.palettes.TonalPalette
+import com.materialkolor.scheme.DynamicScheme
+import com.materialkolor.scheme.DynamicScheme.Platform
+import com.materialkolor.scheme.Variant
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * [ColorSpec] implementation for the 2025 spec.
+ */
+public class ColorSpec2025 : ColorSpec2021() {
+    // Surfaces [S]
+    public override fun background(): DynamicColor {
+        // Remapped to surface for 2025 spec.
+        val color2025 = surface().toBuilder().setName("background").build()
+        return super.background().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onBackground(): DynamicColor {
+        // Remapped to onSurface for 2025 spec.
+        val color2025 = onSurface().toBuilder().setName("on_background").build()
+        return super.onBackground().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun surface(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("surface")
+                .setPalette({ s -> s.neutralPalette })
+                .setTone(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.isDark) {
+                                return@setTone 4.0
+                            } else {
+                                if (s.neutralPalette.keyColor.isYellow()) {
+                                    return@setTone 99.0
+                                } else if (s.variant === Variant.VIBRANT) {
+                                    return@setTone 97.0
+                                } else {
+                                    return@setTone 98.0
+                                }
+                            }
+                        } else {
+                            return@setTone 0.0
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .build()
+        return super.surface().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025).build()
+    }
+
+    public override fun surfaceDim(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("surface_dim")
+                .setPalette({ s -> s.neutralPalette })
+                .setTone(
+                    { s ->
+                        if (s.isDark) {
+                            return@setTone 4.0
+                        } else {
+                            if (s.neutralPalette.keyColor.isYellow()) {
+                                return@setTone 90.0
+                            } else if (s.variant === Variant.VIBRANT) {
+                                return@setTone 85.0
+                            } else {
+                                return@setTone 87.0
+                            }
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setChromaMultiplier(
+                    { s ->
+                        if (!s.isDark) {
+                            if (s.variant === Variant.NEUTRAL) {
+                                return@setChromaMultiplier 2.5
+                            } else if (s.variant === Variant.TONAL_SPOT) {
+                                return@setChromaMultiplier 1.7
+                            } else if (s.variant === Variant.EXPRESSIVE) {
+                                return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                        .isYellow()
+                                ) 2.7 else 1.75
+                            } else if (s.variant === Variant.VIBRANT) {
+                                return@setChromaMultiplier 1.36
+                            }
+                        }
+                        1.0
+                    },
+                )
+                .build()
+        return super.surfaceDim().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun surfaceBright(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("surface_bright")
+                .setPalette({ s -> s.neutralPalette })
+                .setTone(
+                    { s ->
+                        if (s.isDark) {
+                            return@setTone 18.0
+                        } else {
+                            if (s.neutralPalette.keyColor.isYellow()) {
+                                return@setTone 99.0
+                            } else if (s.variant === Variant.VIBRANT) {
+                                return@setTone 97.0
+                            } else {
+                                return@setTone 98.0
+                            }
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setChromaMultiplier(
+                    { s ->
+                        if (s.isDark) {
+                            if (s.variant === Variant.NEUTRAL) {
+                                return@setChromaMultiplier 2.5
+                            } else if (s.variant === Variant.TONAL_SPOT) {
+                                return@setChromaMultiplier 1.7
+                            } else if (s.variant === Variant.EXPRESSIVE) {
+                                return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                        .isYellow()
+                                ) 2.7 else 1.75
+                            } else if (s.variant === Variant.VIBRANT) {
+                                return@setChromaMultiplier 1.36
+                            }
+                        }
+                        1.0
+                    },
+                )
+                .build()
+        return super.surfaceBright().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun surfaceContainerLowest(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("surface_container_lowest")
+                .setPalette({ s -> s.neutralPalette })
+                .setTone({ s -> if (s.isDark) 0.0 else 100.0 })
+                .setIsBackground(true)
+                .build()
+        return super.surfaceContainerLowest().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun surfaceContainerLow(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("surface_container_low")
+                .setPalette({ s -> s.neutralPalette })
+                .setTone(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.isDark) {
+                                return@setTone 6.0
+                            } else {
+                                if (s.neutralPalette.keyColor.isYellow()) {
+                                    return@setTone 98.0
+                                } else if (s.variant === Variant.VIBRANT) {
+                                    return@setTone 95.0
+                                } else {
+                                    return@setTone 96.0
+                                }
+                            }
+                        } else {
+                            return@setTone 15.0
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setChromaMultiplier(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.variant === Variant.NEUTRAL) {
+                                return@setChromaMultiplier 1.3
+                            } else if (s.variant === Variant.TONAL_SPOT) {
+                                return@setChromaMultiplier 1.25
+                            } else if (s.variant === Variant.EXPRESSIVE) {
+                                return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                        .isYellow()
+                                ) 1.3 else 1.15
+                            } else if (s.variant === Variant.VIBRANT) {
+                                return@setChromaMultiplier 1.08
+                            }
+                        }
+                        1.0
+                    },
+                )
+                .build()
+        return super.surfaceContainerLow().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun surfaceContainer(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("surface_container")
+                .setPalette({ s -> s.neutralPalette })
+                .setTone(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.isDark) {
+                                return@setTone 9.0
+                            } else {
+                                if (s.neutralPalette.keyColor.isYellow()) {
+                                    return@setTone 96.0
+                                } else if (s.variant === Variant.VIBRANT) {
+                                    return@setTone 92.0
+                                } else {
+                                    return@setTone 94.0
+                                }
+                            }
+                        } else {
+                            return@setTone 20.0
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setChromaMultiplier(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.variant === Variant.NEUTRAL) {
+                                return@setChromaMultiplier 1.6
+                            } else if (s.variant === Variant.TONAL_SPOT) {
+                                return@setChromaMultiplier 1.4
+                            } else if (s.variant === Variant.EXPRESSIVE) {
+                                return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                        .isYellow()
+                                ) 1.6 else 1.3
+                            } else if (s.variant === Variant.VIBRANT) {
+                                return@setChromaMultiplier 1.15
+                            }
+                        }
+                        1.0
+                    },
+                )
+                .build()
+        return super.surfaceContainer().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun surfaceContainerHigh(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("surface_container_high")
+                .setPalette({ s -> s.neutralPalette })
+                .setTone(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.isDark) {
+                                return@setTone 12.0
+                            } else {
+                                if (s.neutralPalette.keyColor.isYellow()) {
+                                    return@setTone 94.0
+                                } else if (s.variant === Variant.VIBRANT) {
+                                    return@setTone 90.0
+                                } else {
+                                    return@setTone 92.0
+                                }
+                            }
+                        } else {
+                            return@setTone 25.0
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setChromaMultiplier(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.variant === Variant.NEUTRAL) {
+                                return@setChromaMultiplier 1.9
+                            } else if (s.variant === Variant.TONAL_SPOT) {
+                                return@setChromaMultiplier 1.5
+                            } else if (s.variant === Variant.EXPRESSIVE) {
+                                return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                        .isYellow()
+                                ) 1.95 else 1.45
+                            } else if (s.variant === Variant.VIBRANT) {
+                                return@setChromaMultiplier 1.22
+                            }
+                        }
+                        1.0
+                    },
+                )
+                .build()
+        return super.surfaceContainerHigh().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun surfaceContainerHighest(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("surface_container_highest")
+                .setPalette({ s -> s.neutralPalette })
+                .setTone(
+                    { s ->
+                        if (s.isDark) {
+                            return@setTone 15.0
+                        } else {
+                            if (s.neutralPalette.keyColor.isYellow()) {
+                                return@setTone 92.0
+                            } else if (s.variant === Variant.VIBRANT) {
+                                return@setTone 88.0
+                            } else {
+                                return@setTone 90.0
+                            }
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setChromaMultiplier(
+                    { s ->
+                        if (s.variant === Variant.NEUTRAL) {
+                            return@setChromaMultiplier 2.2
+                        } else if (s.variant === Variant.TONAL_SPOT) {
+                            return@setChromaMultiplier 1.7
+                        } else if (s.variant === Variant.EXPRESSIVE) {
+                            return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                    .isYellow()
+                            ) 2.3 else 1.6
+                        } else if (s.variant === Variant.VIBRANT) {
+                            return@setChromaMultiplier 1.29
+                        }
+                        1.0
+                    },
+                )
+                .build()
+        return super.surfaceContainerHighest().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onSurface(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_surface")
+                .setPalette({ s -> s.neutralPalette })
+                .setChromaMultiplier(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.variant === Variant.NEUTRAL) {
+                                return@setChromaMultiplier 2.2
+                            } else if (s.variant === Variant.TONAL_SPOT) {
+                                return@setChromaMultiplier 1.7
+                            } else if (s.variant === Variant.EXPRESSIVE) {
+                                return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                        .isYellow()
+                                ) 2.3 else 1.6
+                            } else if (s.variant === Variant.VIBRANT) {
+                                return@setChromaMultiplier 1.29
+                            }
+                        }
+                        1.0
+                    },
+                )
+                .setBackground(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                        } else {
+                            return@setBackground surfaceContainerHigh()
+                        }
+                    },
+                )
+                .setContrastCurve({ s -> getContrastCurve(9.0) })
+                .build()
+        return super.onSurface().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun surfaceVariant(): DynamicColor {
+        // Remapped to surfaceContainerHighest for 2025 spec.
+        val color2025 =
+            surfaceContainerHighest().toBuilder().setName("surface_variant").build()
+        return super.surfaceVariant().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onSurfaceVariant(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_surface_variant")
+                .setPalette({ s -> s.neutralPalette })
+                .setChromaMultiplier(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.variant === Variant.NEUTRAL) {
+                                return@setChromaMultiplier 2.2
+                            } else if (s.variant === Variant.TONAL_SPOT) {
+                                return@setChromaMultiplier 1.7
+                            } else if (s.variant === Variant.EXPRESSIVE) {
+                                return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                        .isYellow()
+                                ) 2.3 else 1.6
+                            } else if (s.variant === Variant.VIBRANT) {
+                                return@setChromaMultiplier 1.29
+                            }
+                        }
+                        1.0
+                    },
+                )
+                .setBackground(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                        } else {
+                            return@setBackground surfaceContainerHigh()
+                        }
+                    },
+                )
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(4.5) else getContrastCurve(
+                            7.0,
+                        )
+                    },
+                )
+                .build()
+        return super.onSurfaceVariant().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun inverseSurface(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("inverse_surface")
+                .setPalette({ s -> s.neutralPalette })
+                .setTone({ s -> if (s.isDark) 98.0 else 4.0 })
+                .setIsBackground(true)
+                .build()
+        return super.inverseSurface().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun inverseOnSurface(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("inverse_on_surface")
+                .setPalette({ s -> s.neutralPalette })
+                .setBackground({ s -> inverseSurface() })
+                .setContrastCurve({ s -> getContrastCurve(7.0) })
+                .build()
+        return super.inverseOnSurface().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun outline(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("outline")
+                .setPalette({ s -> s.neutralPalette })
+                .setChromaMultiplier(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.variant === Variant.NEUTRAL) {
+                                return@setChromaMultiplier 2.2
+                            } else if (s.variant === Variant.TONAL_SPOT) {
+                                return@setChromaMultiplier 1.7
+                            } else if (s.variant === Variant.EXPRESSIVE) {
+                                return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                        .isYellow()
+                                ) 2.3 else 1.6
+                            } else if (s.variant === Variant.VIBRANT) {
+                                return@setChromaMultiplier 1.29
+                            }
+                        }
+                        1.0
+                    },
+                )
+                .setBackground(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                        } else {
+                            return@setBackground surfaceContainerHigh()
+                        }
+                    },
+                )
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(3.0) else getContrastCurve(
+                            4.5,
+                        )
+                    },
+                )
+                .build()
+        return super.outline().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025).build()
+    }
+
+    public override fun outlineVariant(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("outline_variant")
+                .setPalette({ s -> s.neutralPalette })
+                .setChromaMultiplier(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.variant === Variant.NEUTRAL) {
+                                return@setChromaMultiplier 2.2
+                            } else if (s.variant === Variant.TONAL_SPOT) {
+                                return@setChromaMultiplier 1.7
+                            } else if (s.variant === Variant.EXPRESSIVE) {
+                                return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                        .isYellow()
+                                ) 2.3 else 1.6
+                            } else if (s.variant === Variant.VIBRANT) {
+                                return@setChromaMultiplier 1.29
+                            }
+                        }
+                        1.0
+                    },
+                )
+                .setBackground(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                        } else {
+                            return@setBackground surfaceContainerHigh()
+                        }
+                    },
+                )
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(1.5) else getContrastCurve(
+                            3.0,
+                        )
+                    },
+                )
+                .build()
+        return super.outlineVariant().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun surfaceTint(): DynamicColor {
+        // Remapped to primary for 2025 spec.
+        val color2025 = primary().toBuilder().setName("surface_tint").build()
+        return super.surfaceTint().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    /**///////////////////////////////////////////////////////////// */ // Primaries [P]                                              //
+    /**///////////////////////////////////////////////////////////// */
+
+    public override fun primary(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("primary")
+                .setPalette({ s -> s.primaryPalette })
+                .setTone(
+                    { s ->
+                        if (s.variant === Variant.NEUTRAL) {
+                            if (s.platform === Platform.PHONE) {
+                                return@setTone if (s.isDark) 80.0 else 40.0
+                            } else {
+                                return@setTone 90.0
+                            }
+                        } else if (s.variant === Variant.TONAL_SPOT) {
+                            if (s.platform === Platform.PHONE) {
+                                if (s.isDark) {
+                                    return@setTone 80.0
+                                } else {
+                                    return@setTone tMaxC(s.primaryPalette)
+                                }
+                            } else {
+                                return@setTone tMaxC(s.primaryPalette, 0.0, 90.0)
+                            }
+                        } else if (s.variant === Variant.EXPRESSIVE) {
+                            return@setTone tMaxC(
+                                s.primaryPalette,
+                                0.0,
+                                (if (s.primaryPalette.keyColor.isYellow())
+                                    25
+                                else
+                                    if (s.primaryPalette.keyColor
+                                            .isCyan()
+                                    ) 88 else 98).toDouble(),
+                            )
+                        } else { // VIBRANT
+                            return@setTone tMaxC(
+                                s.primaryPalette,
+                                0.0,
+                                (if (s.primaryPalette.keyColor.isCyan()) 88 else 98).toDouble(),
+                            )
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setBackground(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                        } else {
+                            return@setBackground surfaceContainerHigh()
+                        }
+                    },
+                )
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(4.5) else getContrastCurve(
+                            7.0,
+                        )
+                    },
+                )
+                .setToneDeltaPair(
+                    { s ->
+                        if (s.platform === Platform.PHONE)
+                            ToneDeltaPair(
+                                roleA = primaryContainer(),
+                                roleB = primary(),
+                                delta = 5.0,
+                                polarity = TonePolarity.RELATIVE_LIGHTER,
+                                deltaConstraint = DeltaConstraint.FARTHER,
+                            )
+                        else
+                            null
+                    },
+                )
+                .build()
+
+        return super.primary().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun primaryDim(): DynamicColor = DynamicColor.Companion.Builder()
+        .setName("primary_dim")
+        .setPalette({ s -> s.primaryPalette })
+        .setTone { s ->
+            when {
+                s.variant === Variant.NEUTRAL -> 85.0
+                s.variant === Variant.TONAL_SPOT -> tMaxC(s.primaryPalette, 0.0, 90.0)
+                else -> tMaxC(s.primaryPalette)
+            }
+        }
+        .setIsBackground(true)
+        .setBackground({ s -> surfaceContainerHigh() })
+        .setContrastCurve({ s -> getContrastCurve(4.5) })
+        .setToneDeltaPair(
+            { s ->
+                ToneDeltaPair(
+                    roleA = primaryDim(),
+                    roleB = primary(),
+                    delta = 5.0,
+                    polarity = TonePolarity.DARKER,
+                    deltaConstraint = DeltaConstraint.FARTHER,
+                )
+            },
+        )
+        .build()
+
+    public override fun onPrimary(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_primary")
+                .setPalette({ s -> s.primaryPalette })
+                .setBackground({ s -> if (s.platform === Platform.PHONE) primary() else primaryDim() })
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
+                        else getContrastCurve(7.0)
+                    },
+                )
+                .build()
+        return super.onPrimary().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun primaryContainer(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("primary_container")
+                .setPalette({ s -> s.primaryPalette })
+                .setTone(
+                    { s ->
+                        if (s.platform === Platform.WATCH) {
+                            return@setTone 30.0
+                        } else if (s.variant === Variant.NEUTRAL) {
+                            return@setTone if (s.isDark) 30.0 else 90.0
+                        } else if (s.variant === Variant.TONAL_SPOT) {
+                            return@setTone if (s.isDark)
+                                tMinC(s.primaryPalette, 35.0, 93.0)
+                            else
+                                tMaxC(s.primaryPalette, 0.0, 90.0)
+                        } else if (s.variant === Variant.EXPRESSIVE) {
+                            return@setTone if (s.isDark)
+                                tMaxC(s.primaryPalette, 30.0, 93.0)
+                            else
+                                tMaxC(
+                                    s.primaryPalette,
+                                    78.0,
+                                    (if (s.primaryPalette.keyColor
+                                            .isCyan()
+                                    ) 88 else 90).toDouble(),
+                                )
+                        } else { // VIBRANT
+                            return@setTone if (s.isDark)
+                                tMinC(s.primaryPalette, 66.0, 93.0)
+                            else
+                                tMaxC(
+                                    s.primaryPalette,
+                                    66.0,
+                                    (if (s.primaryPalette.keyColor
+                                            .isCyan()
+                                    ) 88 else 93).toDouble(),
+                                )
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setBackground(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                        } else {
+                            return@setBackground null
+                        }
+                    },
+                )
+                .setToneDeltaPair(
+                    { s ->
+                        if (s.platform === Platform.WATCH)
+                            ToneDeltaPair(
+                                roleA = primaryContainer(),
+                                roleB = primaryDim(),
+                                delta = 10.0,
+                                polarity = TonePolarity.DARKER,
+                                deltaConstraint = DeltaConstraint.FARTHER,
+                            )
+                        else null
+                    },
+                )
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE && s.contrastLevel > 0) getContrastCurve(1.5)
+                        else null
+                    },
+                )
+                .build()
+        return super.primaryContainer().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onPrimaryContainer(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_primary_container")
+                .setPalette({ s -> s.primaryPalette })
+                .setBackground({ s -> primaryContainer() })
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
+                        else getContrastCurve(7.0)
+                    },
+                )
+                .build()
+        return super.onPrimaryContainer().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun inversePrimary(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("inverse_primary")
+                .setPalette({ s -> s.primaryPalette })
+                .setTone({ s -> tMaxC(s.primaryPalette) })
+                .setBackground({ s -> inverseSurface() })
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
+                        else getContrastCurve(7.0)
+                    },
+                )
+                .build()
+        return super.inversePrimary().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    // Secondaries [Q]
+
+    public override fun secondary(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("secondary")
+                .setPalette({ s -> s.secondaryPalette })
+                .setTone(
+                    { s ->
+                        when {
+                            s.platform === Platform.WATCH -> {
+                                if (s.variant === Variant.NEUTRAL) 90.0 else tMaxC(
+                                    palette = s.secondaryPalette,
+                                    lowerBound = 0.0,
+                                    upperBound = 90.0,
+                                )
+                            }
+                            s.variant === Variant.NEUTRAL -> {
+                                if (s.isDark) tMinC(
+                                    palette = s.secondaryPalette,
+                                    lowerBound = 0.0,
+                                    upperBound = 98.0,
+                                ) else tMaxC(s.secondaryPalette)
+                            }
+                            s.variant === Variant.VIBRANT -> {
+                                tMaxC(
+                                    palette = s.secondaryPalette,
+                                    lowerBound = 0.0,
+                                    upperBound = (if (s.isDark) 90 else 98).toDouble(),
+                                )
+                            }
+                            else -> { // EXPRESSIVE and TONAL_SPOT
+                                if (s.isDark) 80.0 else tMaxC(s.secondaryPalette)
+                            }
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setBackground(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.isDark) surfaceBright() else surfaceDim()
+                        } else {
+                            surfaceContainerHigh()
+                        }
+                    },
+                )
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(4.5)
+                        else getContrastCurve(7.0)
+                    },
+                )
+                .setToneDeltaPair(
+                    { s ->
+                        if (s.platform === Platform.PHONE)
+                            ToneDeltaPair(
+                                roleA = secondaryContainer(),
+                                roleB = secondary(),
+                                delta = 5.0,
+                                polarity = TonePolarity.RELATIVE_LIGHTER,
+                                deltaConstraint = DeltaConstraint.FARTHER,
+                            )
+                        else null
+                    },
+                )
+                .build()
+        return super.secondary().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun secondaryDim(): DynamicColor {
+        return DynamicColor.Companion.Builder()
+            .setName("secondary_dim")
+            .setPalette({ s -> s.secondaryPalette })
+            .setTone(
+                { s ->
+                    if (s.variant === Variant.NEUTRAL) {
+                        85.0
+                    } else {
+                        tMaxC(s.secondaryPalette, 0.0, 90.0)
+                    }
+                },
+            )
+            .setIsBackground(true)
+            .setBackground({ s -> surfaceContainerHigh() })
+            .setContrastCurve({ s -> getContrastCurve(4.5) })
+            .setToneDeltaPair(
+                { s ->
+                    ToneDeltaPair(
+                        roleA = secondaryDim(),
+                        roleB = secondary(),
+                        delta = 5.0,
+                        polarity = TonePolarity.DARKER,
+                        deltaConstraint = DeltaConstraint.FARTHER,
+                    )
+                },
+            )
+            .build()
+    }
+
+    public override fun onSecondary(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_secondary")
+                .setPalette({ s -> s.secondaryPalette })
+                .setBackground({ s -> if (s.platform === Platform.PHONE) secondary() else secondaryDim() })
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
+                        else getContrastCurve(7.0)
+                    },
+                )
+                .build()
+        return super.onSecondary().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun secondaryContainer(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("secondary_container")
+                .setPalette({ s -> s.secondaryPalette })
+                .setTone(
+                    { s ->
+                        when {
+                            s.platform === Platform.WATCH -> 30.0
+                            s.variant === Variant.VIBRANT -> {
+                                if (s.isDark) tMinC(s.secondaryPalette, 30.0, 40.0)
+                                else tMaxC(s.secondaryPalette, 84.0, 90.0)
+                            }
+                            s.variant === Variant.EXPRESSIVE -> {
+                                if (s.isDark) 15.0 else tMaxC(s.secondaryPalette, 90.0, 95.0)
+                            }
+                            else -> if (s.isDark) 25.0 else 90.0
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setBackground(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.isDark) surfaceBright() else surfaceDim()
+                        } else {
+                            null
+                        }
+                    },
+                )
+                .setToneDeltaPair(
+                    { s ->
+                        if (s.platform === Platform.WATCH)
+                            ToneDeltaPair(
+                                roleA = secondaryContainer(),
+                                roleB = secondaryDim(),
+                                delta = 10.0,
+                                polarity = TonePolarity.DARKER,
+                                deltaConstraint = DeltaConstraint.FARTHER,
+                            )
+                        else null
+                    },
+                )
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE && s.contrastLevel > 0) getContrastCurve(1.5)
+                        else null
+                    },
+                )
+                .build()
+        return super.secondaryContainer().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onSecondaryContainer(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_secondary_container")
+                .setPalette({ s -> s.secondaryPalette })
+                .setBackground({ s -> secondaryContainer() })
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
+                        else getContrastCurve(7.0)
+                    },
+                )
+                .build()
+        return super.onSecondaryContainer().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    // Tertiaries [T]
+
+    public override fun tertiary(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("tertiary")
+                .setPalette({ s -> s.tertiaryPalette })
+                .setTone(
+                    { s ->
+                        if (s.platform === Platform.WATCH) {
+                            if (s.variant === Variant.TONAL_SPOT)
+                                tMaxC(s.tertiaryPalette, 0.0, 90.0)
+                            else
+                                tMaxC(s.tertiaryPalette)
+                        } else if (s.variant === Variant.EXPRESSIVE || s.variant === Variant.VIBRANT) {
+                            val upperBound = if (s.tertiaryPalette.keyColor.isCyan()) 88
+                            else {
+                                if (s.isDark) 98 else 100
+                            }
+                            tMaxC(
+                                palette = s.tertiaryPalette,
+                                lowerBound = 0.0,
+                                upperBound = upperBound.toDouble(),
+                            )
+                        } else { // NEUTRAL and TONAL_SPOT
+                            if (s.isDark) tMaxC(
+                                palette = s.tertiaryPalette,
+                                lowerBound = 0.0,
+                                upperBound = 98.0,
+                            ) else tMaxC(s.tertiaryPalette)
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setBackground(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.isDark) surfaceBright() else surfaceDim()
+                        } else {
+                            surfaceContainerHigh()
+                        }
+                    },
+                )
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(4.5)
+                        else getContrastCurve(7.0)
+                    },
+                )
+                .setToneDeltaPair(
+                    { s ->
+                        if (s.platform === Platform.PHONE)
+                            ToneDeltaPair(
+                                roleA = tertiaryContainer(),
+                                roleB = tertiary(),
+                                delta = 5.0,
+                                polarity = TonePolarity.RELATIVE_LIGHTER,
+                                deltaConstraint = DeltaConstraint.FARTHER,
+                            )
+                        else null
+                    },
+                )
+                .build()
+        return super.tertiary().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun tertiaryDim(): DynamicColor {
+        return DynamicColor.Companion.Builder()
+            .setName("tertiary_dim")
+            .setPalette({ s -> s.tertiaryPalette })
+            .setTone(
+                { s ->
+                    if (s.variant === Variant.TONAL_SPOT) {
+                        tMaxC(s.tertiaryPalette, 0.0, 90.0)
+                    } else {
+                        tMaxC(s.tertiaryPalette)
+                    }
+                },
+            )
+            .setIsBackground(true)
+            .setBackground({ s -> surfaceContainerHigh() })
+            .setContrastCurve({ s -> getContrastCurve(4.5) })
+            .setToneDeltaPair(
+                { s ->
+                    ToneDeltaPair(
+                        roleA = tertiaryDim(),
+                        roleB = tertiary(),
+                        delta = 5.0,
+                        polarity = TonePolarity.DARKER,
+                        deltaConstraint = DeltaConstraint.FARTHER,
+                    )
+                },
+            )
+            .build()
+    }
+
+    public override fun onTertiary(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_tertiary")
+                .setPalette({ s -> s.tertiaryPalette })
+                .setBackground({ s -> if (s.platform === Platform.PHONE) tertiary() else tertiaryDim() })
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
+                        else getContrastCurve(7.0)
+                    },
+                )
+                .build()
+        return super.onTertiary().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun tertiaryContainer(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("tertiary_container")
+                .setPalette({ s -> s.tertiaryPalette })
+                .setTone(
+                    { s ->
+                        if (s.platform === Platform.WATCH) {
+                            if (s.variant === Variant.TONAL_SPOT) tMaxC(s.tertiaryPalette, 0.0, 90.0)
+                            else tMaxC(s.tertiaryPalette)
+                        } else {
+                            when {
+                                s.variant === Variant.NEUTRAL -> {
+                                    if (s.isDark)
+                                        tMaxC(s.tertiaryPalette, 0.0, 93.0)
+                                    else
+                                        tMaxC(s.tertiaryPalette, 0.0, 96.0)
+                                }
+                                s.variant === Variant.TONAL_SPOT -> {
+                                    tMaxC(
+                                        palette = s.tertiaryPalette,
+                                        lowerBound = 0.0,
+                                        upperBound = (if (s.isDark) 93 else 100).toDouble(),
+                                    )
+                                }
+                                s.variant === Variant.EXPRESSIVE -> {
+                                    val upperBound = if (s.tertiaryPalette.keyColor.isCyan()) 88
+                                    else {
+                                        if (s.isDark) 93 else 100
+                                    }
+
+                                    tMaxC(
+                                        palette = s.tertiaryPalette,
+                                        lowerBound = 75.0,
+                                        upperBound = upperBound.toDouble(),
+                                    )
+                                }
+                                else -> { // VIBRANT
+                                    if (s.isDark) tMaxC(s.tertiaryPalette, 0.0, 93.0)
+                                    else tMaxC(s.tertiaryPalette, 72.0, 100.0)
+                                }
+                            }
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setBackground(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                        } else {
+                            return@setBackground null
+                        }
+                    },
+                )
+                .setToneDeltaPair(
+                    { s ->
+                        if (s.platform === Platform.WATCH)
+                            ToneDeltaPair(
+                                roleA = tertiaryContainer(),
+                                roleB = tertiaryDim(),
+                                delta = 10.0,
+                                polarity = TonePolarity.DARKER,
+                                deltaConstraint = DeltaConstraint.FARTHER,
+                            )
+                        else null
+                    },
+                )
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE && s.contrastLevel > 0) getContrastCurve(1.5)
+                        else null
+                    },
+                )
+                .build()
+        return super.tertiaryContainer().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onTertiaryContainer(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_tertiary_container")
+                .setPalette({ s -> s.tertiaryPalette })
+                .setBackground({ s -> tertiaryContainer() })
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
+                        else getContrastCurve(7.0)
+                    },
+                )
+                .build()
+        return super.onTertiaryContainer().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    // Errors [E]
+
+    public override fun error(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("error")
+                .setPalette({ s -> s.errorPalette })
+                .setTone(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.isDark) tMinC(
+                                palette = s.errorPalette,
+                                lowerBound = 0.0,
+                                upperBound = 98.0,
+                            ) else tMaxC(s.errorPalette)
+                        } else {
+                            tMinC(s.errorPalette)
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setBackground(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.isDark) surfaceBright() else surfaceDim()
+                        } else {
+                            surfaceContainerHigh()
+                        }
+                    },
+                )
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(4.5)
+                        else getContrastCurve(7.0)
+                    },
+                )
+                .setToneDeltaPair(
+                    { s ->
+                        if (s.platform === Platform.PHONE)
+                            ToneDeltaPair(
+                                roleA = errorContainer(),
+                                roleB = error(),
+                                delta = 5.0,
+                                polarity = TonePolarity.RELATIVE_LIGHTER,
+                                deltaConstraint = DeltaConstraint.FARTHER,
+                            )
+                        else null
+                    },
+                )
+                .build()
+        return super.error().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun errorDim(): DynamicColor {
+        return DynamicColor.Companion.Builder()
+            .setName("error_dim")
+            .setPalette({ s -> s.errorPalette })
+            .setTone({ s -> tMinC(s.errorPalette) })
+            .setIsBackground(true)
+            .setBackground({ s -> surfaceContainerHigh() })
+            .setContrastCurve({ s -> getContrastCurve(4.5) })
+            .setToneDeltaPair(
+                { s ->
+                    ToneDeltaPair(
+                        roleA = errorDim(),
+                        roleB = error(),
+                        delta = 5.0,
+                        polarity = TonePolarity.DARKER,
+                        deltaConstraint = DeltaConstraint.FARTHER,
+                    )
+                },
+            )
+            .build()
+    }
+
+    public override fun onError(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_error")
+                .setPalette({ s -> s.errorPalette })
+                .setBackground({ s -> if (s.platform === Platform.PHONE) error() else errorDim() })
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
+                        else getContrastCurve(7.0)
+                    },
+                )
+                .build()
+        return super.onError().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun errorContainer(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("error_container")
+                .setPalette({ s -> s.errorPalette })
+                .setTone(
+                    { s ->
+                        if (s.platform === Platform.WATCH) {
+                            30.0
+                        } else {
+                            if (s.isDark) {
+                                tMinC(
+                                    palette = s.errorPalette,
+                                    lowerBound = 30.0,
+                                    upperBound = 93.0,
+                                )
+                            } else {
+                                tMaxC(s.errorPalette, 0.0, 90.0)
+                            }
+                        }
+                    },
+                )
+                .setIsBackground(true)
+                .setBackground(
+                    { s ->
+                        if (s.platform === Platform.PHONE) {
+                            if (s.isDark) surfaceBright() else surfaceDim()
+                        } else {
+                            null
+                        }
+                    },
+                )
+                .setToneDeltaPair(
+                    { s ->
+                        if (s.platform === Platform.WATCH)
+                            ToneDeltaPair(
+                                roleA = errorContainer(),
+                                roleB = errorDim(),
+                                delta = 10.0,
+                                polarity = TonePolarity.DARKER,
+                                deltaConstraint = DeltaConstraint.FARTHER,
+                            )
+                        else null
+                    },
+                )
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE && s.contrastLevel > 0) getContrastCurve(1.5)
+                        else null
+                    },
+                )
+                .build()
+        return super.errorContainer().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onErrorContainer(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_error_container")
+                .setPalette({ s -> s.errorPalette })
+                .setBackground({ s -> errorContainer() })
+                .setContrastCurve(
+                    { s ->
+                        if (s.platform === Platform.PHONE) getContrastCurve(4.5)
+                        else getContrastCurve(7.0)
+                    },
+                )
+                .build()
+        return super.onErrorContainer().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    // Primary Fixed Colors [PF]
+
+    public override fun primaryFixed(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("primary_fixed")
+                .setPalette({ s -> s.primaryPalette })
+                .setTone(
+                    { s ->
+                        val tempS = DynamicScheme.from(s, false)
+                        primaryContainer().getTone(tempS)
+                    },
+                )
+                .setIsBackground(true)
+                .build()
+        return super.primaryFixed().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun primaryFixedDim(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("primary_fixed_dim")
+                .setPalette({ s -> s.primaryPalette })
+                .setTone({ s -> primaryFixed().getTone(s) })
+                .setIsBackground(true)
+                .setToneDeltaPair(
+                    { s ->
+                        ToneDeltaPair(
+                            roleA = primaryFixedDim(),
+                            roleB = primaryFixed(),
+                            delta = 5.0,
+                            polarity = TonePolarity.DARKER,
+                            deltaConstraint = DeltaConstraint.EXACT,
+                        )
+                    },
+                )
+                .build()
+        return super.primaryFixedDim().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onPrimaryFixed(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_primary_fixed")
+                .setPalette({ s -> s.primaryPalette })
+                .setBackground({ s -> primaryFixedDim() })
+                .setContrastCurve({ s -> getContrastCurve(7.0) })
+                .build()
+        return super.onPrimaryFixed().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onPrimaryFixedVariant(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_primary_fixed_variant")
+                .setPalette({ s -> s.primaryPalette })
+                .setBackground({ s -> primaryFixedDim() })
+                .setContrastCurve({ s -> getContrastCurve(4.5) })
+                .build()
+        return super.onPrimaryFixedVariant().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    // Secondary Fixed Colors [QF]
+
+    public override fun secondaryFixed(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("secondary_fixed")
+                .setPalette({ s -> s.secondaryPalette })
+                .setTone(
+                    { s ->
+                        val tempS: DynamicScheme = DynamicScheme.from(s, isDark = false)
+                        secondaryContainer().getTone(tempS)
+                    },
+                )
+                .setIsBackground(true)
+                .build()
+        return super.secondaryFixed().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun secondaryFixedDim(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("secondary_fixed_dim")
+                .setPalette({ s -> s.secondaryPalette })
+                .setTone({ s -> secondaryFixed().getTone(s) })
+                .setIsBackground(true)
+                .setToneDeltaPair(
+                    { s ->
+                        ToneDeltaPair(
+                            roleA = secondaryFixedDim(),
+                            roleB = secondaryFixed(),
+                            delta = 5.0,
+                            polarity = TonePolarity.DARKER,
+                            deltaConstraint = DeltaConstraint.EXACT,
+                        )
+                    },
+                )
+                .build()
+        return super.secondaryFixedDim().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onSecondaryFixed(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_secondary_fixed")
+                .setPalette({ s -> s.secondaryPalette })
+                .setBackground({ s -> secondaryFixedDim() })
+                .setContrastCurve({ s -> getContrastCurve(7.0) })
+                .build()
+        return super.onSecondaryFixed().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onSecondaryFixedVariant(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_secondary_fixed_variant")
+                .setPalette({ s -> s.secondaryPalette })
+                .setBackground({ s -> secondaryFixedDim() })
+                .setContrastCurve({ s -> getContrastCurve(4.5) })
+                .build()
+        return super.onSecondaryFixedVariant().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    // Tertiary Fixed Colors [TF]
+
+    public override fun tertiaryFixed(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("tertiary_fixed")
+                .setPalette({ s -> s.tertiaryPalette })
+                .setTone(
+                    { s ->
+                        val tempS = DynamicScheme.from(s, isDark = false)
+                        tertiaryContainer().getTone(tempS)
+                    },
+                )
+                .setIsBackground(true)
+                .build()
+        return super.tertiaryFixed().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun tertiaryFixedDim(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("tertiary_fixed_dim")
+                .setPalette({ s -> s.tertiaryPalette })
+                .setTone({ s -> tertiaryFixed().getTone(s) })
+                .setIsBackground(true)
+                .setToneDeltaPair(
+                    { s ->
+                        ToneDeltaPair(
+                            roleA = tertiaryFixedDim(),
+                            roleB = tertiaryFixed(),
+                            delta = 5.0,
+                            polarity = TonePolarity.DARKER,
+                            deltaConstraint = DeltaConstraint.EXACT,
+                        )
+                    },
+                )
+                .build()
+        return super.tertiaryFixedDim().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onTertiaryFixed(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_tertiary_fixed")
+                .setPalette({ s -> s.tertiaryPalette })
+                .setBackground({ s -> tertiaryFixedDim() })
+                .setContrastCurve({ s -> getContrastCurve(7.0) })
+                .build()
+        return super.onTertiaryFixed().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onTertiaryFixedVariant(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion.Builder()
+                .setName("on_tertiary_fixed_variant")
+                .setPalette({ s -> s.tertiaryPalette })
+                .setBackground({ s -> tertiaryFixedDim() })
+                .setContrastCurve({ s -> getContrastCurve(4.5) })
+                .build()
+        return super.onTertiaryFixedVariant().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    // Android-only Colors
+
+    public override fun controlActivated(): DynamicColor {
+        // Remapped to primaryContainer for 2025 spec.
+        val color2025 = primaryContainer().toBuilder().setName("control_activated").build()
+        return super.controlActivated().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun controlNormal(): DynamicColor {
+        // Remapped to onSurfaceVariant for 2025 spec.
+        val color2025 = onSurfaceVariant().toBuilder().setName("control_normal").build()
+        return super.controlNormal().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun textPrimaryInverse(): DynamicColor {
+        // Remapped to inverseOnSurface for 2025 spec.
+        val color2025 = inverseOnSurface().toBuilder().setName("text_primary_inverse").build()
+        return super.textPrimaryInverse().toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    // Color value calculations
+
+    public override fun getHct(scheme: DynamicScheme, color: DynamicColor): Hct {
+        // This is crucial for aesthetics: we aren't simply the taking the standard color
+        // and changing its tone for contrast. Rather, we find the tone for contrast, then
+        // use the specified chroma from the palette to construct a new color.
+        //
+        // For example, this enables colors with standard tone of T90, which has limited chroma, to
+        // "recover" intended chroma as contrast increases.
+        val palette: TonalPalette = color.palette(scheme)
+        val tone = getTone(scheme, color)
+        val hue: Double = palette.hue
+        val chromaMultiplier = if (color.chromaMultiplier == null) 1 else color.chromaMultiplier(scheme)
+        val chroma: Double = palette.chroma * (chromaMultiplier?.toDouble() ?: 1.0)
+
+        return Hct.from(hue, chroma, tone)
+    }
+
+    public override fun getTone(scheme: DynamicScheme, color: DynamicColor): Double {
+        val toneDeltaPair: ToneDeltaPair? =
+            if (color.toneDeltaPair == null) null else color.toneDeltaPair(scheme)
+
+        // Case 0: tone delta pair.
+        if (toneDeltaPair != null) {
+            val roleA = toneDeltaPair.roleA
+            val roleB = toneDeltaPair.roleB
+            val polarity = toneDeltaPair.polarity
+            val constraint: DeltaConstraint = toneDeltaPair.deltaConstraint
+            val absoluteDelta =
+                if (polarity == TonePolarity.DARKER || (polarity == TonePolarity.RELATIVE_LIGHTER && scheme.isDark)
+                    || (polarity == TonePolarity.RELATIVE_DARKER && !scheme.isDark)
+                ) -toneDeltaPair.delta
+                else toneDeltaPair.delta
+
+            val amRoleA = color.name.equals(roleA.name)
+            val selfRole = if (amRoleA) roleA else roleB
+            val referenceRole = if (amRoleA) roleB else roleA
+            var selfTone: Double = selfRole.tone(scheme)
+            val referenceTone = referenceRole.getTone(scheme)
+            val relativeDelta = absoluteDelta * (if (amRoleA) 1 else -1)
+
+            when (constraint) {
+                DeltaConstraint.EXACT -> selfTone = (referenceTone + relativeDelta).coerceIn(0.0, 100.0)
+                DeltaConstraint.NEARER -> if (relativeDelta > 0) {
+                    val t = selfTone.coerceIn(referenceTone, referenceTone + relativeDelta)
+                    selfTone = t.coerceIn(0.0, 100.0)
+                } else {
+                    val t = selfTone.coerceIn(referenceTone + relativeDelta, referenceTone)
+                    selfTone = t.coerceIn(0.0, 100.0)
+                }
+
+                DeltaConstraint.FARTHER -> if (relativeDelta > 0) {
+                    selfTone = selfTone.coerceIn(referenceTone + relativeDelta, 100.0)
+                } else {
+                    selfTone = selfTone.coerceIn(0.0, referenceTone + relativeDelta)
+                }
+            }
+
+            if (color.background != null && color.contrastCurve != null) {
+                val background = color.background(scheme)
+                val contrastCurve: ContrastCurve? = color.contrastCurve(scheme)
+                if (background != null && contrastCurve != null) {
+                    val bgTone = background.getTone(scheme)
+                    val selfContrast = contrastCurve.get(scheme.contrastLevel)
+                    val ratioOfTones = Contrast.ratioOfTones(tone1 = bgTone, tone2 = selfTone)
+                    selfTone =
+                        if (ratioOfTones >= selfContrast && scheme.contrastLevel >= 0) selfTone
+                        else DynamicColor.foregroundTone(bgTone, selfContrast)
+                }
+            }
+
+            // This can avoid the awkward tones for background colors including the access fixed colors.
+            // Accent fixed dim colors should not be adjusted.
+            if (color.isBackground && !color.name.endsWith("_fixed_dim")) {
+                if (selfTone >= 57) {
+                    selfTone = selfTone.coerceIn(65.0, 100.0)
+                } else {
+                    selfTone = selfTone.coerceIn(0.0, 49.0)
+                }
+            }
+
+            return selfTone
+        } else {
+            // Case 1: No tone delta pair; just solve for itself.
+            var answer: Double = color.tone(scheme)
+
+            if (
+                color.background == null || color.background(scheme) == null ||
+                color.contrastCurve == null || color.contrastCurve(scheme) == null
+            ) {
+                return answer // No adjustment for colors with no background.
+            }
+
+            val bgTone = color.background(scheme)?.getTone(scheme) ?: 0.0
+            val desiredRatio = color.contrastCurve(scheme)?.get(scheme.contrastLevel) ?: 0.0
+
+            // Recalculate the tone from desired contrast ratio if the current
+            // contrast ratio is not enough or desired contrast level is decreasing
+            // (<0).
+            val ratioOfTones = Contrast.ratioOfTones(tone1 = bgTone, tone2 = answer)
+            answer =
+                if (ratioOfTones >= desiredRatio && scheme.contrastLevel >= 0) answer
+                else DynamicColor.foregroundTone(bgTone, desiredRatio)
+
+            // This can avoid the awkward tones for background colors including the access fixed colors.
+            // Accent fixed dim colors should not be adjusted.
+            if (color.isBackground && !color.name.endsWith("_fixed_dim")) {
+                if (answer >= 57) {
+                    answer = answer.coerceIn(65.0, 100.0)
+                } else {
+                    answer = answer.coerceIn(0.0, 49.0)
+                }
+            }
+
+            if (color.secondBackground == null || color.secondBackground(scheme) == null) {
+                return answer
+            }
+
+            // Case 2: Adjust for dual backgrounds.
+            val bgTone1 = color.background(scheme)?.getTone(scheme) ?: 0.0
+            val bgTone2 = color.secondBackground(scheme)?.getTone(scheme) ?: 0.0
+            val upper: Double = max(bgTone1, bgTone2)
+            val lower: Double = min(bgTone1, bgTone2)
+
+            if (Contrast.ratioOfTones(upper, answer) >= desiredRatio
+                && Contrast.ratioOfTones(lower, answer) >= desiredRatio
+            ) {
+                return answer
+            }
+
+            // The darkest light tone that satisfies the desired ratio,
+            // or -1 if such ratio cannot be reached.
+            val lightOption: Double = Contrast.lighter(upper, desiredRatio)
+
+            // The lightest dark tone that satisfies the desired ratio,
+            // or -1 if such ratio cannot be reached.
+            val darkOption: Double = Contrast.darker(lower, desiredRatio)
+
+            // Tones suitable for the foreground.
+            val availables = mutableListOf<Double>()
+            if (lightOption != -1.0) {
+                availables.add(lightOption)
+            }
+            if (darkOption != -1.0) {
+                availables.add(darkOption)
+            }
+
+            val prefersLight =
+                DynamicColor.tonePrefersLightForeground(bgTone1)
+                    || DynamicColor.tonePrefersLightForeground(bgTone2)
+            if (prefersLight) {
+                return if (lightOption < 0) 100.0 else lightOption
+            }
+            if (availables.size == 1) {
+                return availables.first()
+            }
+            return if (darkOption < 0) 0.0 else darkOption
+        }
+    }
+
+    // Scheme Palettes
+
+    override fun getPrimaryPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: Platform,
+        contrastLevel: Double
+    ): TonalPalette = when (variant) {
+        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = if (platform === Platform.PHONE)
+                (if (sourceColorHct.isBlue()) 12.0 else 8.0)
+            else
+                (if (sourceColorHct.isBlue()) 16.0 else 12.0),
+        )
+        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = if (platform === Platform.PHONE && isDark) 26.0 else 32.0,
+        )
+        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = if (platform === Platform.PHONE) (if (isDark) 36.0 else 48.0) else 40.0,
+        )
+        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = if (platform === Platform.PHONE) 74.0 else 56.0,
+        )
+        else -> super.getPrimaryPalette(
+            variant = variant,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        )
+    }
+
+    override fun getSecondaryPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: Platform,
+        contrastLevel: Double
+    ): TonalPalette = when (variant) {
+        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = if (platform === Platform.PHONE) {
+                if (sourceColorHct.isBlue()) 6.0 else 4.0
+            } else {
+                if (sourceColorHct.isBlue()) 10.0 else 6.0
+            },
+        )
+        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 16.0)
+        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+            hue = DynamicScheme.getRotatedHue(
+                sourceColorHct = sourceColorHct,
+                hueBreakpoints = doubleArrayOf(0.0, 105.0, 140.0, 204.0, 253.0, 278.0, 300.0, 333.0, 360.0),
+                rotations = doubleArrayOf(-160.0, 155.0, -100.0, 96.0, -96.0, -156.0, -165.0, -160.0),
+            ),
+            chroma = if (platform === Platform.PHONE) (if (isDark) 16.0 else 24.0) else 24.0,
+        )
+        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
+            hue = DynamicScheme.getRotatedHue(
+                sourceColorHct = sourceColorHct,
+                hueBreakpoints = doubleArrayOf(0.0, 38.0, 105.0, 140.0, 333.0, 360.0),
+                rotations = doubleArrayOf(-14.0, 10.0, -14.0, 10.0, -14.0),
+            ),
+            chroma = if (platform === Platform.PHONE) 56.0 else 36.0,
+        )
+        else -> super.getSecondaryPalette(
+            variant,
+            sourceColorHct,
+            isDark,
+            platform,
+            contrastLevel,
+        )
+    }
+
+    override fun getTertiaryPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: Platform,
+        contrastLevel: Double
+    ): TonalPalette = when (variant) {
+        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
+            hue = DynamicScheme.getRotatedHue(
+                sourceColorHct = sourceColorHct,
+                hueBreakpoints = doubleArrayOf(0.0, 38.0, 105.0, 161.0, 204.0, 278.0, 333.0, 360.0),
+                rotations = doubleArrayOf(-32.0, 26.0, 10.0, -39.0, 24.0, -15.0, -32.0),
+            ),
+            chroma = if (platform === Platform.PHONE) 20.0 else 36.0,
+        )
+        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
+            hue = DynamicScheme.getRotatedHue(
+                sourceColorHct = sourceColorHct,
+                hueBreakpoints = doubleArrayOf(0.0, 20.0, 71.0, 161.0, 333.0, 360.0),
+                rotations = doubleArrayOf(-40.0, 48.0, -32.0, 40.0, -32.0),
+            ),
+            chroma = if (platform === Platform.PHONE) 28.0 else 32.0,
+        )
+        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+            hue = DynamicScheme.getRotatedHue(
+                sourceColorHct = sourceColorHct,
+                hueBreakpoints = doubleArrayOf(0.0, 105.0, 140.0, 204.0, 253.0, 278.0, 300.0, 333.0, 360.0),
+                rotations = doubleArrayOf(-165.0, 160.0, -105.0, 101.0, -101.0, -160.0, -170.0, -165.0),
+            ),
+            chroma = 48.0,
+        )
+        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
+            hue = DynamicScheme.getRotatedHue(
+                sourceColorHct = sourceColorHct,
+                hueBreakpoints = doubleArrayOf(0.0, 38.0, 71.0, 105.0, 140.0, 161.0, 253.0, 333.0, 360.0),
+                rotations = doubleArrayOf(-72.0, 35.0, 24.0, -24.0, 62.0, 50.0, 62.0, -72.0),
+            ),
+            chroma = 56.0,
+        )
+        else -> super.getTertiaryPalette(
+            variant = variant,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        )
+    }
+
+    override fun getNeutralPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: Platform,
+        contrastLevel: Double
+    ): TonalPalette = when (variant) {
+        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = if (platform === Platform.PHONE) 1.4 else 6.0,
+        )
+        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = if (platform === Platform.PHONE) 5.0 else 10.0,
+        )
+        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+            hue = getExpressiveNeutralHue(sourceColorHct),
+            chroma = getExpressiveNeutralChroma(sourceColorHct, isDark, platform),
+        )
+        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
+            hue = getVibrantNeutralHue(sourceColorHct),
+            chroma = getVibrantNeutralChroma(sourceColorHct, platform),
+        )
+        else -> super.getNeutralPalette(
+            variant = variant,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        )
+    }
+
+    override fun getNeutralVariantPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: Platform,
+        contrastLevel: Double
+    ): TonalPalette = when (variant) {
+        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = (if (platform === Platform.PHONE) 1.4 else 6.0) * 2.2,
+        )
+        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
+            hue = sourceColorHct.hue,
+            chroma = (if (platform === Platform.PHONE) 5 else 10) * 1.7,
+        )
+        Variant.EXPRESSIVE -> {
+            val expressiveNeutralHue = getExpressiveNeutralHue(sourceColorHct)
+            val expressiveNeutralChroma = getExpressiveNeutralChroma(sourceColorHct, isDark, platform)
+            val d = if (expressiveNeutralHue >= 105 && expressiveNeutralHue < 125) 1.6 else 2.3
+            TonalPalette.fromHueAndChroma(
+                hue = expressiveNeutralHue,
+                chroma = expressiveNeutralChroma * d,
+            )
+        }
+        Variant.VIBRANT -> {
+            val vibrantNeutralHue = getVibrantNeutralHue(sourceColorHct)
+            val vibrantNeutralChroma = getVibrantNeutralChroma(sourceColorHct, platform)
+            TonalPalette.fromHueAndChroma(vibrantNeutralHue, vibrantNeutralChroma * 1.29)
+        }
+        else -> super.getNeutralVariantPalette(
+            variant = variant,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        )
+    }
+
+    override fun getErrorPalette(
+        variant: Variant,
+        sourceColorHct: Hct,
+        isDark: Boolean,
+        platform: Platform,
+        contrastLevel: Double
+    ): TonalPalette? {
+        val errorHue = DynamicScheme.getPiecewiseValue(
+            sourceColorHct = sourceColorHct,
+            hueBreakpoints = doubleArrayOf(0.0, 3.0, 13.0, 23.0, 33.0, 43.0, 153.0, 273.0, 360.0),
+            hues = doubleArrayOf(12.0, 22.0, 32.0, 12.0, 22.0, 32.0, 22.0, 12.0),
+        )
+
+        return when (variant) {
+            Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
+                hue = errorHue,
+                chroma = if (platform === Platform.PHONE) 50.0 else 40.0,
+            )
+            Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
+                hue = errorHue,
+                chroma = if (platform === Platform.PHONE) 60.0 else 48.0,
+            )
+            Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+                hue = errorHue,
+                chroma = if (platform === Platform.PHONE) 64.0 else 48.0,
+            )
+            Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
+                hue = errorHue,
+                chroma = if (platform === Platform.PHONE) 80.0 else 60.0,
+            )
+            else -> super.getErrorPalette(
+                variant,
+                sourceColorHct,
+                isDark,
+                platform,
+                contrastLevel,
+            )
+        }
+    }
+
+    public companion object {
+        // Other
+
+        private fun findBestToneForChroma(
+            hue: Double,
+            chroma: Double,
+            tone: Double,
+            byDecreasingTone: Boolean
+        ): Double {
+            var tone = tone
+            var answer = tone
+            var bestCandidate: Hct = Hct.from(hue, chroma, answer)
+            while (bestCandidate.chroma < chroma) {
+                if (tone < 0 || tone > 100) {
+                    break
+                }
+                tone += if (byDecreasingTone) -1.0 else 1.0
+                val newCandidate: Hct = Hct.from(hue, chroma, tone)
+                if (bestCandidate.chroma < newCandidate.chroma) {
+                    bestCandidate = newCandidate
+                    answer = tone
+                }
+            }
+            return answer
+        }
+
+        private fun tMaxC(palette: TonalPalette): Double {
+            return tMaxC(palette, 0.0, 100.0)
+        }
+
+        private fun tMaxC(palette: TonalPalette, lowerBound: Double, upperBound: Double): Double {
+            val answer = findBestToneForChroma(palette.hue, palette.chroma, 100.0, true)
+            return answer.coerceIn(lowerBound, upperBound)
+        }
+
+        private fun tMinC(palette: TonalPalette): Double {
+            return tMinC(palette, 0.0, 100.0)
+        }
+
+        private fun tMinC(palette: TonalPalette, lowerBound: Double, upperBound: Double): Double {
+            val answer = findBestToneForChroma(palette.hue, palette.chroma, 0.0, false)
+            return answer.coerceIn(lowerBound, upperBound)
+        }
+
+        private fun getContrastCurve(defaultContrast: Double): ContrastCurve = when (defaultContrast) {
+            1.5 -> ContrastCurve(1.5, 1.5, 3.0, 4.5)
+            3.0 -> ContrastCurve(3.0, 3.0, 4.5, 7.0)
+            4.5 -> ContrastCurve(4.5, 4.5, 7.0, 11.0)
+            6.0 -> ContrastCurve(6.0, 6.0, 7.0, 11.0)
+            7.0 -> ContrastCurve(7.0, 7.0, 11.0, 21.0)
+            9.0 -> ContrastCurve(9.0, 9.0, 11.0, 21.0)
+            11.0 -> ContrastCurve(11.0, 11.0, 21.0, 21.0)
+            21.0 -> ContrastCurve(21.0, 21.0, 21.0, 21.0)
+            else -> {
+                // Shouldn't happen.
+                ContrastCurve(defaultContrast, defaultContrast, 7.0, 21.0)
+            }
+        }
+
+        private fun getExpressiveNeutralHue(sourceColorHct: Hct): Double = DynamicScheme.getRotatedHue(
+            sourceColorHct = sourceColorHct,
+            hueBreakpoints = doubleArrayOf(0.0, 71.0, 124.0, 253.0, 278.0, 300.0, 360.0),
+            rotations = doubleArrayOf(10.0, 0.0, 10.0, 0.0, 10.0, 0.0),
+        )
+
+        private fun getExpressiveNeutralChroma(
+            sourceColorHct: Hct,
+            isDark: Boolean,
+            platform: Platform,
+        ): Double {
+            val neutralHue = getExpressiveNeutralHue(sourceColorHct)
+            val neutralHueIsYellow = neutralHue >= 105 && neutralHue < 125
+
+            val value =
+                if (platform === Platform.PHONE) {
+                    if (isDark) {
+                        if (neutralHueIsYellow) 6 else 14
+                    } else {
+                        18
+                    }
+                } else {
+                    12
+                }
+            return value.toDouble()
+        }
+
+        private fun getVibrantNeutralHue(sourceColorHct: Hct): Double = DynamicScheme.getRotatedHue(
+            sourceColorHct = sourceColorHct,
+            hueBreakpoints = doubleArrayOf(0.0, 38.0, 105.0, 140.0, 333.0, 360.0),
+            rotations = doubleArrayOf(-14.0, 10.0, -14.0, 10.0, -14.0),
+        )
+
+        private fun getVibrantNeutralChroma(sourceColorHct: Hct, platform: Platform): Double {
+            val neutralHue = getVibrantNeutralHue(sourceColorHct)
+            val neutralHueIsBlue = neutralHue >= 250 && neutralHue < 270
+            return (if (platform === Platform.PHONE) 28 else (if (neutralHueIsBlue) 28 else 20)).toDouble()
+        }
+    }
+}

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2025.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2025.kt
@@ -33,7 +33,9 @@ public class ColorSpec2025 : ColorSpec2021() {
     public override fun background(): DynamicColor {
         // Remapped to surface for 2025 spec.
         val color2025 = surface().toBuilder().setName("background").build()
-        return super.background().toBuilder()
+        return super
+            .background()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
@@ -41,95 +43,23 @@ public class ColorSpec2025 : ColorSpec2021() {
     public override fun onBackground(): DynamicColor {
         // Remapped to onSurface for 2025 spec.
         val color2025 = onSurface().toBuilder().setName("on_background").build()
-        return super.onBackground().toBuilder()
+        return super
+            .onBackground()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun surface(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("surface")
-                .setPalette({ s -> s.neutralPalette })
-                .setTone(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.isDark) {
-                                return@setTone 4.0
-                            } else {
-                                if (s.neutralPalette.keyColor.isYellow()) {
-                                    return@setTone 99.0
-                                } else if (s.variant === Variant.VIBRANT) {
-                                    return@setTone 97.0
-                                } else {
-                                    return@setTone 98.0
-                                }
-                            }
-                        } else {
-                            return@setTone 0.0
-                        }
-                    },
-                )
-                .setIsBackground(true)
-                .build()
-        return super.surface().toBuilder()
-            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025).build()
-    }
-
-    public override fun surfaceDim(): DynamicColor {
-        val color2025 =
-            DynamicColor.Companion.Builder()
-                .setName("surface_dim")
-                .setPalette({ s -> s.neutralPalette })
-                .setTone(
-                    { s ->
+                .setPalette { s -> s.neutralPalette }
+                .setTone { s ->
+                    if (s.platform === Platform.PHONE) {
                         if (s.isDark) {
                             return@setTone 4.0
-                        } else {
-                            if (s.neutralPalette.keyColor.isYellow()) {
-                                return@setTone 90.0
-                            } else if (s.variant === Variant.VIBRANT) {
-                                return@setTone 85.0
-                            } else {
-                                return@setTone 87.0
-                            }
-                        }
-                    },
-                )
-                .setIsBackground(true)
-                .setChromaMultiplier(
-                    { s ->
-                        if (!s.isDark) {
-                            if (s.variant === Variant.NEUTRAL) {
-                                return@setChromaMultiplier 2.5
-                            } else if (s.variant === Variant.TONAL_SPOT) {
-                                return@setChromaMultiplier 1.7
-                            } else if (s.variant === Variant.EXPRESSIVE) {
-                                return@setChromaMultiplier if (s.neutralPalette.keyColor
-                                        .isYellow()
-                                ) 2.7 else 1.75
-                            } else if (s.variant === Variant.VIBRANT) {
-                                return@setChromaMultiplier 1.36
-                            }
-                        }
-                        1.0
-                    },
-                )
-                .build()
-        return super.surfaceDim().toBuilder()
-            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
-            .build()
-    }
-
-    public override fun surfaceBright(): DynamicColor {
-        val color2025 =
-            DynamicColor.Companion.Builder()
-                .setName("surface_bright")
-                .setPalette({ s -> s.neutralPalette })
-                .setTone(
-                    { s ->
-                        if (s.isDark) {
-                            return@setTone 18.0
                         } else {
                             if (s.neutralPalette.keyColor.isYellow()) {
                                 return@setTone 99.0
@@ -139,216 +69,328 @@ public class ColorSpec2025 : ColorSpec2021() {
                                 return@setTone 98.0
                             }
                         }
-                    },
-                )
-                .setIsBackground(true)
-                .setChromaMultiplier(
-                    { s ->
-                        if (s.isDark) {
-                            if (s.variant === Variant.NEUTRAL) {
-                                return@setChromaMultiplier 2.5
-                            } else if (s.variant === Variant.TONAL_SPOT) {
-                                return@setChromaMultiplier 1.7
-                            } else if (s.variant === Variant.EXPRESSIVE) {
-                                return@setChromaMultiplier if (s.neutralPalette.keyColor
-                                        .isYellow()
-                                ) 2.7 else 1.75
-                            } else if (s.variant === Variant.VIBRANT) {
-                                return@setChromaMultiplier 1.36
-                            }
-                        }
-                        1.0
-                    },
-                )
+                    } else {
+                        return@setTone 0.0
+                    }
+                }.setIsBackground(true)
                 .build()
-        return super.surfaceBright().toBuilder()
+        return super
+            .surface()
+            .toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun surfaceDim(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion
+                .Builder()
+                .setName("surface_dim")
+                .setPalette { s -> s.neutralPalette }
+                .setTone { s ->
+                    if (s.isDark) {
+                        return@setTone 4.0
+                    } else {
+                        if (s.neutralPalette.keyColor.isYellow()) {
+                            return@setTone 90.0
+                        } else if (s.variant === Variant.VIBRANT) {
+                            return@setTone 85.0
+                        } else {
+                            return@setTone 87.0
+                        }
+                    }
+                }.setIsBackground(true)
+                .setChromaMultiplier { s ->
+                    if (!s.isDark) {
+                        if (s.variant === Variant.NEUTRAL) {
+                            return@setChromaMultiplier 2.5
+                        } else if (s.variant === Variant.TONAL_SPOT) {
+                            return@setChromaMultiplier 1.7
+                        } else if (s.variant === Variant.EXPRESSIVE) {
+                            return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                    .isYellow()
+                            ) {
+                                2.7
+                            } else {
+                                1.75
+                            }
+                        } else if (s.variant === Variant.VIBRANT) {
+                            return@setChromaMultiplier 1.36
+                        }
+                    }
+                    1.0
+                }.build()
+        return super
+            .surfaceDim()
+            .toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun surfaceBright(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion
+                .Builder()
+                .setName("surface_bright")
+                .setPalette { s -> s.neutralPalette }
+                .setTone { s ->
+                    if (s.isDark) {
+                        return@setTone 18.0
+                    } else {
+                        if (s.neutralPalette.keyColor.isYellow()) {
+                            return@setTone 99.0
+                        } else if (s.variant === Variant.VIBRANT) {
+                            return@setTone 97.0
+                        } else {
+                            return@setTone 98.0
+                        }
+                    }
+                }.setIsBackground(true)
+                .setChromaMultiplier { s ->
+                    if (s.isDark) {
+                        if (s.variant === Variant.NEUTRAL) {
+                            return@setChromaMultiplier 2.5
+                        } else if (s.variant === Variant.TONAL_SPOT) {
+                            return@setChromaMultiplier 1.7
+                        } else if (s.variant === Variant.EXPRESSIVE) {
+                            return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                    .isYellow()
+                            ) {
+                                2.7
+                            } else {
+                                1.75
+                            }
+                        } else if (s.variant === Variant.VIBRANT) {
+                            return@setChromaMultiplier 1.36
+                        }
+                    }
+                    1.0
+                }.build()
+        return super
+            .surfaceBright()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun surfaceContainerLowest(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("surface_container_lowest")
-                .setPalette({ s -> s.neutralPalette })
-                .setTone({ s -> if (s.isDark) 0.0 else 100.0 })
+                .setPalette { s -> s.neutralPalette }
+                .setTone { s -> if (s.isDark) 0.0 else 100.0 }
                 .setIsBackground(true)
                 .build()
-        return super.surfaceContainerLowest().toBuilder()
+        return super
+            .surfaceContainerLowest()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun surfaceContainerLow(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("surface_container_low")
-                .setPalette({ s -> s.neutralPalette })
-                .setTone(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.isDark) {
-                                return@setTone 6.0
-                            } else {
-                                if (s.neutralPalette.keyColor.isYellow()) {
-                                    return@setTone 98.0
-                                } else if (s.variant === Variant.VIBRANT) {
-                                    return@setTone 95.0
-                                } else {
-                                    return@setTone 96.0
-                                }
-                            }
+                .setPalette { s -> s.neutralPalette }
+                .setTone { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.isDark) {
+                            return@setTone 6.0
                         } else {
-                            return@setTone 15.0
-                        }
-                    },
-                )
-                .setIsBackground(true)
-                .setChromaMultiplier(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.variant === Variant.NEUTRAL) {
-                                return@setChromaMultiplier 1.3
-                            } else if (s.variant === Variant.TONAL_SPOT) {
-                                return@setChromaMultiplier 1.25
-                            } else if (s.variant === Variant.EXPRESSIVE) {
-                                return@setChromaMultiplier if (s.neutralPalette.keyColor
-                                        .isYellow()
-                                ) 1.3 else 1.15
+                            if (s.neutralPalette.keyColor.isYellow()) {
+                                return@setTone 98.0
                             } else if (s.variant === Variant.VIBRANT) {
-                                return@setChromaMultiplier 1.08
+                                return@setTone 95.0
+                            } else {
+                                return@setTone 96.0
                             }
                         }
-                        1.0
-                    },
-                )
-                .build()
-        return super.surfaceContainerLow().toBuilder()
+                    } else {
+                        return@setTone 15.0
+                    }
+                }.setIsBackground(true)
+                .setChromaMultiplier { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.variant === Variant.NEUTRAL) {
+                            return@setChromaMultiplier 1.3
+                        } else if (s.variant === Variant.TONAL_SPOT) {
+                            return@setChromaMultiplier 1.25
+                        } else if (s.variant === Variant.EXPRESSIVE) {
+                            return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                    .isYellow()
+                            ) {
+                                1.3
+                            } else {
+                                1.15
+                            }
+                        } else if (s.variant === Variant.VIBRANT) {
+                            return@setChromaMultiplier 1.08
+                        }
+                    }
+                    1.0
+                }.build()
+        return super
+            .surfaceContainerLow()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun surfaceContainer(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("surface_container")
-                .setPalette({ s -> s.neutralPalette })
-                .setTone(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.isDark) {
-                                return@setTone 9.0
-                            } else {
-                                if (s.neutralPalette.keyColor.isYellow()) {
-                                    return@setTone 96.0
-                                } else if (s.variant === Variant.VIBRANT) {
-                                    return@setTone 92.0
-                                } else {
-                                    return@setTone 94.0
-                                }
-                            }
+                .setPalette { s -> s.neutralPalette }
+                .setTone { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.isDark) {
+                            return@setTone 9.0
                         } else {
-                            return@setTone 20.0
-                        }
-                    },
-                )
-                .setIsBackground(true)
-                .setChromaMultiplier(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.variant === Variant.NEUTRAL) {
-                                return@setChromaMultiplier 1.6
-                            } else if (s.variant === Variant.TONAL_SPOT) {
-                                return@setChromaMultiplier 1.4
-                            } else if (s.variant === Variant.EXPRESSIVE) {
-                                return@setChromaMultiplier if (s.neutralPalette.keyColor
-                                        .isYellow()
-                                ) 1.6 else 1.3
+                            if (s.neutralPalette.keyColor.isYellow()) {
+                                return@setTone 96.0
                             } else if (s.variant === Variant.VIBRANT) {
-                                return@setChromaMultiplier 1.15
+                                return@setTone 92.0
+                            } else {
+                                return@setTone 94.0
                             }
                         }
-                        1.0
-                    },
-                )
-                .build()
-        return super.surfaceContainer().toBuilder()
+                    } else {
+                        return@setTone 20.0
+                    }
+                }.setIsBackground(true)
+                .setChromaMultiplier { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.variant === Variant.NEUTRAL) {
+                            return@setChromaMultiplier 1.6
+                        } else if (s.variant === Variant.TONAL_SPOT) {
+                            return@setChromaMultiplier 1.4
+                        } else if (s.variant === Variant.EXPRESSIVE) {
+                            return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                    .isYellow()
+                            ) {
+                                1.6
+                            } else {
+                                1.3
+                            }
+                        } else if (s.variant === Variant.VIBRANT) {
+                            return@setChromaMultiplier 1.15
+                        }
+                    }
+                    1.0
+                }.build()
+        return super
+            .surfaceContainer()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun surfaceContainerHigh(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("surface_container_high")
-                .setPalette({ s -> s.neutralPalette })
-                .setTone(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.isDark) {
-                                return@setTone 12.0
-                            } else {
-                                if (s.neutralPalette.keyColor.isYellow()) {
-                                    return@setTone 94.0
-                                } else if (s.variant === Variant.VIBRANT) {
-                                    return@setTone 90.0
-                                } else {
-                                    return@setTone 92.0
-                                }
-                            }
+                .setPalette { s -> s.neutralPalette }
+                .setTone { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.isDark) {
+                            return@setTone 12.0
                         } else {
-                            return@setTone 25.0
-                        }
-                    },
-                )
-                .setIsBackground(true)
-                .setChromaMultiplier(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.variant === Variant.NEUTRAL) {
-                                return@setChromaMultiplier 1.9
-                            } else if (s.variant === Variant.TONAL_SPOT) {
-                                return@setChromaMultiplier 1.5
-                            } else if (s.variant === Variant.EXPRESSIVE) {
-                                return@setChromaMultiplier if (s.neutralPalette.keyColor
-                                        .isYellow()
-                                ) 1.95 else 1.45
+                            if (s.neutralPalette.keyColor.isYellow()) {
+                                return@setTone 94.0
                             } else if (s.variant === Variant.VIBRANT) {
-                                return@setChromaMultiplier 1.22
+                                return@setTone 90.0
+                            } else {
+                                return@setTone 92.0
                             }
                         }
-                        1.0
-                    },
-                )
-                .build()
-        return super.surfaceContainerHigh().toBuilder()
+                    } else {
+                        return@setTone 25.0
+                    }
+                }.setIsBackground(true)
+                .setChromaMultiplier { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.variant === Variant.NEUTRAL) {
+                            return@setChromaMultiplier 1.9
+                        } else if (s.variant === Variant.TONAL_SPOT) {
+                            return@setChromaMultiplier 1.5
+                        } else if (s.variant === Variant.EXPRESSIVE) {
+                            return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                    .isYellow()
+                            ) {
+                                1.95
+                            } else {
+                                1.45
+                            }
+                        } else if (s.variant === Variant.VIBRANT) {
+                            return@setChromaMultiplier 1.22
+                        }
+                    }
+                    1.0
+                }.build()
+        return super
+            .surfaceContainerHigh()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun surfaceContainerHighest(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("surface_container_highest")
-                .setPalette({ s -> s.neutralPalette })
-                .setTone(
-                    { s ->
-                        if (s.isDark) {
-                            return@setTone 15.0
+                .setPalette { s -> s.neutralPalette }
+                .setTone { s ->
+                    if (s.isDark) {
+                        return@setTone 15.0
+                    } else {
+                        if (s.neutralPalette.keyColor.isYellow()) {
+                            return@setTone 92.0
+                        } else if (s.variant === Variant.VIBRANT) {
+                            return@setTone 88.0
                         } else {
-                            if (s.neutralPalette.keyColor.isYellow()) {
-                                return@setTone 92.0
-                            } else if (s.variant === Variant.VIBRANT) {
-                                return@setTone 88.0
-                            } else {
-                                return@setTone 90.0
-                            }
+                            return@setTone 90.0
                         }
-                    },
-                )
-                .setIsBackground(true)
-                .setChromaMultiplier(
-                    { s ->
+                    }
+                }.setIsBackground(true)
+                .setChromaMultiplier { s ->
+                    if (s.variant === Variant.NEUTRAL) {
+                        return@setChromaMultiplier 2.2
+                    } else if (s.variant === Variant.TONAL_SPOT) {
+                        return@setChromaMultiplier 1.7
+                    } else if (s.variant === Variant.EXPRESSIVE) {
+                        return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                .isYellow()
+                        ) {
+                            2.3
+                        } else {
+                            1.6
+                        }
+                    } else if (s.variant === Variant.VIBRANT) {
+                        return@setChromaMultiplier 1.29
+                    }
+                    1.0
+                }.build()
+        return super
+            .surfaceContainerHighest()
+            .toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
+    }
+
+    public override fun onSurface(): DynamicColor {
+        val color2025 =
+            DynamicColor.Companion
+                .Builder()
+                .setName("on_surface")
+                .setPalette { s -> s.neutralPalette }
+                .setChromaMultiplier { s ->
+                    if (s.platform === Platform.PHONE) {
                         if (s.variant === Variant.NEUTRAL) {
                             return@setChromaMultiplier 2.2
                         } else if (s.variant === Variant.TONAL_SPOT) {
@@ -356,54 +398,27 @@ public class ColorSpec2025 : ColorSpec2021() {
                         } else if (s.variant === Variant.EXPRESSIVE) {
                             return@setChromaMultiplier if (s.neutralPalette.keyColor
                                     .isYellow()
-                            ) 2.3 else 1.6
+                            ) {
+                                2.3
+                            } else {
+                                1.6
+                            }
                         } else if (s.variant === Variant.VIBRANT) {
                             return@setChromaMultiplier 1.29
                         }
-                        1.0
-                    },
-                )
+                    }
+                    1.0
+                }.setBackground { s ->
+                    if (s.platform === Platform.PHONE) {
+                        return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                    } else {
+                        return@setBackground surfaceContainerHigh()
+                    }
+                }.setContrastCurve { s -> getContrastCurve(9.0) }
                 .build()
-        return super.surfaceContainerHighest().toBuilder()
-            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
-            .build()
-    }
-
-    public override fun onSurface(): DynamicColor {
-        val color2025 =
-            DynamicColor.Companion.Builder()
-                .setName("on_surface")
-                .setPalette({ s -> s.neutralPalette })
-                .setChromaMultiplier(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.variant === Variant.NEUTRAL) {
-                                return@setChromaMultiplier 2.2
-                            } else if (s.variant === Variant.TONAL_SPOT) {
-                                return@setChromaMultiplier 1.7
-                            } else if (s.variant === Variant.EXPRESSIVE) {
-                                return@setChromaMultiplier if (s.neutralPalette.keyColor
-                                        .isYellow()
-                                ) 2.3 else 1.6
-                            } else if (s.variant === Variant.VIBRANT) {
-                                return@setChromaMultiplier 1.29
-                            }
-                        }
-                        1.0
-                    },
-                )
-                .setBackground(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
-                        } else {
-                            return@setBackground surfaceContainerHigh()
-                        }
-                    },
-                )
-                .setContrastCurve({ s -> getContrastCurve(9.0) })
-                .build()
-        return super.onSurface().toBuilder()
+        return super
+            .onSurface()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
@@ -412,167 +427,182 @@ public class ColorSpec2025 : ColorSpec2021() {
         // Remapped to surfaceContainerHighest for 2025 spec.
         val color2025 =
             surfaceContainerHighest().toBuilder().setName("surface_variant").build()
-        return super.surfaceVariant().toBuilder()
+        return super
+            .surfaceVariant()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun onSurfaceVariant(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_surface_variant")
-                .setPalette({ s -> s.neutralPalette })
-                .setChromaMultiplier(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.variant === Variant.NEUTRAL) {
-                                return@setChromaMultiplier 2.2
-                            } else if (s.variant === Variant.TONAL_SPOT) {
-                                return@setChromaMultiplier 1.7
-                            } else if (s.variant === Variant.EXPRESSIVE) {
-                                return@setChromaMultiplier if (s.neutralPalette.keyColor
-                                        .isYellow()
-                                ) 2.3 else 1.6
-                            } else if (s.variant === Variant.VIBRANT) {
-                                return@setChromaMultiplier 1.29
+                .setPalette { s -> s.neutralPalette }
+                .setChromaMultiplier { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.variant === Variant.NEUTRAL) {
+                            return@setChromaMultiplier 2.2
+                        } else if (s.variant === Variant.TONAL_SPOT) {
+                            return@setChromaMultiplier 1.7
+                        } else if (s.variant === Variant.EXPRESSIVE) {
+                            return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                    .isYellow()
+                            ) {
+                                2.3
+                            } else {
+                                1.6
                             }
+                        } else if (s.variant === Variant.VIBRANT) {
+                            return@setChromaMultiplier 1.29
                         }
-                        1.0
-                    },
-                )
-                .setBackground(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
-                        } else {
-                            return@setBackground surfaceContainerHigh()
-                        }
-                    },
-                )
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(4.5) else getContrastCurve(
+                    }
+                    1.0
+                }.setBackground { s ->
+                    if (s.platform === Platform.PHONE) {
+                        return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                    } else {
+                        return@setBackground surfaceContainerHigh()
+                    }
+                }.setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(4.5)
+                    } else {
+                        getContrastCurve(
                             7.0,
                         )
-                    },
-                )
-                .build()
-        return super.onSurfaceVariant().toBuilder()
+                    }
+                }.build()
+        return super
+            .onSurfaceVariant()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun inverseSurface(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("inverse_surface")
-                .setPalette({ s -> s.neutralPalette })
-                .setTone({ s -> if (s.isDark) 98.0 else 4.0 })
+                .setPalette { s -> s.neutralPalette }
+                .setTone { s -> if (s.isDark) 98.0 else 4.0 }
                 .setIsBackground(true)
                 .build()
-        return super.inverseSurface().toBuilder()
+        return super
+            .inverseSurface()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun inverseOnSurface(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("inverse_on_surface")
-                .setPalette({ s -> s.neutralPalette })
-                .setBackground({ s -> inverseSurface() })
-                .setContrastCurve({ s -> getContrastCurve(7.0) })
+                .setPalette { s -> s.neutralPalette }
+                .setBackground { s -> inverseSurface() }
+                .setContrastCurve { s -> getContrastCurve(7.0) }
                 .build()
-        return super.inverseOnSurface().toBuilder()
+        return super
+            .inverseOnSurface()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun outline(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("outline")
-                .setPalette({ s -> s.neutralPalette })
-                .setChromaMultiplier(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.variant === Variant.NEUTRAL) {
-                                return@setChromaMultiplier 2.2
-                            } else if (s.variant === Variant.TONAL_SPOT) {
-                                return@setChromaMultiplier 1.7
-                            } else if (s.variant === Variant.EXPRESSIVE) {
-                                return@setChromaMultiplier if (s.neutralPalette.keyColor
-                                        .isYellow()
-                                ) 2.3 else 1.6
-                            } else if (s.variant === Variant.VIBRANT) {
-                                return@setChromaMultiplier 1.29
+                .setPalette { s -> s.neutralPalette }
+                .setChromaMultiplier { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.variant === Variant.NEUTRAL) {
+                            return@setChromaMultiplier 2.2
+                        } else if (s.variant === Variant.TONAL_SPOT) {
+                            return@setChromaMultiplier 1.7
+                        } else if (s.variant === Variant.EXPRESSIVE) {
+                            return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                    .isYellow()
+                            ) {
+                                2.3
+                            } else {
+                                1.6
                             }
+                        } else if (s.variant === Variant.VIBRANT) {
+                            return@setChromaMultiplier 1.29
                         }
-                        1.0
-                    },
-                )
-                .setBackground(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
-                        } else {
-                            return@setBackground surfaceContainerHigh()
-                        }
-                    },
-                )
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(3.0) else getContrastCurve(
+                    }
+                    1.0
+                }.setBackground { s ->
+                    if (s.platform === Platform.PHONE) {
+                        return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                    } else {
+                        return@setBackground surfaceContainerHigh()
+                    }
+                }.setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(3.0)
+                    } else {
+                        getContrastCurve(
                             4.5,
                         )
-                    },
-                )
-                .build()
-        return super.outline().toBuilder()
-            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025).build()
+                    }
+                }.build()
+        return super
+            .outline()
+            .toBuilder()
+            .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
+            .build()
     }
 
     public override fun outlineVariant(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("outline_variant")
-                .setPalette({ s -> s.neutralPalette })
-                .setChromaMultiplier(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.variant === Variant.NEUTRAL) {
-                                return@setChromaMultiplier 2.2
-                            } else if (s.variant === Variant.TONAL_SPOT) {
-                                return@setChromaMultiplier 1.7
-                            } else if (s.variant === Variant.EXPRESSIVE) {
-                                return@setChromaMultiplier if (s.neutralPalette.keyColor
-                                        .isYellow()
-                                ) 2.3 else 1.6
-                            } else if (s.variant === Variant.VIBRANT) {
-                                return@setChromaMultiplier 1.29
+                .setPalette { s -> s.neutralPalette }
+                .setChromaMultiplier { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.variant === Variant.NEUTRAL) {
+                            return@setChromaMultiplier 2.2
+                        } else if (s.variant === Variant.TONAL_SPOT) {
+                            return@setChromaMultiplier 1.7
+                        } else if (s.variant === Variant.EXPRESSIVE) {
+                            return@setChromaMultiplier if (s.neutralPalette.keyColor
+                                    .isYellow()
+                            ) {
+                                2.3
+                            } else {
+                                1.6
                             }
+                        } else if (s.variant === Variant.VIBRANT) {
+                            return@setChromaMultiplier 1.29
                         }
-                        1.0
-                    },
-                )
-                .setBackground(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
-                        } else {
-                            return@setBackground surfaceContainerHigh()
-                        }
-                    },
-                )
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(1.5) else getContrastCurve(
+                    }
+                    1.0
+                }.setBackground { s ->
+                    if (s.platform === Platform.PHONE) {
+                        return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                    } else {
+                        return@setBackground surfaceContainerHigh()
+                    }
+                }.setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(1.5)
+                    } else {
+                        getContrastCurve(
                             3.0,
                         )
-                    },
-                )
-                .build()
-        return super.outlineVariant().toBuilder()
+                    }
+                }.build()
+        return super
+            .outlineVariant()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
@@ -580,110 +610,110 @@ public class ColorSpec2025 : ColorSpec2021() {
     public override fun surfaceTint(): DynamicColor {
         // Remapped to primary for 2025 spec.
         val color2025 = primary().toBuilder().setName("surface_tint").build()
-        return super.surfaceTint().toBuilder()
+        return super
+            .surfaceTint()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
-    /**///////////////////////////////////////////////////////////// */ // Primaries [P]                                              //
-    /**///////////////////////////////////////////////////////////// */
+    // Primaries [P]
 
     public override fun primary(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("primary")
-                .setPalette({ s -> s.primaryPalette })
-                .setTone(
-                    { s ->
-                        if (s.variant === Variant.NEUTRAL) {
-                            if (s.platform === Platform.PHONE) {
-                                return@setTone if (s.isDark) 80.0 else 40.0
-                            } else {
-                                return@setTone 90.0
-                            }
-                        } else if (s.variant === Variant.TONAL_SPOT) {
-                            if (s.platform === Platform.PHONE) {
-                                if (s.isDark) {
-                                    return@setTone 80.0
-                                } else {
-                                    return@setTone tMaxC(s.primaryPalette)
-                                }
-                            } else {
-                                return@setTone tMaxC(s.primaryPalette, 0.0, 90.0)
-                            }
-                        } else if (s.variant === Variant.EXPRESSIVE) {
-                            return@setTone tMaxC(
-                                s.primaryPalette,
-                                0.0,
-                                (if (s.primaryPalette.keyColor.isYellow())
-                                    25
-                                else
-                                    if (s.primaryPalette.keyColor
-                                            .isCyan()
-                                    ) 88 else 98).toDouble(),
-                            )
-                        } else { // VIBRANT
-                            return@setTone tMaxC(
-                                s.primaryPalette,
-                                0.0,
-                                (if (s.primaryPalette.keyColor.isCyan()) 88 else 98).toDouble(),
-                            )
-                        }
-                    },
-                )
-                .setIsBackground(true)
-                .setBackground(
-                    { s ->
+                .setPalette { s -> s.primaryPalette }
+                .setTone { s ->
+                    if (s.variant === Variant.NEUTRAL) {
                         if (s.platform === Platform.PHONE) {
-                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                            return@setTone if (s.isDark) 80.0 else 40.0
                         } else {
-                            return@setBackground surfaceContainerHigh()
+                            return@setTone 90.0
                         }
-                    },
-                )
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(4.5) else getContrastCurve(
+                    } else if (s.variant === Variant.TONAL_SPOT) {
+                        if (s.platform === Platform.PHONE) {
+                            if (s.isDark) {
+                                return@setTone 80.0
+                            } else {
+                                return@setTone tMaxC(s.primaryPalette)
+                            }
+                        } else {
+                            return@setTone tMaxC(s.primaryPalette, 0.0, 90.0)
+                        }
+                    } else if (s.variant === Variant.EXPRESSIVE) {
+                        return@setTone tMaxC(
+                            s.primaryPalette,
+                            0.0,
+                            (
+                                if (s.primaryPalette.keyColor.isYellow()) {
+                                    25
+                                } else if (s.primaryPalette.keyColor.isCyan()) {
+                                    88
+                                } else {
+                                    98
+                                }
+                            ).toDouble(),
+                        )
+                    } else { // VIBRANT
+                        return@setTone tMaxC(
+                            s.primaryPalette,
+                            0.0,
+                            (if (s.primaryPalette.keyColor.isCyan()) 88 else 98).toDouble(),
+                        )
+                    }
+                }.setIsBackground(true)
+                .setBackground { s ->
+                    if (s.platform === Platform.PHONE) {
+                        return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                    } else {
+                        return@setBackground surfaceContainerHigh()
+                    }
+                }.setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(4.5)
+                    } else {
+                        getContrastCurve(
                             7.0,
                         )
-                    },
-                )
-                .setToneDeltaPair(
-                    { s ->
-                        if (s.platform === Platform.PHONE)
-                            ToneDeltaPair(
-                                roleA = primaryContainer(),
-                                roleB = primary(),
-                                delta = 5.0,
-                                polarity = TonePolarity.RELATIVE_LIGHTER,
-                                deltaConstraint = DeltaConstraint.FARTHER,
-                            )
-                        else
-                            null
-                    },
-                )
-                .build()
+                    }
+                }.setToneDeltaPair { s ->
+                    if (s.platform === Platform.PHONE) {
+                        ToneDeltaPair(
+                            roleA = primaryContainer(),
+                            roleB = primary(),
+                            delta = 5.0,
+                            polarity = TonePolarity.RELATIVE_LIGHTER,
+                            deltaConstraint = DeltaConstraint.FARTHER,
+                        )
+                    } else {
+                        null
+                    }
+                }.build()
 
-        return super.primary().toBuilder()
+        return super
+            .primary()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
-    public override fun primaryDim(): DynamicColor = DynamicColor.Companion.Builder()
-        .setName("primary_dim")
-        .setPalette({ s -> s.primaryPalette })
-        .setTone { s ->
-            when {
-                s.variant === Variant.NEUTRAL -> 85.0
-                s.variant === Variant.TONAL_SPOT -> tMaxC(s.primaryPalette, 0.0, 90.0)
-                else -> tMaxC(s.primaryPalette)
-            }
-        }
-        .setIsBackground(true)
-        .setBackground({ s -> surfaceContainerHigh() })
-        .setContrastCurve({ s -> getContrastCurve(4.5) })
-        .setToneDeltaPair(
-            { s ->
+    public override fun primaryDim(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
+            .setName("primary_dim")
+            .setPalette { s -> s.primaryPalette }
+            .setTone { s ->
+                when {
+                    s.variant === Variant.NEUTRAL -> 85.0
+                    s.variant === Variant.TONAL_SPOT -> tMaxC(s.primaryPalette, 0.0, 90.0)
+                    else -> tMaxC(s.primaryPalette)
+                }
+            }.setIsBackground(true)
+            .setBackground { s -> surfaceContainerHigh() }
+            .setContrastCurve { s -> getContrastCurve(4.5) }
+            .setToneDeltaPair { s ->
                 ToneDeltaPair(
                     roleA = primaryDim(),
                     roleB = primary(),
@@ -691,137 +721,155 @@ public class ColorSpec2025 : ColorSpec2021() {
                     polarity = TonePolarity.DARKER,
                     deltaConstraint = DeltaConstraint.FARTHER,
                 )
-            },
-        )
-        .build()
+            }.build()
 
     public override fun onPrimary(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_primary")
-                .setPalette({ s -> s.primaryPalette })
-                .setBackground({ s -> if (s.platform === Platform.PHONE) primary() else primaryDim() })
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
-                        else getContrastCurve(7.0)
-                    },
-                )
-                .build()
-        return super.onPrimary().toBuilder()
+                .setPalette { s -> s.primaryPalette }
+                .setBackground { s -> if (s.platform === Platform.PHONE) primary() else primaryDim() }
+                .setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(6.0)
+                    } else {
+                        getContrastCurve(7.0)
+                    }
+                }.build()
+        return super
+            .onPrimary()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun primaryContainer(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("primary_container")
-                .setPalette({ s -> s.primaryPalette })
-                .setTone(
-                    { s ->
-                        if (s.platform === Platform.WATCH) {
-                            return@setTone 30.0
-                        } else if (s.variant === Variant.NEUTRAL) {
-                            return@setTone if (s.isDark) 30.0 else 90.0
-                        } else if (s.variant === Variant.TONAL_SPOT) {
-                            return@setTone if (s.isDark)
-                                tMinC(s.primaryPalette, 35.0, 93.0)
-                            else
-                                tMaxC(s.primaryPalette, 0.0, 90.0)
-                        } else if (s.variant === Variant.EXPRESSIVE) {
-                            return@setTone if (s.isDark)
-                                tMaxC(s.primaryPalette, 30.0, 93.0)
-                            else
-                                tMaxC(
-                                    s.primaryPalette,
-                                    78.0,
-                                    (if (s.primaryPalette.keyColor
-                                            .isCyan()
-                                    ) 88 else 90).toDouble(),
-                                )
-                        } else { // VIBRANT
-                            return@setTone if (s.isDark)
-                                tMinC(s.primaryPalette, 66.0, 93.0)
-                            else
-                                tMaxC(
-                                    s.primaryPalette,
-                                    66.0,
-                                    (if (s.primaryPalette.keyColor
-                                            .isCyan()
-                                    ) 88 else 93).toDouble(),
-                                )
-                        }
-                    },
-                )
-                .setIsBackground(true)
-                .setBackground(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                .setPalette { s -> s.primaryPalette }
+                .setTone { s ->
+                    if (s.platform === Platform.WATCH) {
+                        return@setTone 30.0
+                    } else if (s.variant === Variant.NEUTRAL) {
+                        return@setTone if (s.isDark) 30.0 else 90.0
+                    } else if (s.variant === Variant.TONAL_SPOT) {
+                        return@setTone if (s.isDark) {
+                            tMinC(s.primaryPalette, 35.0, 93.0)
                         } else {
-                            return@setBackground null
+                            tMaxC(s.primaryPalette, 0.0, 90.0)
                         }
-                    },
-                )
-                .setToneDeltaPair(
-                    { s ->
-                        if (s.platform === Platform.WATCH)
-                            ToneDeltaPair(
-                                roleA = primaryContainer(),
-                                roleB = primaryDim(),
-                                delta = 10.0,
-                                polarity = TonePolarity.DARKER,
-                                deltaConstraint = DeltaConstraint.FARTHER,
+                    } else if (s.variant === Variant.EXPRESSIVE) {
+                        return@setTone if (s.isDark) {
+                            tMaxC(s.primaryPalette, 30.0, 93.0)
+                        } else {
+                            tMaxC(
+                                s.primaryPalette,
+                                78.0,
+                                (
+                                    if (s.primaryPalette.keyColor
+                                            .isCyan()
+                                    ) {
+                                        88
+                                    } else {
+                                        90
+                                    }
+                                ).toDouble(),
                             )
-                        else null
-                    },
-                )
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE && s.contrastLevel > 0) getContrastCurve(1.5)
-                        else null
-                    },
-                )
-                .build()
-        return super.primaryContainer().toBuilder()
+                        }
+                    } else { // VIBRANT
+                        return@setTone if (s.isDark) {
+                            tMinC(s.primaryPalette, 66.0, 93.0)
+                        } else {
+                            tMaxC(
+                                s.primaryPalette,
+                                66.0,
+                                (
+                                    if (s.primaryPalette.keyColor
+                                            .isCyan()
+                                    ) {
+                                        88
+                                    } else {
+                                        93
+                                    }
+                                ).toDouble(),
+                            )
+                        }
+                    }
+                }.setIsBackground(true)
+                .setBackground { s ->
+                    if (s.platform === Platform.PHONE) {
+                        return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                    } else {
+                        return@setBackground null
+                    }
+                }.setToneDeltaPair { s ->
+                    if (s.platform === Platform.WATCH) {
+                        ToneDeltaPair(
+                            roleA = primaryContainer(),
+                            roleB = primaryDim(),
+                            delta = 10.0,
+                            polarity = TonePolarity.DARKER,
+                            deltaConstraint = DeltaConstraint.FARTHER,
+                        )
+                    } else {
+                        null
+                    }
+                }.setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE && s.contrastLevel > 0) {
+                        getContrastCurve(1.5)
+                    } else {
+                        null
+                    }
+                }.build()
+        return super
+            .primaryContainer()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun onPrimaryContainer(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_primary_container")
-                .setPalette({ s -> s.primaryPalette })
-                .setBackground({ s -> primaryContainer() })
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
-                        else getContrastCurve(7.0)
-                    },
-                )
-                .build()
-        return super.onPrimaryContainer().toBuilder()
+                .setPalette { s -> s.primaryPalette }
+                .setBackground { s -> primaryContainer() }
+                .setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(6.0)
+                    } else {
+                        getContrastCurve(7.0)
+                    }
+                }.build()
+        return super
+            .onPrimaryContainer()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun inversePrimary(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("inverse_primary")
-                .setPalette({ s -> s.primaryPalette })
-                .setTone({ s -> tMaxC(s.primaryPalette) })
-                .setBackground({ s -> inverseSurface() })
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
-                        else getContrastCurve(7.0)
-                    },
-                )
-                .build()
-        return super.inversePrimary().toBuilder()
+                .setPalette { s -> s.primaryPalette }
+                .setTone { s -> tMaxC(s.primaryPalette) }
+                .setBackground { s -> inverseSurface() }
+                .setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(6.0)
+                    } else {
+                        getContrastCurve(7.0)
+                    }
+                }.build()
+        return super
+            .inversePrimary()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
@@ -830,191 +878,195 @@ public class ColorSpec2025 : ColorSpec2021() {
 
     public override fun secondary(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("secondary")
-                .setPalette({ s -> s.secondaryPalette })
-                .setTone(
-                    { s ->
-                        when {
-                            s.platform === Platform.WATCH -> {
-                                if (s.variant === Variant.NEUTRAL) 90.0 else tMaxC(
+                .setPalette { s -> s.secondaryPalette }
+                .setTone { s ->
+                    when {
+                        s.platform === Platform.WATCH -> {
+                            if (s.variant === Variant.NEUTRAL) {
+                                90.0
+                            } else {
+                                tMaxC(
                                     palette = s.secondaryPalette,
                                     lowerBound = 0.0,
                                     upperBound = 90.0,
                                 )
                             }
-                            s.variant === Variant.NEUTRAL -> {
-                                if (s.isDark) tMinC(
+                        }
+                        s.variant === Variant.NEUTRAL -> {
+                            if (s.isDark) {
+                                tMinC(
                                     palette = s.secondaryPalette,
                                     lowerBound = 0.0,
                                     upperBound = 98.0,
-                                ) else tMaxC(s.secondaryPalette)
-                            }
-                            s.variant === Variant.VIBRANT -> {
-                                tMaxC(
-                                    palette = s.secondaryPalette,
-                                    lowerBound = 0.0,
-                                    upperBound = (if (s.isDark) 90 else 98).toDouble(),
                                 )
-                            }
-                            else -> { // EXPRESSIVE and TONAL_SPOT
-                                if (s.isDark) 80.0 else tMaxC(s.secondaryPalette)
+                            } else {
+                                tMaxC(s.secondaryPalette)
                             }
                         }
-                    },
-                )
-                .setIsBackground(true)
-                .setBackground(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.isDark) surfaceBright() else surfaceDim()
-                        } else {
-                            surfaceContainerHigh()
-                        }
-                    },
-                )
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(4.5)
-                        else getContrastCurve(7.0)
-                    },
-                )
-                .setToneDeltaPair(
-                    { s ->
-                        if (s.platform === Platform.PHONE)
-                            ToneDeltaPair(
-                                roleA = secondaryContainer(),
-                                roleB = secondary(),
-                                delta = 5.0,
-                                polarity = TonePolarity.RELATIVE_LIGHTER,
-                                deltaConstraint = DeltaConstraint.FARTHER,
+                        s.variant === Variant.VIBRANT -> {
+                            tMaxC(
+                                palette = s.secondaryPalette,
+                                lowerBound = 0.0,
+                                upperBound = (if (s.isDark) 90 else 98).toDouble(),
                             )
-                        else null
-                    },
-                )
-                .build()
-        return super.secondary().toBuilder()
+                        }
+                        else -> { // EXPRESSIVE and TONAL_SPOT
+                            if (s.isDark) 80.0 else tMaxC(s.secondaryPalette)
+                        }
+                    }
+                }.setIsBackground(true)
+                .setBackground { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.isDark) surfaceBright() else surfaceDim()
+                    } else {
+                        surfaceContainerHigh()
+                    }
+                }.setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(4.5)
+                    } else {
+                        getContrastCurve(7.0)
+                    }
+                }.setToneDeltaPair { s ->
+                    if (s.platform === Platform.PHONE) {
+                        ToneDeltaPair(
+                            roleA = secondaryContainer(),
+                            roleB = secondary(),
+                            delta = 5.0,
+                            polarity = TonePolarity.RELATIVE_LIGHTER,
+                            deltaConstraint = DeltaConstraint.FARTHER,
+                        )
+                    } else {
+                        null
+                    }
+                }.build()
+        return super
+            .secondary()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
-    public override fun secondaryDim(): DynamicColor {
-        return DynamicColor.Companion.Builder()
+    public override fun secondaryDim(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
             .setName("secondary_dim")
-            .setPalette({ s -> s.secondaryPalette })
-            .setTone(
-                { s ->
-                    if (s.variant === Variant.NEUTRAL) {
-                        85.0
-                    } else {
-                        tMaxC(s.secondaryPalette, 0.0, 90.0)
-                    }
-                },
-            )
-            .setIsBackground(true)
-            .setBackground({ s -> surfaceContainerHigh() })
-            .setContrastCurve({ s -> getContrastCurve(4.5) })
-            .setToneDeltaPair(
-                { s ->
-                    ToneDeltaPair(
-                        roleA = secondaryDim(),
-                        roleB = secondary(),
-                        delta = 5.0,
-                        polarity = TonePolarity.DARKER,
-                        deltaConstraint = DeltaConstraint.FARTHER,
-                    )
-                },
-            )
-            .build()
-    }
+            .setPalette { s -> s.secondaryPalette }
+            .setTone { s ->
+                if (s.variant === Variant.NEUTRAL) {
+                    85.0
+                } else {
+                    tMaxC(s.secondaryPalette, 0.0, 90.0)
+                }
+            }.setIsBackground(true)
+            .setBackground { s -> surfaceContainerHigh() }
+            .setContrastCurve { s -> getContrastCurve(4.5) }
+            .setToneDeltaPair { s ->
+                ToneDeltaPair(
+                    roleA = secondaryDim(),
+                    roleB = secondary(),
+                    delta = 5.0,
+                    polarity = TonePolarity.DARKER,
+                    deltaConstraint = DeltaConstraint.FARTHER,
+                )
+            }.build()
 
     public override fun onSecondary(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_secondary")
-                .setPalette({ s -> s.secondaryPalette })
-                .setBackground({ s -> if (s.platform === Platform.PHONE) secondary() else secondaryDim() })
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
-                        else getContrastCurve(7.0)
-                    },
-                )
-                .build()
-        return super.onSecondary().toBuilder()
+                .setPalette { s -> s.secondaryPalette }
+                .setBackground { s ->
+                    if (s.platform === Platform.PHONE) secondary() else secondaryDim()
+                }.setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(6.0)
+                    } else {
+                        getContrastCurve(7.0)
+                    }
+                }.build()
+        return super
+            .onSecondary()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun secondaryContainer(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("secondary_container")
-                .setPalette({ s -> s.secondaryPalette })
-                .setTone(
-                    { s ->
-                        when {
-                            s.platform === Platform.WATCH -> 30.0
-                            s.variant === Variant.VIBRANT -> {
-                                if (s.isDark) tMinC(s.secondaryPalette, 30.0, 40.0)
-                                else tMaxC(s.secondaryPalette, 84.0, 90.0)
+                .setPalette { s -> s.secondaryPalette }
+                .setTone { s ->
+                    when {
+                        s.platform === Platform.WATCH -> 30.0
+                        s.variant === Variant.VIBRANT -> {
+                            if (s.isDark) {
+                                tMinC(s.secondaryPalette, 30.0, 40.0)
+                            } else {
+                                tMaxC(s.secondaryPalette, 84.0, 90.0)
                             }
-                            s.variant === Variant.EXPRESSIVE -> {
-                                if (s.isDark) 15.0 else tMaxC(s.secondaryPalette, 90.0, 95.0)
-                            }
-                            else -> if (s.isDark) 25.0 else 90.0
                         }
-                    },
-                )
-                .setIsBackground(true)
-                .setBackground(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.isDark) surfaceBright() else surfaceDim()
-                        } else {
-                            null
+                        s.variant === Variant.EXPRESSIVE -> {
+                            if (s.isDark) 15.0 else tMaxC(s.secondaryPalette, 90.0, 95.0)
                         }
-                    },
-                )
-                .setToneDeltaPair(
-                    { s ->
-                        if (s.platform === Platform.WATCH)
-                            ToneDeltaPair(
-                                roleA = secondaryContainer(),
-                                roleB = secondaryDim(),
-                                delta = 10.0,
-                                polarity = TonePolarity.DARKER,
-                                deltaConstraint = DeltaConstraint.FARTHER,
-                            )
-                        else null
-                    },
-                )
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE && s.contrastLevel > 0) getContrastCurve(1.5)
-                        else null
-                    },
-                )
-                .build()
-        return super.secondaryContainer().toBuilder()
+                        else -> if (s.isDark) 25.0 else 90.0
+                    }
+                }.setIsBackground(true)
+                .setBackground { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.isDark) surfaceBright() else surfaceDim()
+                    } else {
+                        null
+                    }
+                }.setToneDeltaPair { s ->
+                    if (s.platform === Platform.WATCH) {
+                        ToneDeltaPair(
+                            roleA = secondaryContainer(),
+                            roleB = secondaryDim(),
+                            delta = 10.0,
+                            polarity = TonePolarity.DARKER,
+                            deltaConstraint = DeltaConstraint.FARTHER,
+                        )
+                    } else {
+                        null
+                    }
+                }.setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE && s.contrastLevel > 0) {
+                        getContrastCurve(1.5)
+                    } else {
+                        null
+                    }
+                }.build()
+        return super
+            .secondaryContainer()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun onSecondaryContainer(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_secondary_container")
-                .setPalette({ s -> s.secondaryPalette })
-                .setBackground({ s -> secondaryContainer() })
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
-                        else getContrastCurve(7.0)
-                    },
-                )
-                .build()
-        return super.onSecondaryContainer().toBuilder()
+                .setPalette { s -> s.secondaryPalette }
+                .setBackground { s -> secondaryContainer() }
+                .setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(6.0)
+                    } else {
+                        getContrastCurve(7.0)
+                    }
+                }.build()
+        return super
+            .onSecondaryContainer()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
@@ -1023,212 +1075,219 @@ public class ColorSpec2025 : ColorSpec2021() {
 
     public override fun tertiary(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("tertiary")
-                .setPalette({ s -> s.tertiaryPalette })
-                .setTone(
-                    { s ->
-                        if (s.platform === Platform.WATCH) {
-                            if (s.variant === Variant.TONAL_SPOT)
-                                tMaxC(s.tertiaryPalette, 0.0, 90.0)
-                            else
-                                tMaxC(s.tertiaryPalette)
-                        } else if (s.variant === Variant.EXPRESSIVE || s.variant === Variant.VIBRANT) {
-                            val upperBound = if (s.tertiaryPalette.keyColor.isCyan()) 88
-                            else {
-                                if (s.isDark) 98 else 100
-                            }
+                .setPalette { s -> s.tertiaryPalette }
+                .setTone { s ->
+                    if (s.platform === Platform.WATCH) {
+                        if (s.variant === Variant.TONAL_SPOT) {
+                            tMaxC(s.tertiaryPalette, 0.0, 90.0)
+                        } else {
+                            tMaxC(s.tertiaryPalette)
+                        }
+                    } else if (s.variant === Variant.EXPRESSIVE || s.variant === Variant.VIBRANT) {
+                        val upperBound = if (s.tertiaryPalette.keyColor.isCyan()) {
+                            88
+                        } else {
+                            if (s.isDark) 98 else 100
+                        }
+                        tMaxC(
+                            palette = s.tertiaryPalette,
+                            lowerBound = 0.0,
+                            upperBound = upperBound.toDouble(),
+                        )
+                    } else { // NEUTRAL and TONAL_SPOT
+                        if (s.isDark) {
                             tMaxC(
                                 palette = s.tertiaryPalette,
                                 lowerBound = 0.0,
-                                upperBound = upperBound.toDouble(),
-                            )
-                        } else { // NEUTRAL and TONAL_SPOT
-                            if (s.isDark) tMaxC(
-                                palette = s.tertiaryPalette,
-                                lowerBound = 0.0,
                                 upperBound = 98.0,
-                            ) else tMaxC(s.tertiaryPalette)
-                        }
-                    },
-                )
-                .setIsBackground(true)
-                .setBackground(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.isDark) surfaceBright() else surfaceDim()
-                        } else {
-                            surfaceContainerHigh()
-                        }
-                    },
-                )
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(4.5)
-                        else getContrastCurve(7.0)
-                    },
-                )
-                .setToneDeltaPair(
-                    { s ->
-                        if (s.platform === Platform.PHONE)
-                            ToneDeltaPair(
-                                roleA = tertiaryContainer(),
-                                roleB = tertiary(),
-                                delta = 5.0,
-                                polarity = TonePolarity.RELATIVE_LIGHTER,
-                                deltaConstraint = DeltaConstraint.FARTHER,
                             )
-                        else null
-                    },
-                )
-                .build()
-        return super.tertiary().toBuilder()
+                        } else {
+                            tMaxC(s.tertiaryPalette)
+                        }
+                    }
+                }.setIsBackground(true)
+                .setBackground { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.isDark) surfaceBright() else surfaceDim()
+                    } else {
+                        surfaceContainerHigh()
+                    }
+                }.setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(4.5)
+                    } else {
+                        getContrastCurve(7.0)
+                    }
+                }.setToneDeltaPair { s ->
+                    if (s.platform === Platform.PHONE) {
+                        ToneDeltaPair(
+                            roleA = tertiaryContainer(),
+                            roleB = tertiary(),
+                            delta = 5.0,
+                            polarity = TonePolarity.RELATIVE_LIGHTER,
+                            deltaConstraint = DeltaConstraint.FARTHER,
+                        )
+                    } else {
+                        null
+                    }
+                }.build()
+        return super
+            .tertiary()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
-    public override fun tertiaryDim(): DynamicColor {
-        return DynamicColor.Companion.Builder()
+    public override fun tertiaryDim(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
             .setName("tertiary_dim")
-            .setPalette({ s -> s.tertiaryPalette })
-            .setTone(
-                { s ->
-                    if (s.variant === Variant.TONAL_SPOT) {
-                        tMaxC(s.tertiaryPalette, 0.0, 90.0)
-                    } else {
-                        tMaxC(s.tertiaryPalette)
-                    }
-                },
-            )
-            .setIsBackground(true)
-            .setBackground({ s -> surfaceContainerHigh() })
-            .setContrastCurve({ s -> getContrastCurve(4.5) })
-            .setToneDeltaPair(
-                { s ->
-                    ToneDeltaPair(
-                        roleA = tertiaryDim(),
-                        roleB = tertiary(),
-                        delta = 5.0,
-                        polarity = TonePolarity.DARKER,
-                        deltaConstraint = DeltaConstraint.FARTHER,
-                    )
-                },
-            )
-            .build()
-    }
+            .setPalette { s -> s.tertiaryPalette }
+            .setTone { s ->
+                if (s.variant === Variant.TONAL_SPOT) {
+                    tMaxC(s.tertiaryPalette, 0.0, 90.0)
+                } else {
+                    tMaxC(s.tertiaryPalette)
+                }
+            }.setIsBackground(true)
+            .setBackground { s -> surfaceContainerHigh() }
+            .setContrastCurve { s -> getContrastCurve(4.5) }
+            .setToneDeltaPair { s ->
+                ToneDeltaPair(
+                    roleA = tertiaryDim(),
+                    roleB = tertiary(),
+                    delta = 5.0,
+                    polarity = TonePolarity.DARKER,
+                    deltaConstraint = DeltaConstraint.FARTHER,
+                )
+            }.build()
 
     public override fun onTertiary(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_tertiary")
-                .setPalette({ s -> s.tertiaryPalette })
-                .setBackground({ s -> if (s.platform === Platform.PHONE) tertiary() else tertiaryDim() })
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
-                        else getContrastCurve(7.0)
-                    },
-                )
-                .build()
-        return super.onTertiary().toBuilder()
+                .setPalette { s -> s.tertiaryPalette }
+                .setBackground { s ->
+                    if (s.platform === Platform.PHONE) tertiary() else tertiaryDim()
+                }.setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(6.0)
+                    } else {
+                        getContrastCurve(7.0)
+                    }
+                }.build()
+        return super
+            .onTertiary()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun tertiaryContainer(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("tertiary_container")
-                .setPalette({ s -> s.tertiaryPalette })
-                .setTone(
-                    { s ->
-                        if (s.platform === Platform.WATCH) {
-                            if (s.variant === Variant.TONAL_SPOT) tMaxC(s.tertiaryPalette, 0.0, 90.0)
-                            else tMaxC(s.tertiaryPalette)
+                .setPalette { s -> s.tertiaryPalette }
+                .setTone { s ->
+                    if (s.platform === Platform.WATCH) {
+                        if (s.variant === Variant.TONAL_SPOT) {
+                            tMaxC(s.tertiaryPalette, 0.0, 90.0)
                         } else {
-                            when {
-                                s.variant === Variant.NEUTRAL -> {
-                                    if (s.isDark)
-                                        tMaxC(s.tertiaryPalette, 0.0, 93.0)
-                                    else
-                                        tMaxC(s.tertiaryPalette, 0.0, 96.0)
+                            tMaxC(s.tertiaryPalette)
+                        }
+                    } else {
+                        when {
+                            s.variant === Variant.NEUTRAL -> {
+                                if (s.isDark) {
+                                    tMaxC(s.tertiaryPalette, 0.0, 93.0)
+                                } else {
+                                    tMaxC(s.tertiaryPalette, 0.0, 96.0)
                                 }
-                                s.variant === Variant.TONAL_SPOT -> {
-                                    tMaxC(
-                                        palette = s.tertiaryPalette,
-                                        lowerBound = 0.0,
-                                        upperBound = (if (s.isDark) 93 else 100).toDouble(),
-                                    )
+                            }
+                            s.variant === Variant.TONAL_SPOT -> {
+                                tMaxC(
+                                    palette = s.tertiaryPalette,
+                                    lowerBound = 0.0,
+                                    upperBound = (if (s.isDark) 93 else 100).toDouble(),
+                                )
+                            }
+                            s.variant === Variant.EXPRESSIVE -> {
+                                val upperBound = if (s.tertiaryPalette.keyColor.isCyan()) {
+                                    88
+                                } else {
+                                    if (s.isDark) 93 else 100
                                 }
-                                s.variant === Variant.EXPRESSIVE -> {
-                                    val upperBound = if (s.tertiaryPalette.keyColor.isCyan()) 88
-                                    else {
-                                        if (s.isDark) 93 else 100
-                                    }
 
-                                    tMaxC(
-                                        palette = s.tertiaryPalette,
-                                        lowerBound = 75.0,
-                                        upperBound = upperBound.toDouble(),
-                                    )
-                                }
-                                else -> { // VIBRANT
-                                    if (s.isDark) tMaxC(s.tertiaryPalette, 0.0, 93.0)
-                                    else tMaxC(s.tertiaryPalette, 72.0, 100.0)
+                                tMaxC(
+                                    palette = s.tertiaryPalette,
+                                    lowerBound = 75.0,
+                                    upperBound = upperBound.toDouble(),
+                                )
+                            }
+                            else -> { // VIBRANT
+                                if (s.isDark) {
+                                    tMaxC(s.tertiaryPalette, 0.0, 93.0)
+                                } else {
+                                    tMaxC(s.tertiaryPalette, 72.0, 100.0)
                                 }
                             }
                         }
-                    },
-                )
-                .setIsBackground(true)
-                .setBackground(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
-                        } else {
-                            return@setBackground null
-                        }
-                    },
-                )
-                .setToneDeltaPair(
-                    { s ->
-                        if (s.platform === Platform.WATCH)
-                            ToneDeltaPair(
-                                roleA = tertiaryContainer(),
-                                roleB = tertiaryDim(),
-                                delta = 10.0,
-                                polarity = TonePolarity.DARKER,
-                                deltaConstraint = DeltaConstraint.FARTHER,
-                            )
-                        else null
-                    },
-                )
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE && s.contrastLevel > 0) getContrastCurve(1.5)
-                        else null
-                    },
-                )
-                .build()
-        return super.tertiaryContainer().toBuilder()
+                    }
+                }.setIsBackground(true)
+                .setBackground { s ->
+                    if (s.platform === Platform.PHONE) {
+                        return@setBackground if (s.isDark) surfaceBright() else surfaceDim()
+                    } else {
+                        return@setBackground null
+                    }
+                }.setToneDeltaPair { s ->
+                    if (s.platform === Platform.WATCH) {
+                        ToneDeltaPair(
+                            roleA = tertiaryContainer(),
+                            roleB = tertiaryDim(),
+                            delta = 10.0,
+                            polarity = TonePolarity.DARKER,
+                            deltaConstraint = DeltaConstraint.FARTHER,
+                        )
+                    } else {
+                        null
+                    }
+                }.setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE && s.contrastLevel > 0) {
+                        getContrastCurve(1.5)
+                    } else {
+                        null
+                    }
+                }.build()
+        return super
+            .tertiaryContainer()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun onTertiaryContainer(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_tertiary_container")
-                .setPalette({ s -> s.tertiaryPalette })
-                .setBackground({ s -> tertiaryContainer() })
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
-                        else getContrastCurve(7.0)
-                    },
-                )
-                .build()
-        return super.onTertiaryContainer().toBuilder()
+                .setPalette { s -> s.tertiaryPalette }
+                .setBackground { s -> tertiaryContainer() }
+                .setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(6.0)
+                    } else {
+                        getContrastCurve(7.0)
+                    }
+                }.build()
+        return super
+            .onTertiaryContainer()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
@@ -1237,168 +1296,167 @@ public class ColorSpec2025 : ColorSpec2021() {
 
     public override fun error(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("error")
-                .setPalette({ s -> s.errorPalette })
-                .setTone(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.isDark) tMinC(
+                .setPalette { s -> s.errorPalette }
+                .setTone { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.isDark) {
+                            tMinC(
                                 palette = s.errorPalette,
                                 lowerBound = 0.0,
                                 upperBound = 98.0,
-                            ) else tMaxC(s.errorPalette)
-                        } else {
-                            tMinC(s.errorPalette)
-                        }
-                    },
-                )
-                .setIsBackground(true)
-                .setBackground(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.isDark) surfaceBright() else surfaceDim()
-                        } else {
-                            surfaceContainerHigh()
-                        }
-                    },
-                )
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(4.5)
-                        else getContrastCurve(7.0)
-                    },
-                )
-                .setToneDeltaPair(
-                    { s ->
-                        if (s.platform === Platform.PHONE)
-                            ToneDeltaPair(
-                                roleA = errorContainer(),
-                                roleB = error(),
-                                delta = 5.0,
-                                polarity = TonePolarity.RELATIVE_LIGHTER,
-                                deltaConstraint = DeltaConstraint.FARTHER,
                             )
-                        else null
-                    },
-                )
-                .build()
-        return super.error().toBuilder()
+                        } else {
+                            tMaxC(s.errorPalette)
+                        }
+                    } else {
+                        tMinC(s.errorPalette)
+                    }
+                }.setIsBackground(true)
+                .setBackground { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.isDark) surfaceBright() else surfaceDim()
+                    } else {
+                        surfaceContainerHigh()
+                    }
+                }.setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(4.5)
+                    } else {
+                        getContrastCurve(7.0)
+                    }
+                }.setToneDeltaPair { s ->
+                    if (s.platform === Platform.PHONE) {
+                        ToneDeltaPair(
+                            roleA = errorContainer(),
+                            roleB = error(),
+                            delta = 5.0,
+                            polarity = TonePolarity.RELATIVE_LIGHTER,
+                            deltaConstraint = DeltaConstraint.FARTHER,
+                        )
+                    } else {
+                        null
+                    }
+                }.build()
+        return super
+            .error()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
-    public override fun errorDim(): DynamicColor {
-        return DynamicColor.Companion.Builder()
+    public override fun errorDim(): DynamicColor =
+        DynamicColor.Companion
+            .Builder()
             .setName("error_dim")
-            .setPalette({ s -> s.errorPalette })
-            .setTone({ s -> tMinC(s.errorPalette) })
+            .setPalette { s -> s.errorPalette }
+            .setTone { s -> tMinC(s.errorPalette) }
             .setIsBackground(true)
-            .setBackground({ s -> surfaceContainerHigh() })
-            .setContrastCurve({ s -> getContrastCurve(4.5) })
-            .setToneDeltaPair(
-                { s ->
-                    ToneDeltaPair(
-                        roleA = errorDim(),
-                        roleB = error(),
-                        delta = 5.0,
-                        polarity = TonePolarity.DARKER,
-                        deltaConstraint = DeltaConstraint.FARTHER,
-                    )
-                },
-            )
-            .build()
-    }
+            .setBackground { s -> surfaceContainerHigh() }
+            .setContrastCurve { s -> getContrastCurve(4.5) }
+            .setToneDeltaPair { s ->
+                ToneDeltaPair(
+                    roleA = errorDim(),
+                    roleB = error(),
+                    delta = 5.0,
+                    polarity = TonePolarity.DARKER,
+                    deltaConstraint = DeltaConstraint.FARTHER,
+                )
+            }.build()
 
     public override fun onError(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_error")
-                .setPalette({ s -> s.errorPalette })
-                .setBackground({ s -> if (s.platform === Platform.PHONE) error() else errorDim() })
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(6.0)
-                        else getContrastCurve(7.0)
-                    },
-                )
-                .build()
-        return super.onError().toBuilder()
+                .setPalette { s -> s.errorPalette }
+                .setBackground { s -> if (s.platform === Platform.PHONE) error() else errorDim() }
+                .setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(6.0)
+                    } else {
+                        getContrastCurve(7.0)
+                    }
+                }.build()
+        return super
+            .onError()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun errorContainer(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("error_container")
-                .setPalette({ s -> s.errorPalette })
-                .setTone(
-                    { s ->
-                        if (s.platform === Platform.WATCH) {
-                            30.0
-                        } else {
-                            if (s.isDark) {
-                                tMinC(
-                                    palette = s.errorPalette,
-                                    lowerBound = 30.0,
-                                    upperBound = 93.0,
-                                )
-                            } else {
-                                tMaxC(s.errorPalette, 0.0, 90.0)
-                            }
-                        }
-                    },
-                )
-                .setIsBackground(true)
-                .setBackground(
-                    { s ->
-                        if (s.platform === Platform.PHONE) {
-                            if (s.isDark) surfaceBright() else surfaceDim()
-                        } else {
-                            null
-                        }
-                    },
-                )
-                .setToneDeltaPair(
-                    { s ->
-                        if (s.platform === Platform.WATCH)
-                            ToneDeltaPair(
-                                roleA = errorContainer(),
-                                roleB = errorDim(),
-                                delta = 10.0,
-                                polarity = TonePolarity.DARKER,
-                                deltaConstraint = DeltaConstraint.FARTHER,
+                .setPalette { s -> s.errorPalette }
+                .setTone { s ->
+                    if (s.platform === Platform.WATCH) {
+                        30.0
+                    } else {
+                        if (s.isDark) {
+                            tMinC(
+                                palette = s.errorPalette,
+                                lowerBound = 30.0,
+                                upperBound = 93.0,
                             )
-                        else null
-                    },
-                )
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE && s.contrastLevel > 0) getContrastCurve(1.5)
-                        else null
-                    },
-                )
-                .build()
-        return super.errorContainer().toBuilder()
+                        } else {
+                            tMaxC(s.errorPalette, 0.0, 90.0)
+                        }
+                    }
+                }.setIsBackground(true)
+                .setBackground { s ->
+                    if (s.platform === Platform.PHONE) {
+                        if (s.isDark) surfaceBright() else surfaceDim()
+                    } else {
+                        null
+                    }
+                }.setToneDeltaPair { s ->
+                    if (s.platform === Platform.WATCH) {
+                        ToneDeltaPair(
+                            roleA = errorContainer(),
+                            roleB = errorDim(),
+                            delta = 10.0,
+                            polarity = TonePolarity.DARKER,
+                            deltaConstraint = DeltaConstraint.FARTHER,
+                        )
+                    } else {
+                        null
+                    }
+                }.setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE && s.contrastLevel > 0) {
+                        getContrastCurve(1.5)
+                    } else {
+                        null
+                    }
+                }.build()
+        return super
+            .errorContainer()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun onErrorContainer(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_error_container")
-                .setPalette({ s -> s.errorPalette })
-                .setBackground({ s -> errorContainer() })
-                .setContrastCurve(
-                    { s ->
-                        if (s.platform === Platform.PHONE) getContrastCurve(4.5)
-                        else getContrastCurve(7.0)
-                    },
-                )
-                .build()
-        return super.onErrorContainer().toBuilder()
+                .setPalette { s -> s.errorPalette }
+                .setBackground { s -> errorContainer() }
+                .setContrastCurve { s ->
+                    if (s.platform === Platform.PHONE) {
+                        getContrastCurve(4.5)
+                    } else {
+                        getContrastCurve(7.0)
+                    }
+                }.build()
+        return super
+            .onErrorContainer()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
@@ -1407,68 +1465,74 @@ public class ColorSpec2025 : ColorSpec2021() {
 
     public override fun primaryFixed(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("primary_fixed")
-                .setPalette({ s -> s.primaryPalette })
-                .setTone(
-                    { s ->
-                        val tempS = DynamicScheme.from(s, false)
-                        primaryContainer().getTone(tempS)
-                    },
-                )
-                .setIsBackground(true)
+                .setPalette { s -> s.primaryPalette }
+                .setTone { s ->
+                    val tempS = DynamicScheme.from(s, false)
+                    primaryContainer().getTone(tempS)
+                }.setIsBackground(true)
                 .build()
-        return super.primaryFixed().toBuilder()
+        return super
+            .primaryFixed()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun primaryFixedDim(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("primary_fixed_dim")
-                .setPalette({ s -> s.primaryPalette })
-                .setTone({ s -> primaryFixed().getTone(s) })
+                .setPalette { s -> s.primaryPalette }
+                .setTone { s -> primaryFixed().getTone(s) }
                 .setIsBackground(true)
-                .setToneDeltaPair(
-                    { s ->
-                        ToneDeltaPair(
-                            roleA = primaryFixedDim(),
-                            roleB = primaryFixed(),
-                            delta = 5.0,
-                            polarity = TonePolarity.DARKER,
-                            deltaConstraint = DeltaConstraint.EXACT,
-                        )
-                    },
-                )
-                .build()
-        return super.primaryFixedDim().toBuilder()
+                .setToneDeltaPair { s ->
+                    ToneDeltaPair(
+                        roleA = primaryFixedDim(),
+                        roleB = primaryFixed(),
+                        delta = 5.0,
+                        polarity = TonePolarity.DARKER,
+                        deltaConstraint = DeltaConstraint.EXACT,
+                    )
+                }.build()
+        return super
+            .primaryFixedDim()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun onPrimaryFixed(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_primary_fixed")
-                .setPalette({ s -> s.primaryPalette })
-                .setBackground({ s -> primaryFixedDim() })
-                .setContrastCurve({ s -> getContrastCurve(7.0) })
+                .setPalette { s -> s.primaryPalette }
+                .setBackground { s -> primaryFixedDim() }
+                .setContrastCurve { s -> getContrastCurve(7.0) }
                 .build()
-        return super.onPrimaryFixed().toBuilder()
+        return super
+            .onPrimaryFixed()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun onPrimaryFixedVariant(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_primary_fixed_variant")
-                .setPalette({ s -> s.primaryPalette })
-                .setBackground({ s -> primaryFixedDim() })
-                .setContrastCurve({ s -> getContrastCurve(4.5) })
+                .setPalette { s -> s.primaryPalette }
+                .setBackground { s -> primaryFixedDim() }
+                .setContrastCurve { s -> getContrastCurve(4.5) }
                 .build()
-        return super.onPrimaryFixedVariant().toBuilder()
+        return super
+            .onPrimaryFixedVariant()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
@@ -1477,68 +1541,74 @@ public class ColorSpec2025 : ColorSpec2021() {
 
     public override fun secondaryFixed(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("secondary_fixed")
-                .setPalette({ s -> s.secondaryPalette })
-                .setTone(
-                    { s ->
-                        val tempS: DynamicScheme = DynamicScheme.from(s, isDark = false)
-                        secondaryContainer().getTone(tempS)
-                    },
-                )
-                .setIsBackground(true)
+                .setPalette { s -> s.secondaryPalette }
+                .setTone { s ->
+                    val tempS: DynamicScheme = DynamicScheme.from(s, isDark = false)
+                    secondaryContainer().getTone(tempS)
+                }.setIsBackground(true)
                 .build()
-        return super.secondaryFixed().toBuilder()
+        return super
+            .secondaryFixed()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun secondaryFixedDim(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("secondary_fixed_dim")
-                .setPalette({ s -> s.secondaryPalette })
-                .setTone({ s -> secondaryFixed().getTone(s) })
+                .setPalette { s -> s.secondaryPalette }
+                .setTone { s -> secondaryFixed().getTone(s) }
                 .setIsBackground(true)
-                .setToneDeltaPair(
-                    { s ->
-                        ToneDeltaPair(
-                            roleA = secondaryFixedDim(),
-                            roleB = secondaryFixed(),
-                            delta = 5.0,
-                            polarity = TonePolarity.DARKER,
-                            deltaConstraint = DeltaConstraint.EXACT,
-                        )
-                    },
-                )
-                .build()
-        return super.secondaryFixedDim().toBuilder()
+                .setToneDeltaPair { s ->
+                    ToneDeltaPair(
+                        roleA = secondaryFixedDim(),
+                        roleB = secondaryFixed(),
+                        delta = 5.0,
+                        polarity = TonePolarity.DARKER,
+                        deltaConstraint = DeltaConstraint.EXACT,
+                    )
+                }.build()
+        return super
+            .secondaryFixedDim()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun onSecondaryFixed(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_secondary_fixed")
-                .setPalette({ s -> s.secondaryPalette })
-                .setBackground({ s -> secondaryFixedDim() })
-                .setContrastCurve({ s -> getContrastCurve(7.0) })
+                .setPalette { s -> s.secondaryPalette }
+                .setBackground { s -> secondaryFixedDim() }
+                .setContrastCurve { s -> getContrastCurve(7.0) }
                 .build()
-        return super.onSecondaryFixed().toBuilder()
+        return super
+            .onSecondaryFixed()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun onSecondaryFixedVariant(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_secondary_fixed_variant")
-                .setPalette({ s -> s.secondaryPalette })
-                .setBackground({ s -> secondaryFixedDim() })
-                .setContrastCurve({ s -> getContrastCurve(4.5) })
+                .setPalette { s -> s.secondaryPalette }
+                .setBackground { s -> secondaryFixedDim() }
+                .setContrastCurve { s -> getContrastCurve(4.5) }
                 .build()
-        return super.onSecondaryFixedVariant().toBuilder()
+        return super
+            .onSecondaryFixedVariant()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
@@ -1547,68 +1617,74 @@ public class ColorSpec2025 : ColorSpec2021() {
 
     public override fun tertiaryFixed(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("tertiary_fixed")
-                .setPalette({ s -> s.tertiaryPalette })
-                .setTone(
-                    { s ->
-                        val tempS = DynamicScheme.from(s, isDark = false)
-                        tertiaryContainer().getTone(tempS)
-                    },
-                )
-                .setIsBackground(true)
+                .setPalette { s -> s.tertiaryPalette }
+                .setTone { s ->
+                    val tempS = DynamicScheme.from(s, isDark = false)
+                    tertiaryContainer().getTone(tempS)
+                }.setIsBackground(true)
                 .build()
-        return super.tertiaryFixed().toBuilder()
+        return super
+            .tertiaryFixed()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun tertiaryFixedDim(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("tertiary_fixed_dim")
-                .setPalette({ s -> s.tertiaryPalette })
-                .setTone({ s -> tertiaryFixed().getTone(s) })
+                .setPalette { s -> s.tertiaryPalette }
+                .setTone { s -> tertiaryFixed().getTone(s) }
                 .setIsBackground(true)
-                .setToneDeltaPair(
-                    { s ->
-                        ToneDeltaPair(
-                            roleA = tertiaryFixedDim(),
-                            roleB = tertiaryFixed(),
-                            delta = 5.0,
-                            polarity = TonePolarity.DARKER,
-                            deltaConstraint = DeltaConstraint.EXACT,
-                        )
-                    },
-                )
-                .build()
-        return super.tertiaryFixedDim().toBuilder()
+                .setToneDeltaPair { s ->
+                    ToneDeltaPair(
+                        roleA = tertiaryFixedDim(),
+                        roleB = tertiaryFixed(),
+                        delta = 5.0,
+                        polarity = TonePolarity.DARKER,
+                        deltaConstraint = DeltaConstraint.EXACT,
+                    )
+                }.build()
+        return super
+            .tertiaryFixedDim()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun onTertiaryFixed(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_tertiary_fixed")
-                .setPalette({ s -> s.tertiaryPalette })
-                .setBackground({ s -> tertiaryFixedDim() })
-                .setContrastCurve({ s -> getContrastCurve(7.0) })
+                .setPalette { s -> s.tertiaryPalette }
+                .setBackground { s -> tertiaryFixedDim() }
+                .setContrastCurve { s -> getContrastCurve(7.0) }
                 .build()
-        return super.onTertiaryFixed().toBuilder()
+        return super
+            .onTertiaryFixed()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     public override fun onTertiaryFixedVariant(): DynamicColor {
         val color2025 =
-            DynamicColor.Companion.Builder()
+            DynamicColor.Companion
+                .Builder()
                 .setName("on_tertiary_fixed_variant")
-                .setPalette({ s -> s.tertiaryPalette })
-                .setBackground({ s -> tertiaryFixedDim() })
-                .setContrastCurve({ s -> getContrastCurve(4.5) })
+                .setPalette { s -> s.tertiaryPalette }
+                .setBackground { s -> tertiaryFixedDim() }
+                .setContrastCurve { s -> getContrastCurve(4.5) }
                 .build()
-        return super.onTertiaryFixedVariant().toBuilder()
+        return super
+            .onTertiaryFixedVariant()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
@@ -1618,7 +1694,9 @@ public class ColorSpec2025 : ColorSpec2021() {
     public override fun controlActivated(): DynamicColor {
         // Remapped to primaryContainer for 2025 spec.
         val color2025 = primaryContainer().toBuilder().setName("control_activated").build()
-        return super.controlActivated().toBuilder()
+        return super
+            .controlActivated()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
@@ -1626,7 +1704,9 @@ public class ColorSpec2025 : ColorSpec2021() {
     public override fun controlNormal(): DynamicColor {
         // Remapped to onSurfaceVariant for 2025 spec.
         val color2025 = onSurfaceVariant().toBuilder().setName("control_normal").build()
-        return super.controlNormal().toBuilder()
+        return super
+            .controlNormal()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
@@ -1634,14 +1714,19 @@ public class ColorSpec2025 : ColorSpec2021() {
     public override fun textPrimaryInverse(): DynamicColor {
         // Remapped to inverseOnSurface for 2025 spec.
         val color2025 = inverseOnSurface().toBuilder().setName("text_primary_inverse").build()
-        return super.textPrimaryInverse().toBuilder()
+        return super
+            .textPrimaryInverse()
+            .toBuilder()
             .extendSpecVersion(ColorSpec.SpecVersion.SPEC_2025, color2025)
             .build()
     }
 
     // Color value calculations
 
-    public override fun getHct(scheme: DynamicScheme, color: DynamicColor): Hct {
+    public override fun getHct(
+        scheme: DynamicScheme,
+        color: DynamicColor,
+    ): Hct {
         // This is crucial for aesthetics: we aren't simply the taking the standard color
         // and changing its tone for contrast. Rather, we find the tone for contrast, then
         // use the specified chroma from the palette to construct a new color.
@@ -1651,13 +1736,17 @@ public class ColorSpec2025 : ColorSpec2021() {
         val palette: TonalPalette = color.palette(scheme)
         val tone = getTone(scheme, color)
         val hue: Double = palette.hue
-        val chromaMultiplier = if (color.chromaMultiplier == null) 1 else color.chromaMultiplier(scheme)
+        val chromaMultiplier =
+            if (color.chromaMultiplier == null) 1 else color.chromaMultiplier(scheme)
         val chroma: Double = palette.chroma * (chromaMultiplier?.toDouble() ?: 1.0)
 
         return Hct.from(hue, chroma, tone)
     }
 
-    public override fun getTone(scheme: DynamicScheme, color: DynamicColor): Double {
+    public override fun getTone(
+        scheme: DynamicScheme,
+        color: DynamicColor,
+    ): Double {
         val toneDeltaPair: ToneDeltaPair? =
             if (color.toneDeltaPair == null) null else color.toneDeltaPair(scheme)
 
@@ -1668,12 +1757,16 @@ public class ColorSpec2025 : ColorSpec2021() {
             val polarity = toneDeltaPair.polarity
             val constraint: DeltaConstraint = toneDeltaPair.deltaConstraint
             val absoluteDelta =
-                if (polarity == TonePolarity.DARKER || (polarity == TonePolarity.RELATIVE_LIGHTER && scheme.isDark)
-                    || (polarity == TonePolarity.RELATIVE_DARKER && !scheme.isDark)
-                ) -toneDeltaPair.delta
-                else toneDeltaPair.delta
+                if (polarity == TonePolarity.DARKER ||
+                    (polarity == TonePolarity.RELATIVE_LIGHTER && scheme.isDark) ||
+                    (polarity == TonePolarity.RELATIVE_DARKER && !scheme.isDark)
+                ) {
+                    -toneDeltaPair.delta
+                } else {
+                    toneDeltaPair.delta
+                }
 
-            val amRoleA = color.name.equals(roleA.name)
+            val amRoleA = color.name == roleA.name
             val selfRole = if (amRoleA) roleA else roleB
             val referenceRole = if (amRoleA) roleB else roleA
             var selfTone: Double = selfRole.tone(scheme)
@@ -1681,7 +1774,9 @@ public class ColorSpec2025 : ColorSpec2021() {
             val relativeDelta = absoluteDelta * (if (amRoleA) 1 else -1)
 
             when (constraint) {
-                DeltaConstraint.EXACT -> selfTone = (referenceTone + relativeDelta).coerceIn(0.0, 100.0)
+                DeltaConstraint.EXACT ->
+                    selfTone =
+                        (referenceTone + relativeDelta).coerceIn(0.0, 100.0)
                 DeltaConstraint.NEARER -> if (relativeDelta > 0) {
                     val t = selfTone.coerceIn(referenceTone, referenceTone + relativeDelta)
                     selfTone = t.coerceIn(0.0, 100.0)
@@ -1690,10 +1785,10 @@ public class ColorSpec2025 : ColorSpec2021() {
                     selfTone = t.coerceIn(0.0, 100.0)
                 }
 
-                DeltaConstraint.FARTHER -> if (relativeDelta > 0) {
-                    selfTone = selfTone.coerceIn(referenceTone + relativeDelta, 100.0)
+                DeltaConstraint.FARTHER -> selfTone = if (relativeDelta > 0) {
+                    selfTone.coerceIn(referenceTone + relativeDelta, 100.0)
                 } else {
-                    selfTone = selfTone.coerceIn(0.0, referenceTone + relativeDelta)
+                    selfTone.coerceIn(0.0, referenceTone + relativeDelta)
                 }
             }
 
@@ -1705,18 +1800,21 @@ public class ColorSpec2025 : ColorSpec2021() {
                     val selfContrast = contrastCurve.get(scheme.contrastLevel)
                     val ratioOfTones = Contrast.ratioOfTones(tone1 = bgTone, tone2 = selfTone)
                     selfTone =
-                        if (ratioOfTones >= selfContrast && scheme.contrastLevel >= 0) selfTone
-                        else DynamicColor.foregroundTone(bgTone, selfContrast)
+                        if (ratioOfTones >= selfContrast && scheme.contrastLevel >= 0) {
+                            selfTone
+                        } else {
+                            DynamicColor.foregroundTone(bgTone, selfContrast)
+                        }
                 }
             }
 
-            // This can avoid the awkward tones for background colors including the access fixed colors.
-            // Accent fixed dim colors should not be adjusted.
+            // This can avoid the awkward tones for background colors including the access fixed
+            // colors. Accent fixed dim colors should not be adjusted.
             if (color.isBackground && !color.name.endsWith("_fixed_dim")) {
-                if (selfTone >= 57) {
-                    selfTone = selfTone.coerceIn(65.0, 100.0)
+                selfTone = if (selfTone >= 57) {
+                    selfTone.coerceIn(65.0, 100.0)
                 } else {
-                    selfTone = selfTone.coerceIn(0.0, 49.0)
+                    selfTone.coerceIn(0.0, 49.0)
                 }
             }
 
@@ -1726,8 +1824,10 @@ public class ColorSpec2025 : ColorSpec2021() {
             var answer: Double = color.tone(scheme)
 
             if (
-                color.background == null || color.background(scheme) == null ||
-                color.contrastCurve == null || color.contrastCurve(scheme) == null
+                color.background == null ||
+                color.background(scheme) == null ||
+                color.contrastCurve == null ||
+                color.contrastCurve(scheme) == null
             ) {
                 return answer // No adjustment for colors with no background.
             }
@@ -1740,16 +1840,19 @@ public class ColorSpec2025 : ColorSpec2021() {
             // (<0).
             val ratioOfTones = Contrast.ratioOfTones(tone1 = bgTone, tone2 = answer)
             answer =
-                if (ratioOfTones >= desiredRatio && scheme.contrastLevel >= 0) answer
-                else DynamicColor.foregroundTone(bgTone, desiredRatio)
-
-            // This can avoid the awkward tones for background colors including the access fixed colors.
-            // Accent fixed dim colors should not be adjusted.
-            if (color.isBackground && !color.name.endsWith("_fixed_dim")) {
-                if (answer >= 57) {
-                    answer = answer.coerceIn(65.0, 100.0)
+                if (ratioOfTones >= desiredRatio && scheme.contrastLevel >= 0) {
+                    answer
                 } else {
-                    answer = answer.coerceIn(0.0, 49.0)
+                    DynamicColor.foregroundTone(bgTone, desiredRatio)
+                }
+
+            // This can avoid the awkward tones for background colors including the access
+            // fixed colors. Accent fixed dim colors should not be adjusted.
+            if (color.isBackground && !color.name.endsWith("_fixed_dim")) {
+                answer = if (answer >= 57) {
+                    answer.coerceIn(65.0, 100.0)
+                } else {
+                    answer.coerceIn(0.0, 49.0)
                 }
             }
 
@@ -1763,8 +1866,8 @@ public class ColorSpec2025 : ColorSpec2021() {
             val upper: Double = max(bgTone1, bgTone2)
             val lower: Double = min(bgTone1, bgTone2)
 
-            if (Contrast.ratioOfTones(upper, answer) >= desiredRatio
-                && Contrast.ratioOfTones(lower, answer) >= desiredRatio
+            if (Contrast.ratioOfTones(upper, answer) >= desiredRatio &&
+                Contrast.ratioOfTones(lower, answer) >= desiredRatio
             ) {
                 return answer
             }
@@ -1787,8 +1890,8 @@ public class ColorSpec2025 : ColorSpec2021() {
             }
 
             val prefersLight =
-                DynamicColor.tonePrefersLightForeground(bgTone1)
-                    || DynamicColor.tonePrefersLightForeground(bgTone2)
+                DynamicColor.tonePrefersLightForeground(bgTone1) ||
+                    DynamicColor.tonePrefersLightForeground(bgTone2)
             if (prefersLight) {
                 return if (lightOption < 0) 100.0 else lightOption
             }
@@ -1806,201 +1909,256 @@ public class ColorSpec2025 : ColorSpec2021() {
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: Platform,
-        contrastLevel: Double
-    ): TonalPalette = when (variant) {
-        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = if (platform === Platform.PHONE)
-                (if (sourceColorHct.isBlue()) 12.0 else 8.0)
-            else
-                (if (sourceColorHct.isBlue()) 16.0 else 12.0),
-        )
-        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = if (platform === Platform.PHONE && isDark) 26.0 else 32.0,
-        )
-        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = if (platform === Platform.PHONE) (if (isDark) 36.0 else 48.0) else 40.0,
-        )
-        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = if (platform === Platform.PHONE) 74.0 else 56.0,
-        )
-        else -> super.getPrimaryPalette(
-            variant = variant,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        )
-    }
+        contrastLevel: Double,
+    ): TonalPalette =
+        when (variant) {
+            Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = if (platform === Platform.PHONE) {
+                    (if (sourceColorHct.isBlue()) 12.0 else 8.0)
+                } else {
+                    (if (sourceColorHct.isBlue()) 16.0 else 12.0)
+                },
+            )
+            Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = if (platform === Platform.PHONE && isDark) 26.0 else 32.0,
+            )
+            Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = if (platform === Platform.PHONE) (if (isDark) 36.0 else 48.0) else 40.0,
+            )
+            Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = if (platform === Platform.PHONE) 74.0 else 56.0,
+            )
+            else -> super.getPrimaryPalette(
+                variant = variant,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            )
+        }
 
     override fun getSecondaryPalette(
         variant: Variant,
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: Platform,
-        contrastLevel: Double
-    ): TonalPalette = when (variant) {
-        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = if (platform === Platform.PHONE) {
-                if (sourceColorHct.isBlue()) 6.0 else 4.0
-            } else {
-                if (sourceColorHct.isBlue()) 10.0 else 6.0
-            },
-        )
-        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 16.0)
-        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
-            hue = DynamicScheme.getRotatedHue(
-                sourceColorHct = sourceColorHct,
-                hueBreakpoints = doubleArrayOf(0.0, 105.0, 140.0, 204.0, 253.0, 278.0, 300.0, 333.0, 360.0),
-                rotations = doubleArrayOf(-160.0, 155.0, -100.0, 96.0, -96.0, -156.0, -165.0, -160.0),
-            ),
-            chroma = if (platform === Platform.PHONE) (if (isDark) 16.0 else 24.0) else 24.0,
-        )
-        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
-            hue = DynamicScheme.getRotatedHue(
-                sourceColorHct = sourceColorHct,
-                hueBreakpoints = doubleArrayOf(0.0, 38.0, 105.0, 140.0, 333.0, 360.0),
-                rotations = doubleArrayOf(-14.0, 10.0, -14.0, 10.0, -14.0),
-            ),
-            chroma = if (platform === Platform.PHONE) 56.0 else 36.0,
-        )
-        else -> super.getSecondaryPalette(
-            variant,
-            sourceColorHct,
-            isDark,
-            platform,
-            contrastLevel,
-        )
-    }
+        contrastLevel: Double,
+    ): TonalPalette =
+        when (variant) {
+            Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = if (platform === Platform.PHONE) {
+                    if (sourceColorHct.isBlue()) 6.0 else 4.0
+                } else {
+                    if (sourceColorHct.isBlue()) 10.0 else 6.0
+                },
+            )
+            Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(sourceColorHct.hue, 16.0)
+            Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+                hue = DynamicScheme.getRotatedHue(
+                    sourceColorHct = sourceColorHct,
+                    hueBreakpoints = doubleArrayOf(
+                        0.0,
+                        105.0,
+                        140.0,
+                        204.0,
+                        253.0,
+                        278.0,
+                        300.0,
+                        333.0,
+                        360.0,
+                    ),
+                    rotations = doubleArrayOf(
+                        -160.0,
+                        155.0,
+                        -100.0,
+                        96.0,
+                        -96.0,
+                        -156.0,
+                        -165.0,
+                        -160.0,
+                    ),
+                ),
+                chroma = if (platform === Platform.PHONE) (if (isDark) 16.0 else 24.0) else 24.0,
+            )
+            Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
+                hue = DynamicScheme.getRotatedHue(
+                    sourceColorHct = sourceColorHct,
+                    hueBreakpoints = doubleArrayOf(0.0, 38.0, 105.0, 140.0, 333.0, 360.0),
+                    rotations = doubleArrayOf(-14.0, 10.0, -14.0, 10.0, -14.0),
+                ),
+                chroma = if (platform === Platform.PHONE) 56.0 else 36.0,
+            )
+            else -> super.getSecondaryPalette(
+                variant,
+                sourceColorHct,
+                isDark,
+                platform,
+                contrastLevel,
+            )
+        }
 
     override fun getTertiaryPalette(
         variant: Variant,
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: Platform,
-        contrastLevel: Double
-    ): TonalPalette = when (variant) {
-        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
-            hue = DynamicScheme.getRotatedHue(
+        contrastLevel: Double,
+    ): TonalPalette =
+        when (variant) {
+            Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
+                hue = DynamicScheme.getRotatedHue(
+                    sourceColorHct = sourceColorHct,
+                    hueBreakpoints = doubleArrayOf(0.0, 38.0, 105.0, 161.0, 204.0, 278.0, 333.0, 360.0),
+                    rotations = doubleArrayOf(-32.0, 26.0, 10.0, -39.0, 24.0, -15.0, -32.0),
+                ),
+                chroma = if (platform === Platform.PHONE) 20.0 else 36.0,
+            )
+            Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
+                hue = DynamicScheme.getRotatedHue(
+                    sourceColorHct = sourceColorHct,
+                    hueBreakpoints = doubleArrayOf(0.0, 20.0, 71.0, 161.0, 333.0, 360.0),
+                    rotations = doubleArrayOf(-40.0, 48.0, -32.0, 40.0, -32.0),
+                ),
+                chroma = if (platform === Platform.PHONE) 28.0 else 32.0,
+            )
+            Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+                hue = DynamicScheme.getRotatedHue(
+                    sourceColorHct = sourceColorHct,
+                    hueBreakpoints = doubleArrayOf(
+                        0.0,
+                        105.0,
+                        140.0,
+                        204.0,
+                        253.0,
+                        278.0,
+                        300.0,
+                        333.0,
+                        360.0,
+                    ),
+                    rotations = doubleArrayOf(
+                        -165.0,
+                        160.0,
+                        -105.0,
+                        101.0,
+                        -101.0,
+                        -160.0,
+                        -170.0,
+                        -165.0,
+                    ),
+                ),
+                chroma = 48.0,
+            )
+            Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
+                hue = DynamicScheme.getRotatedHue(
+                    sourceColorHct = sourceColorHct,
+                    hueBreakpoints = doubleArrayOf(
+                        0.0,
+                        38.0,
+                        71.0,
+                        105.0,
+                        140.0,
+                        161.0,
+                        253.0,
+                        333.0,
+                        360.0,
+                    ),
+                    rotations = doubleArrayOf(-72.0, 35.0, 24.0, -24.0, 62.0, 50.0, 62.0, -72.0),
+                ),
+                chroma = 56.0,
+            )
+            else -> super.getTertiaryPalette(
+                variant = variant,
                 sourceColorHct = sourceColorHct,
-                hueBreakpoints = doubleArrayOf(0.0, 38.0, 105.0, 161.0, 204.0, 278.0, 333.0, 360.0),
-                rotations = doubleArrayOf(-32.0, 26.0, 10.0, -39.0, 24.0, -15.0, -32.0),
-            ),
-            chroma = if (platform === Platform.PHONE) 20.0 else 36.0,
-        )
-        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
-            hue = DynamicScheme.getRotatedHue(
-                sourceColorHct = sourceColorHct,
-                hueBreakpoints = doubleArrayOf(0.0, 20.0, 71.0, 161.0, 333.0, 360.0),
-                rotations = doubleArrayOf(-40.0, 48.0, -32.0, 40.0, -32.0),
-            ),
-            chroma = if (platform === Platform.PHONE) 28.0 else 32.0,
-        )
-        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
-            hue = DynamicScheme.getRotatedHue(
-                sourceColorHct = sourceColorHct,
-                hueBreakpoints = doubleArrayOf(0.0, 105.0, 140.0, 204.0, 253.0, 278.0, 300.0, 333.0, 360.0),
-                rotations = doubleArrayOf(-165.0, 160.0, -105.0, 101.0, -101.0, -160.0, -170.0, -165.0),
-            ),
-            chroma = 48.0,
-        )
-        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
-            hue = DynamicScheme.getRotatedHue(
-                sourceColorHct = sourceColorHct,
-                hueBreakpoints = doubleArrayOf(0.0, 38.0, 71.0, 105.0, 140.0, 161.0, 253.0, 333.0, 360.0),
-                rotations = doubleArrayOf(-72.0, 35.0, 24.0, -24.0, 62.0, 50.0, 62.0, -72.0),
-            ),
-            chroma = 56.0,
-        )
-        else -> super.getTertiaryPalette(
-            variant = variant,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        )
-    }
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            )
+        }
 
     override fun getNeutralPalette(
         variant: Variant,
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: Platform,
-        contrastLevel: Double
-    ): TonalPalette = when (variant) {
-        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = if (platform === Platform.PHONE) 1.4 else 6.0,
-        )
-        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = if (platform === Platform.PHONE) 5.0 else 10.0,
-        )
-        Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
-            hue = getExpressiveNeutralHue(sourceColorHct),
-            chroma = getExpressiveNeutralChroma(sourceColorHct, isDark, platform),
-        )
-        Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
-            hue = getVibrantNeutralHue(sourceColorHct),
-            chroma = getVibrantNeutralChroma(sourceColorHct, platform),
-        )
-        else -> super.getNeutralPalette(
-            variant = variant,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        )
-    }
+        contrastLevel: Double,
+    ): TonalPalette =
+        when (variant) {
+            Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = if (platform === Platform.PHONE) 1.4 else 6.0,
+            )
+            Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = if (platform === Platform.PHONE) 5.0 else 10.0,
+            )
+            Variant.EXPRESSIVE -> TonalPalette.fromHueAndChroma(
+                hue = getExpressiveNeutralHue(sourceColorHct),
+                chroma = getExpressiveNeutralChroma(sourceColorHct, isDark, platform),
+            )
+            Variant.VIBRANT -> TonalPalette.fromHueAndChroma(
+                hue = getVibrantNeutralHue(sourceColorHct),
+                chroma = getVibrantNeutralChroma(sourceColorHct, platform),
+            )
+            else -> super.getNeutralPalette(
+                variant = variant,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            )
+        }
 
     override fun getNeutralVariantPalette(
         variant: Variant,
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: Platform,
-        contrastLevel: Double
-    ): TonalPalette = when (variant) {
-        Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = (if (platform === Platform.PHONE) 1.4 else 6.0) * 2.2,
-        )
-        Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = (if (platform === Platform.PHONE) 5 else 10) * 1.7,
-        )
-        Variant.EXPRESSIVE -> {
-            val expressiveNeutralHue = getExpressiveNeutralHue(sourceColorHct)
-            val expressiveNeutralChroma = getExpressiveNeutralChroma(sourceColorHct, isDark, platform)
-            val d = if (expressiveNeutralHue >= 105 && expressiveNeutralHue < 125) 1.6 else 2.3
-            TonalPalette.fromHueAndChroma(
-                hue = expressiveNeutralHue,
-                chroma = expressiveNeutralChroma * d,
+        contrastLevel: Double,
+    ): TonalPalette =
+        when (variant) {
+            Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = (if (platform === Platform.PHONE) 1.4 else 6.0) * 2.2,
+            )
+            Variant.TONAL_SPOT -> TonalPalette.fromHueAndChroma(
+                hue = sourceColorHct.hue,
+                chroma = (if (platform === Platform.PHONE) 5.0 else 10.0) * 1.7,
+            )
+            Variant.EXPRESSIVE -> {
+                val expressiveNeutralHue = getExpressiveNeutralHue(sourceColorHct)
+                val expressiveNeutralChroma =
+                    getExpressiveNeutralChroma(sourceColorHct, isDark, platform)
+                val d = if (expressiveNeutralHue >= 105 && expressiveNeutralHue < 125) 1.6 else 2.3
+                TonalPalette.fromHueAndChroma(
+                    hue = expressiveNeutralHue,
+                    chroma = expressiveNeutralChroma * d,
+                )
+            }
+            Variant.VIBRANT -> {
+                val vibrantNeutralHue = getVibrantNeutralHue(sourceColorHct)
+                val vibrantNeutralChroma = getVibrantNeutralChroma(sourceColorHct, platform)
+                TonalPalette.fromHueAndChroma(vibrantNeutralHue, vibrantNeutralChroma * 1.29)
+            }
+            else -> super.getNeutralVariantPalette(
+                variant = variant,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
             )
         }
-        Variant.VIBRANT -> {
-            val vibrantNeutralHue = getVibrantNeutralHue(sourceColorHct)
-            val vibrantNeutralChroma = getVibrantNeutralChroma(sourceColorHct, platform)
-            TonalPalette.fromHueAndChroma(vibrantNeutralHue, vibrantNeutralChroma * 1.29)
-        }
-        else -> super.getNeutralVariantPalette(
-            variant = variant,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        )
-    }
 
     override fun getErrorPalette(
         variant: Variant,
         sourceColorHct: Hct,
         isDark: Boolean,
         platform: Platform,
-        contrastLevel: Double
+        contrastLevel: Double,
     ): TonalPalette? {
         val errorHue = DynamicScheme.getPiecewiseValue(
             sourceColorHct = sourceColorHct,
@@ -2036,13 +2194,11 @@ public class ColorSpec2025 : ColorSpec2021() {
     }
 
     public companion object {
-        // Other
-
         private fun findBestToneForChroma(
             hue: Double,
             chroma: Double,
             tone: Double,
-            byDecreasingTone: Boolean
+            byDecreasingTone: Boolean,
         ): Double {
             var tone = tone
             var answer = tone
@@ -2061,44 +2217,47 @@ public class ColorSpec2025 : ColorSpec2021() {
             return answer
         }
 
-        private fun tMaxC(palette: TonalPalette): Double {
-            return tMaxC(palette, 0.0, 100.0)
-        }
+        private fun tMaxC(palette: TonalPalette): Double = tMaxC(palette, 0.0, 100.0)
 
-        private fun tMaxC(palette: TonalPalette, lowerBound: Double, upperBound: Double): Double {
+        private fun tMaxC(
+            palette: TonalPalette,
+            lowerBound: Double,
+            upperBound: Double,
+        ): Double {
             val answer = findBestToneForChroma(palette.hue, palette.chroma, 100.0, true)
             return answer.coerceIn(lowerBound, upperBound)
         }
 
-        private fun tMinC(palette: TonalPalette): Double {
-            return tMinC(palette, 0.0, 100.0)
-        }
+        private fun tMinC(palette: TonalPalette): Double = tMinC(palette, 0.0, 100.0)
 
-        private fun tMinC(palette: TonalPalette, lowerBound: Double, upperBound: Double): Double {
+        private fun tMinC(
+            palette: TonalPalette,
+            lowerBound: Double,
+            upperBound: Double,
+        ): Double {
             val answer = findBestToneForChroma(palette.hue, palette.chroma, 0.0, false)
             return answer.coerceIn(lowerBound, upperBound)
         }
 
-        private fun getContrastCurve(defaultContrast: Double): ContrastCurve = when (defaultContrast) {
-            1.5 -> ContrastCurve(1.5, 1.5, 3.0, 4.5)
-            3.0 -> ContrastCurve(3.0, 3.0, 4.5, 7.0)
-            4.5 -> ContrastCurve(4.5, 4.5, 7.0, 11.0)
-            6.0 -> ContrastCurve(6.0, 6.0, 7.0, 11.0)
-            7.0 -> ContrastCurve(7.0, 7.0, 11.0, 21.0)
-            9.0 -> ContrastCurve(9.0, 9.0, 11.0, 21.0)
-            11.0 -> ContrastCurve(11.0, 11.0, 21.0, 21.0)
-            21.0 -> ContrastCurve(21.0, 21.0, 21.0, 21.0)
-            else -> {
-                // Shouldn't happen.
-                ContrastCurve(defaultContrast, defaultContrast, 7.0, 21.0)
+        private fun getContrastCurve(defaultContrast: Double): ContrastCurve =
+            when (defaultContrast) {
+                1.5 -> ContrastCurve(1.5, 1.5, 3.0, 4.5)
+                3.0 -> ContrastCurve(3.0, 3.0, 4.5, 7.0)
+                4.5 -> ContrastCurve(4.5, 4.5, 7.0, 11.0)
+                6.0 -> ContrastCurve(6.0, 6.0, 7.0, 11.0)
+                7.0 -> ContrastCurve(7.0, 7.0, 11.0, 21.0)
+                9.0 -> ContrastCurve(9.0, 9.0, 11.0, 21.0)
+                11.0 -> ContrastCurve(11.0, 11.0, 21.0, 21.0)
+                21.0 -> ContrastCurve(21.0, 21.0, 21.0, 21.0)
+                else -> ContrastCurve(defaultContrast, defaultContrast, 7.0, 21.0)
             }
-        }
 
-        private fun getExpressiveNeutralHue(sourceColorHct: Hct): Double = DynamicScheme.getRotatedHue(
-            sourceColorHct = sourceColorHct,
-            hueBreakpoints = doubleArrayOf(0.0, 71.0, 124.0, 253.0, 278.0, 300.0, 360.0),
-            rotations = doubleArrayOf(10.0, 0.0, 10.0, 0.0, 10.0, 0.0),
-        )
+        private fun getExpressiveNeutralHue(sourceColorHct: Hct): Double =
+            DynamicScheme.getRotatedHue(
+                sourceColorHct = sourceColorHct,
+                hueBreakpoints = doubleArrayOf(0.0, 71.0, 124.0, 253.0, 278.0, 300.0, 360.0),
+                rotations = doubleArrayOf(10.0, 0.0, 10.0, 0.0, 10.0, 0.0),
+            )
 
         private fun getExpressiveNeutralChroma(
             sourceColorHct: Hct,
@@ -2121,16 +2280,21 @@ public class ColorSpec2025 : ColorSpec2021() {
             return value.toDouble()
         }
 
-        private fun getVibrantNeutralHue(sourceColorHct: Hct): Double = DynamicScheme.getRotatedHue(
-            sourceColorHct = sourceColorHct,
-            hueBreakpoints = doubleArrayOf(0.0, 38.0, 105.0, 140.0, 333.0, 360.0),
-            rotations = doubleArrayOf(-14.0, 10.0, -14.0, 10.0, -14.0),
-        )
+        private fun getVibrantNeutralHue(sourceColorHct: Hct): Double =
+            DynamicScheme.getRotatedHue(
+                sourceColorHct = sourceColorHct,
+                hueBreakpoints = doubleArrayOf(0.0, 38.0, 105.0, 140.0, 333.0, 360.0),
+                rotations = doubleArrayOf(-14.0, 10.0, -14.0, 10.0, -14.0),
+            )
 
-        private fun getVibrantNeutralChroma(sourceColorHct: Hct, platform: Platform): Double {
+        private fun getVibrantNeutralChroma(
+            sourceColorHct: Hct,
+            platform: Platform,
+        ): Double {
             val neutralHue = getVibrantNeutralHue(sourceColorHct)
             val neutralHueIsBlue = neutralHue >= 250 && neutralHue < 270
-            return (if (platform === Platform.PHONE) 28 else (if (neutralHueIsBlue) 28 else 20)).toDouble()
+            val value = if (platform === Platform.PHONE) 28 else (if (neutralHueIsBlue) 28 else 20)
+            return value.toDouble()
         }
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2025.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2025.kt
@@ -729,8 +729,13 @@ public class ColorSpec2025 : ColorSpec2021() {
                 .Builder()
                 .setName("on_primary")
                 .setPalette { s -> s.primaryPalette }
-                .setBackground { s -> if (s.platform === Platform.PHONE) primary() else primaryDim() }
-                .setContrastCurve { s ->
+                .setBackground { s ->
+                    if (s.platform === Platform.PHONE) {
+                        primary()
+                    } else {
+                        primaryDim()
+                    }
+                }.setContrastCurve { s ->
                     if (s.platform === Platform.PHONE) {
                         getContrastCurve(6.0)
                     } else {
@@ -2013,7 +2018,16 @@ public class ColorSpec2025 : ColorSpec2021() {
             Variant.NEUTRAL -> TonalPalette.fromHueAndChroma(
                 hue = DynamicScheme.getRotatedHue(
                     sourceColorHct = sourceColorHct,
-                    hueBreakpoints = doubleArrayOf(0.0, 38.0, 105.0, 161.0, 204.0, 278.0, 333.0, 360.0),
+                    hueBreakpoints = doubleArrayOf(
+                        0.0,
+                        38.0,
+                        105.0,
+                        161.0,
+                        204.0,
+                        278.0,
+                        333.0,
+                        360.0,
+                    ),
                     rotations = doubleArrayOf(-32.0, 26.0, 10.0, -39.0, 24.0, -15.0, -32.0),
                 ),
                 chroma = if (platform === Platform.PHONE) 20.0 else 36.0,

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpecs.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpecs.kt
@@ -22,7 +22,6 @@ internal object ColorSpecs {
     private val SPEC_2021: ColorSpec = ColorSpec2021()
     private val SPEC_2025: ColorSpec = ColorSpec2025()
 
-    fun get(
-        specVersion: ColorSpec.SpecVersion?,
-    ): ColorSpec = if (specVersion === ColorSpec.SpecVersion.SPEC_2025) SPEC_2025 else SPEC_2021
+    fun get(specVersion: ColorSpec.SpecVersion?): ColorSpec =
+        if (specVersion === ColorSpec.SpecVersion.SPEC_2025) SPEC_2025 else SPEC_2021
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpecs.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpecs.kt
@@ -15,21 +15,14 @@
  */
 package com.materialkolor.dynamiccolor
 
-import kotlin.jvm.JvmOverloads
-
 /**
  * A utility class to get the correct color spec for a given spec version.
  */
-public object ColorSpecs {
+internal object ColorSpecs {
     private val SPEC_2021: ColorSpec = ColorSpec2021()
     private val SPEC_2025: ColorSpec = ColorSpec2025()
 
-    @JvmOverloads
-    public fun get(specVersion: ColorSpec.SpecVersion? = ColorSpec.SpecVersion.SPEC_2021): ColorSpec =
-        get(specVersion, false)
-
-    public fun get(
+    fun get(
         specVersion: ColorSpec.SpecVersion?,
-        isExtendedFidelity: Boolean,
     ): ColorSpec = if (specVersion === ColorSpec.SpecVersion.SPEC_2025) SPEC_2025 else SPEC_2021
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpecs.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpecs.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.materialkolor.dynamiccolor
+
+import kotlin.jvm.JvmOverloads
+
+/**
+ * A utility class to get the correct color spec for a given spec version.
+ */
+public object ColorSpecs {
+    private val SPEC_2021: ColorSpec = ColorSpec2021()
+    private val SPEC_2025: ColorSpec = ColorSpec2025()
+
+    @JvmOverloads
+    public fun get(specVersion: ColorSpec.SpecVersion? = ColorSpec.SpecVersion.SPEC_2021): ColorSpec {
+        return get(specVersion, false)
+    }
+
+    public fun get(specVersion: ColorSpec.SpecVersion?, isExtendedFidelity: Boolean): ColorSpec {
+        return if (specVersion === ColorSpec.SpecVersion.SPEC_2025) SPEC_2025 else SPEC_2021
+    }
+}

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpecs.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpecs.kt
@@ -25,11 +25,11 @@ public object ColorSpecs {
     private val SPEC_2025: ColorSpec = ColorSpec2025()
 
     @JvmOverloads
-    public fun get(specVersion: ColorSpec.SpecVersion? = ColorSpec.SpecVersion.SPEC_2021): ColorSpec {
-        return get(specVersion, false)
-    }
+    public fun get(specVersion: ColorSpec.SpecVersion? = ColorSpec.SpecVersion.SPEC_2021): ColorSpec =
+        get(specVersion, false)
 
-    public fun get(specVersion: ColorSpec.SpecVersion?, isExtendedFidelity: Boolean): ColorSpec {
-        return if (specVersion === ColorSpec.SpecVersion.SPEC_2025) SPEC_2025 else SPEC_2021
-    }
+    public fun get(
+        specVersion: ColorSpec.SpecVersion?,
+        isExtendedFidelity: Boolean,
+    ): ColorSpec = if (specVersion === ColorSpec.SpecVersion.SPEC_2025) SPEC_2025 else SPEC_2021
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/DynamicColor.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/DynamicColor.kt
@@ -265,7 +265,9 @@ public class DynamicColor(
                 // high and max contrast in light mode. PC's standard tone was T90, OPC's was T10, it was
                 // light mode, and the contrast level was 0.6568521221032331.
                 val negligibleDifference =
-                    abs(lighterRatio - darkerRatio) < 0.1 && lighterRatio < ratio && darkerRatio < ratio
+                    abs(lighterRatio - darkerRatio) < 0.1 &&
+                        lighterRatio < ratio &&
+                        darkerRatio < ratio
                 if (lighterRatio >= ratio || lighterRatio >= darkerRatio || negligibleDifference) {
                     lighterTone
                 } else {
@@ -346,7 +348,9 @@ public class DynamicColor(
                     this.isBackground = isBackground
                 }
 
-            public fun setChromaMultiplier(chromaMultiplier: ((DynamicScheme) -> Double?)?): Builder =
+            public fun setChromaMultiplier(
+                chromaMultiplier: ((DynamicScheme) -> Double?)?,
+            ): Builder =
                 apply {
                     this.chromaMultiplier = chromaMultiplier
                 }
@@ -356,15 +360,20 @@ public class DynamicColor(
                     this.background = background
                 }
 
-            public fun setSecondBackground(secondBackground: ((DynamicScheme) -> DynamicColor?)?): Builder =
-                apply { this.secondBackground = secondBackground }
+            public fun setSecondBackground(
+                secondBackground: ((DynamicScheme) -> DynamicColor?)?,
+            ): Builder = apply { this.secondBackground = secondBackground }
 
-            public fun setContrastCurve(contrastCurve: ((DynamicScheme) -> ContrastCurve?)?): Builder =
+            public fun setContrastCurve(
+                contrastCurve: ((DynamicScheme) -> ContrastCurve?)?,
+            ): Builder =
                 apply {
                     this.contrastCurve = contrastCurve
                 }
 
-            public fun setToneDeltaPair(toneDeltaPair: ((DynamicScheme) -> ToneDeltaPair?)?): Builder =
+            public fun setToneDeltaPair(
+                toneDeltaPair: ((DynamicScheme) -> ToneDeltaPair?)?,
+            ): Builder =
                 apply {
                     this.toneDeltaPair = toneDeltaPair
                 }
@@ -385,10 +394,22 @@ public class DynamicColor(
                     .setIsBackground(this.isBackground)
                     .setPalette { s: DynamicScheme ->
                         val palette =
-                            if (s.specVersion == specVersion) extendedColor.palette else this.palette
+                            if (s.specVersion ==
+                                specVersion
+                            ) {
+                                extendedColor.palette
+                            } else {
+                                this.palette
+                            }
                         palette?.invoke(s) ?: extendedColor.palette(s)
                     }.setTone { s: DynamicScheme ->
-                        val tone = if (s.specVersion == specVersion) extendedColor.tone else this.tone
+                        val tone = if (s.specVersion ==
+                            specVersion
+                        ) {
+                            extendedColor.tone
+                        } else {
+                            this.tone
+                        }
                         tone?.invoke(s) ?: extendedColor.tone(s)
                     }.setChromaMultiplier { s: DynamicScheme ->
                         val chromaMultiplier = if (s.specVersion == specVersion) {
@@ -399,7 +420,13 @@ public class DynamicColor(
                         if (chromaMultiplier != null) chromaMultiplier(s) else 1.0
                     }.setBackground { s: DynamicScheme ->
                         val background =
-                            if (s.specVersion == specVersion) extendedColor.background else this.background
+                            if (s.specVersion ==
+                                specVersion
+                            ) {
+                                extendedColor.background
+                            } else {
+                                this.background
+                            }
                         background?.invoke(s)
                     }.setSecondBackground { s: DynamicScheme ->
                         val secondBackground =
@@ -431,7 +458,13 @@ public class DynamicColor(
                         toneDeltaPair?.invoke(s)
                     }.setOpacity { s: DynamicScheme ->
                         val opacity =
-                            if (s.specVersion == specVersion) extendedColor.opacity else this.opacity
+                            if (s.specVersion ==
+                                specVersion
+                            ) {
+                                extendedColor.opacity
+                            } else {
+                                this.opacity
+                            }
                         opacity?.invoke(s)
                     }
             }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/DynamicColor.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/DynamicColor.kt
@@ -21,8 +21,6 @@ import com.materialkolor.palettes.TonalPalette
 import com.materialkolor.scheme.DynamicScheme
 import dev.drewhamilton.poko.Poko
 import kotlin.math.abs
-import kotlin.math.max
-import kotlin.math.min
 import kotlin.math.round
 
 /**
@@ -78,11 +76,12 @@ public class DynamicColor(
     public val palette: (DynamicScheme) -> TonalPalette,
     public val tone: (DynamicScheme) -> Double,
     public val isBackground: Boolean,
-    public val background: ((DynamicScheme) -> DynamicColor)?,
-    public val secondBackground: ((DynamicScheme) -> DynamicColor)?,
-    public val contrastCurve: ContrastCurve?,
-    public val toneDeltaPair: ((DynamicScheme) -> ToneDeltaPair)?,
-    public val opacity: ((DynamicScheme) -> Double)? = null,
+    public val chromaMultiplier: ((DynamicScheme) -> Double?)? = null,
+    public val background: ((DynamicScheme) -> DynamicColor?)? = null,
+    public val secondBackground: ((DynamicScheme) -> DynamicColor?)? = null,
+    public val contrastCurve: ((DynamicScheme) -> ContrastCurve?)? = null,
+    public val toneDeltaPair: ((DynamicScheme) -> ToneDeltaPair?)? = null,
+    public val opacity: ((DynamicScheme) -> Double?)? = null,
 ) {
     private val hctCache: HashMap<DynamicScheme, Hct> = HashMap()
 
@@ -94,10 +93,11 @@ public class DynamicColor(
      */
     public fun getArgb(scheme: DynamicScheme): Int {
         val argb: Int = getHct(scheme).toInt()
-        if (opacity == null) {
+        val percentage = opacity?.invoke(scheme)
+        if (opacity == null || percentage == null) {
             return argb
         }
-        val percentage: Double = opacity.invoke(scheme)
+
         val alpha = round(percentage * 255).toInt().coerceIn(0, 255)
         return argb and 0x00ffffff or (alpha shl 24)
     }
@@ -119,8 +119,7 @@ public class DynamicColor(
         //
         // For example, this enables colors with standard tone of T90, which has limited chroma, to
         // "recover" intended chroma as contrast increases.
-        val tone = getTone(scheme)
-        val answer: Hct = palette(scheme).getHct(tone)
+        val answer: Hct = ColorSpecs.get(scheme.specVersion).getHct(scheme, this)
         // NOMUTANTS--trivial test with onerous dependency injection requirement.
         if (hctCache.size > 4) {
             hctCache.clear()
@@ -134,169 +133,21 @@ public class DynamicColor(
      * Returns the tone in HCT, ranging from 0 to 100, of the resolved color given scheme.
      */
     public fun getTone(scheme: DynamicScheme): Double {
-        val decreasingContrast: Boolean = scheme.contrastLevel < 0
+        return ColorSpecs.get(scheme.specVersion).getTone(scheme, this)
+    }
 
-        // Case 1: dual foreground, pair of colors with delta constraint.
-        return if (toneDeltaPair != null) {
-            val toneDeltaPair: ToneDeltaPair = toneDeltaPair.invoke(scheme)
-            val roleA: DynamicColor = toneDeltaPair.roleA
-            val roleB: DynamicColor = toneDeltaPair.roleB
-            val delta: Double = toneDeltaPair.delta
-            val polarity: TonePolarity = toneDeltaPair.polarity
-            val stayTogether: Boolean = toneDeltaPair.stayTogether
-            val bg: DynamicColor = background!!(scheme)
-            val bgTone = bg.getTone(scheme)
-            val aIsNearer =
-                polarity === TonePolarity.NEARER ||
-                    polarity === TonePolarity.LIGHTER &&
-                    !scheme.isDark ||
-                    polarity === TonePolarity.DARKER &&
-                    scheme.isDark
-            val nearer = if (aIsNearer) roleA else roleB
-            val farther = if (aIsNearer) roleB else roleA
-            val amNearer = name == nearer.name
-            val expansionDir = (if (scheme.isDark) 1 else -1).toDouble()
-
-            // 1st round: solve to min, each
-            val nContrast: Double = nearer.contrastCurve!!.get(scheme.contrastLevel)
-            val fContrast: Double = farther.contrastCurve!!.get(scheme.contrastLevel)
-
-            // If a color is good enough, it is not adjusted.
-            // Initial and adjusted tones for `nearer`
-            val nInitialTone: Double = nearer.tone(scheme)
-            var nTone = if (Contrast.ratioOfTones(bgTone, nInitialTone) >=
-                nContrast
-            ) {
-                nInitialTone
-            } else {
-                foregroundTone(bgTone, nContrast)
-            }
-            // Initial and adjusted tones for `farther`
-            val fInitialTone: Double = farther.tone(scheme)
-            var fTone = if (Contrast.ratioOfTones(bgTone, fInitialTone) >=
-                fContrast
-            ) {
-                fInitialTone
-            } else {
-                foregroundTone(bgTone, fContrast)
-            }
-            if (decreasingContrast) {
-                // If decreasing contrast, adjust color to the "bare minimum"
-                // that satisfies contrast.
-                nTone = foregroundTone(bgTone, nContrast)
-                fTone = foregroundTone(bgTone, fContrast)
-            }
-
-            // If constraint is not satisfied, try another round.
-            if ((fTone - nTone) * expansionDir < delta) {
-                // 2nd round: expand farther to match delta.
-                fTone = (nTone + delta * expansionDir).coerceIn(0.0, 100.0)
-                // If constraint is not satisfied, try another round.
-                if ((fTone - nTone) * expansionDir < delta) {
-                    // 3rd round: contract nearer to match delta.
-                    nTone = (fTone - delta * expansionDir).coerceIn(0.0, 100.0)
-                }
-            }
-
-            // Avoids the 50-59 awkward zone.
-            if (50 <= nTone && nTone < 60) {
-                // If `nearer` is in the awkward zone, move it away, together with
-                // `farther`.
-                if (expansionDir > 0) {
-                    nTone = 60.0
-                    fTone = max(fTone, nTone + delta * expansionDir)
-                } else {
-                    nTone = 49.0
-                    fTone = min(fTone, nTone + delta * expansionDir)
-                }
-            } else if (50 <= fTone && fTone < 60) {
-                if (stayTogether) {
-                    // Fixes both, to avoid two colors on opposite sides of the "awkward
-                    // zone".
-                    if (expansionDir > 0) {
-                        nTone = 60.0
-                        fTone = max(fTone, nTone + delta * expansionDir)
-                    } else {
-                        nTone = 49.0
-                        fTone = min(fTone, nTone + delta * expansionDir)
-                    }
-                } else {
-                    // Not required to stay together; fixes just one.
-                    fTone = if (expansionDir > 0) {
-                        60.0
-                    } else {
-                        49.0
-                    }
-                }
-            }
-
-            // Returns `nTone` if this color is `nearer`, otherwise `fTone`.
-            if (amNearer) nTone else fTone
-        } else {
-            // Case 2: No contrast pair; just solve for itself.
-            var answer: Double = tone(scheme)
-            if (background == null) {
-                return answer // No adjustment for colors with no background.
-            }
-            val bgTone: Double = background.invoke(scheme).getTone(scheme)
-            val desiredRatio = contrastCurve?.get(scheme.contrastLevel)
-                ?: return answer // No adjustment for colors with no contrast curve.
-            if (Contrast.ratioOfTones(bgTone, answer) >= desiredRatio) {
-                // Don't "improve" what's good enough.
-            } else {
-                // Rough improvement.
-                answer = foregroundTone(bgTone, desiredRatio)
-            }
-            if (decreasingContrast) {
-                answer = foregroundTone(bgTone, desiredRatio)
-            }
-            if (isBackground && 50 <= answer && answer < 60) {
-                // Must adjust
-                answer = (if (Contrast.ratioOfTones(49.0, bgTone) >= desiredRatio) 49.0 else 60.0)
-            }
-            if (secondBackground != null) {
-                // Case 3: Adjust for dual backgrounds.
-                val bgTone1: Double = background.invoke(scheme).getTone(scheme)
-                val bgTone2: Double = secondBackground.invoke(scheme).getTone(scheme)
-                val upper: Double = max(bgTone1, bgTone2)
-                val lower: Double = min(bgTone1, bgTone2)
-                if (Contrast.ratioOfTones(upper, answer) >= desiredRatio &&
-                    Contrast.ratioOfTones(lower, answer) >= desiredRatio
-                ) {
-                    return answer
-                }
-
-                // The darkest light tone that satisfies the desired ratio,
-                // or -1 if such ratio cannot be reached.
-                val lightOption: Double = Contrast.lighter(upper, desiredRatio)
-
-                // The lightest dark tone that satisfies the desired ratio,
-                // or -1 if such ratio cannot be reached.
-                val darkOption: Double = Contrast.darker(lower, desiredRatio)
-
-                // Tones suitable for the foreground.
-                val availables: MutableList<Double> = mutableListOf()
-                if (lightOption != -1.0) {
-                    availables.add(lightOption)
-                }
-                if (darkOption != -1.0) {
-                    availables.add(darkOption)
-                }
-                val prefersLight = (
-                    tonePrefersLightForeground(bgTone1) ||
-                        tonePrefersLightForeground(bgTone2)
-                )
-                if (prefersLight) {
-                    return if (lightOption == -1.0) 100.0 else lightOption
-                }
-                if (availables.size == 1) {
-                    return availables[0]
-                }
-                return if (darkOption == -1.0) 0.0 else darkOption
-            }
-
-            answer
-        }
+    public fun toBuilder(): Builder {
+        return Builder()
+            .setName(this.name)
+            .setPalette(this.palette)
+            .setTone(this.tone)
+            .setIsBackground(this.isBackground)
+            .setChromaMultiplier(this.chromaMultiplier)
+            .setBackground(this.background)
+            .setSecondBackground(this.secondBackground)
+            .setContrastCurve(this.contrastCurve)
+            .setToneDeltaPair(this.toneDeltaPair)
+            .setOpacity(this.opacity)
     }
 
     public companion object {
@@ -452,5 +303,171 @@ public class DynamicColor(
 
         /** Tones less than ~T50 always permit white at 4.5 contrast.  */
         public fun toneAllowsLightForeground(tone: Double): Boolean = round(tone) <= 49
+
+        public fun getInitialToneFromBackground(
+            background: ((DynamicScheme) -> DynamicColor?)? = null,
+        ): (DynamicScheme) -> Double {
+            if (background == null) {
+                return { scheme -> 50.0 }
+            }
+            return { scheme: DynamicScheme? ->
+                if (scheme == null) 50.0 else background(scheme)?.getTone(scheme) ?: 50.0
+            }
+        }
+
+        /** Builder for [DynamicColor].  */
+        public class Builder {
+            private var name: String? = null
+            private var palette: ((DynamicScheme) -> TonalPalette)? = null
+            private var tone: ((DynamicScheme) -> Double)? = null
+            private var isBackground = false
+            private var chromaMultiplier: ((DynamicScheme) -> Double?)? = null
+            private var background: ((DynamicScheme) -> DynamicColor?)? = null
+            private var secondBackground: ((DynamicScheme) -> DynamicColor?)? = null
+            private var contrastCurve: ((DynamicScheme) -> ContrastCurve?)? = null
+            private var toneDeltaPair: ((DynamicScheme) -> ToneDeltaPair?)? = null
+            private var opacity: ((DynamicScheme) -> Double?)? = null
+
+            public fun setName(name: String): Builder = apply {
+                this.name = name
+            }
+
+            public fun setPalette(palette: (DynamicScheme) -> TonalPalette): Builder = apply {
+                this.palette = palette
+            }
+
+            public fun setTone(tone: (DynamicScheme) -> Double): Builder = apply {
+                this.tone = tone
+            }
+
+            public fun setIsBackground(isBackground: Boolean): Builder = apply {
+                this.isBackground = isBackground
+            }
+
+            public fun setChromaMultiplier(chromaMultiplier: ((DynamicScheme) -> Double?)?): Builder = apply {
+                this.chromaMultiplier = chromaMultiplier
+            }
+
+            public fun setBackground(background: ((DynamicScheme) -> DynamicColor?)?): Builder = apply {
+                this.background = background
+            }
+
+            public fun setSecondBackground(
+                secondBackground: ((DynamicScheme) -> DynamicColor?)?
+            ): Builder = apply { this.secondBackground = secondBackground }
+
+            public fun setContrastCurve(contrastCurve: ((DynamicScheme) -> ContrastCurve?)?): Builder =
+                apply {
+                    this.contrastCurve = contrastCurve
+                }
+
+            public fun setToneDeltaPair(toneDeltaPair: ((DynamicScheme) -> ToneDeltaPair?)?): Builder =
+                apply {
+                    this.toneDeltaPair = toneDeltaPair
+                }
+
+            public fun setOpacity(opacity: ((DynamicScheme) -> Double?)?): Builder = apply {
+                this.opacity = opacity
+            }
+
+            public fun extendSpecVersion(
+                specVersion: ColorSpec.SpecVersion,
+                extendedColor: DynamicColor
+            ): Builder {
+                validateExtendedColor(specVersion, extendedColor)
+
+                return Builder()
+                    .setName(this.name!!)
+                    .setIsBackground(this.isBackground)
+                    .setPalette { s: DynamicScheme ->
+                        val palette =
+                            if (s.specVersion == specVersion) extendedColor.palette else this.palette
+                        palette?.invoke(s) ?: extendedColor.palette(s)
+                    }
+                    .setTone { s: DynamicScheme ->
+                        val tone = if (s.specVersion == specVersion) extendedColor.tone else this.tone
+                        tone?.invoke(s) ?: extendedColor.tone(s)
+                    }
+                    .setChromaMultiplier { s: DynamicScheme ->
+                        val chromaMultiplier = if (s.specVersion == specVersion)
+                            extendedColor.chromaMultiplier else this.chromaMultiplier
+                        if (chromaMultiplier != null) chromaMultiplier(s) else 1.0
+                    }
+                    .setBackground { s: DynamicScheme ->
+                        val background =
+                            if (s.specVersion == specVersion) extendedColor.background else this.background
+                        background?.invoke(s)
+                    }
+                    .setSecondBackground { s: DynamicScheme ->
+                        val secondBackground =
+                            if (s.specVersion == specVersion) extendedColor.secondBackground
+                            else this.secondBackground
+                        secondBackground?.invoke(s)
+                    }
+                    .setContrastCurve { s: DynamicScheme ->
+                        val contrastCurve =
+                            if (s.specVersion == specVersion) extendedColor.contrastCurve else this.contrastCurve
+                        contrastCurve?.invoke(s)
+                    }
+                    .setToneDeltaPair { s: DynamicScheme ->
+                        val toneDeltaPair =
+                            if (s.specVersion == specVersion) extendedColor.toneDeltaPair else this.toneDeltaPair
+                        toneDeltaPair?.invoke(s)
+                    }
+                    .setOpacity { s: DynamicScheme ->
+                        val opacity =
+                            if (s.specVersion == specVersion) extendedColor.opacity else this.opacity
+                        opacity?.invoke(s)
+                    }
+            }
+
+            public fun build(): DynamicColor {
+                require(!(background == null && secondBackground != null)) { "Color $name has secondBackground defined, but background is not defined." }
+                require(!(background == null && contrastCurve != null)) { "Color $name has contrastCurve defined, but background is not defined." }
+                require(!(background != null && contrastCurve == null)) { "Color $name has background defined, but contrastCurve is not defined." }
+
+                val tone = this.tone ?: getInitialToneFromBackground(this.background)
+                return DynamicColor(
+                    name = this.name!!,
+                    palette = this.palette!!,
+                    tone = tone,
+                    isBackground = this.isBackground,
+                    chromaMultiplier = this.chromaMultiplier,
+                    background = this.background,
+                    secondBackground = this.secondBackground,
+                    contrastCurve = this.contrastCurve,
+                    toneDeltaPair = this.toneDeltaPair,
+                    opacity = this.opacity,
+                )
+            }
+
+            private fun validateExtendedColor(
+                specVersion: ColorSpec.SpecVersion?,
+                extendedColor: DynamicColor
+            ) {
+                require(this.name == extendedColor.name) {
+                    ("Attempting to extend color "
+                        + this.name
+                        + " with color "
+                        + extendedColor.name
+                        + " of different name for spec version "
+                        + specVersion
+                        + ".")
+                }
+                require(this.isBackground == extendedColor.isBackground) {
+                    ("Attempting to extend color "
+                        + this.name
+                        + " as a "
+                        + (if (this.isBackground) "background" else "foreground")
+                        + " with color "
+                        + extendedColor.name
+                        + " as a "
+                        + (if (extendedColor.isBackground) "background" else "foreground")
+                        + " for spec version "
+                        + specVersion
+                        + ".")
+                }
+            }
+        }
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/DynamicColor.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/DynamicColor.kt
@@ -132,12 +132,11 @@ public class DynamicColor(
     /**
      * Returns the tone in HCT, ranging from 0 to 100, of the resolved color given scheme.
      */
-    public fun getTone(scheme: DynamicScheme): Double {
-        return ColorSpecs.get(scheme.specVersion).getTone(scheme, this)
-    }
+    public fun getTone(scheme: DynamicScheme): Double =
+        ColorSpecs.get(scheme.specVersion).getTone(scheme, this)
 
-    public fun toBuilder(): Builder {
-        return Builder()
+    public fun toBuilder(): Builder =
+        Builder()
             .setName(this.name)
             .setPalette(this.palette)
             .setTone(this.tone)
@@ -148,7 +147,6 @@ public class DynamicColor(
             .setContrastCurve(this.contrastCurve)
             .setToneDeltaPair(this.toneDeltaPair)
             .setOpacity(this.opacity)
-    }
 
     public companion object {
         /**
@@ -328,33 +326,38 @@ public class DynamicColor(
             private var toneDeltaPair: ((DynamicScheme) -> ToneDeltaPair?)? = null
             private var opacity: ((DynamicScheme) -> Double?)? = null
 
-            public fun setName(name: String): Builder = apply {
-                this.name = name
-            }
+            public fun setName(name: String): Builder =
+                apply {
+                    this.name = name
+                }
 
-            public fun setPalette(palette: (DynamicScheme) -> TonalPalette): Builder = apply {
-                this.palette = palette
-            }
+            public fun setPalette(palette: (DynamicScheme) -> TonalPalette): Builder =
+                apply {
+                    this.palette = palette
+                }
 
-            public fun setTone(tone: (DynamicScheme) -> Double): Builder = apply {
-                this.tone = tone
-            }
+            public fun setTone(tone: (DynamicScheme) -> Double): Builder =
+                apply {
+                    this.tone = tone
+                }
 
-            public fun setIsBackground(isBackground: Boolean): Builder = apply {
-                this.isBackground = isBackground
-            }
+            public fun setIsBackground(isBackground: Boolean): Builder =
+                apply {
+                    this.isBackground = isBackground
+                }
 
-            public fun setChromaMultiplier(chromaMultiplier: ((DynamicScheme) -> Double?)?): Builder = apply {
-                this.chromaMultiplier = chromaMultiplier
-            }
+            public fun setChromaMultiplier(chromaMultiplier: ((DynamicScheme) -> Double?)?): Builder =
+                apply {
+                    this.chromaMultiplier = chromaMultiplier
+                }
 
-            public fun setBackground(background: ((DynamicScheme) -> DynamicColor?)?): Builder = apply {
-                this.background = background
-            }
+            public fun setBackground(background: ((DynamicScheme) -> DynamicColor?)?): Builder =
+                apply {
+                    this.background = background
+                }
 
-            public fun setSecondBackground(
-                secondBackground: ((DynamicScheme) -> DynamicColor?)?
-            ): Builder = apply { this.secondBackground = secondBackground }
+            public fun setSecondBackground(secondBackground: ((DynamicScheme) -> DynamicColor?)?): Builder =
+                apply { this.secondBackground = secondBackground }
 
             public fun setContrastCurve(contrastCurve: ((DynamicScheme) -> ContrastCurve?)?): Builder =
                 apply {
@@ -366,13 +369,14 @@ public class DynamicColor(
                     this.toneDeltaPair = toneDeltaPair
                 }
 
-            public fun setOpacity(opacity: ((DynamicScheme) -> Double?)?): Builder = apply {
-                this.opacity = opacity
-            }
+            public fun setOpacity(opacity: ((DynamicScheme) -> Double?)?): Builder =
+                apply {
+                    this.opacity = opacity
+                }
 
             public fun extendSpecVersion(
                 specVersion: ColorSpec.SpecVersion,
-                extendedColor: DynamicColor
+                extendedColor: DynamicColor,
             ): Builder {
                 validateExtendedColor(specVersion, extendedColor)
 
@@ -383,38 +387,49 @@ public class DynamicColor(
                         val palette =
                             if (s.specVersion == specVersion) extendedColor.palette else this.palette
                         palette?.invoke(s) ?: extendedColor.palette(s)
-                    }
-                    .setTone { s: DynamicScheme ->
+                    }.setTone { s: DynamicScheme ->
                         val tone = if (s.specVersion == specVersion) extendedColor.tone else this.tone
                         tone?.invoke(s) ?: extendedColor.tone(s)
-                    }
-                    .setChromaMultiplier { s: DynamicScheme ->
-                        val chromaMultiplier = if (s.specVersion == specVersion)
-                            extendedColor.chromaMultiplier else this.chromaMultiplier
+                    }.setChromaMultiplier { s: DynamicScheme ->
+                        val chromaMultiplier = if (s.specVersion == specVersion) {
+                            extendedColor.chromaMultiplier
+                        } else {
+                            this.chromaMultiplier
+                        }
                         if (chromaMultiplier != null) chromaMultiplier(s) else 1.0
-                    }
-                    .setBackground { s: DynamicScheme ->
+                    }.setBackground { s: DynamicScheme ->
                         val background =
                             if (s.specVersion == specVersion) extendedColor.background else this.background
                         background?.invoke(s)
-                    }
-                    .setSecondBackground { s: DynamicScheme ->
+                    }.setSecondBackground { s: DynamicScheme ->
                         val secondBackground =
-                            if (s.specVersion == specVersion) extendedColor.secondBackground
-                            else this.secondBackground
+                            if (s.specVersion == specVersion) {
+                                extendedColor.secondBackground
+                            } else {
+                                this.secondBackground
+                            }
                         secondBackground?.invoke(s)
-                    }
-                    .setContrastCurve { s: DynamicScheme ->
+                    }.setContrastCurve { s: DynamicScheme ->
                         val contrastCurve =
-                            if (s.specVersion == specVersion) extendedColor.contrastCurve else this.contrastCurve
+                            if (s.specVersion ==
+                                specVersion
+                            ) {
+                                extendedColor.contrastCurve
+                            } else {
+                                this.contrastCurve
+                            }
                         contrastCurve?.invoke(s)
-                    }
-                    .setToneDeltaPair { s: DynamicScheme ->
+                    }.setToneDeltaPair { s: DynamicScheme ->
                         val toneDeltaPair =
-                            if (s.specVersion == specVersion) extendedColor.toneDeltaPair else this.toneDeltaPair
+                            if (s.specVersion ==
+                                specVersion
+                            ) {
+                                extendedColor.toneDeltaPair
+                            } else {
+                                this.toneDeltaPair
+                            }
                         toneDeltaPair?.invoke(s)
-                    }
-                    .setOpacity { s: DynamicScheme ->
+                    }.setOpacity { s: DynamicScheme ->
                         val opacity =
                             if (s.specVersion == specVersion) extendedColor.opacity else this.opacity
                         opacity?.invoke(s)
@@ -422,9 +437,15 @@ public class DynamicColor(
             }
 
             public fun build(): DynamicColor {
-                require(!(background == null && secondBackground != null)) { "Color $name has secondBackground defined, but background is not defined." }
-                require(!(background == null && contrastCurve != null)) { "Color $name has contrastCurve defined, but background is not defined." }
-                require(!(background != null && contrastCurve == null)) { "Color $name has background defined, but contrastCurve is not defined." }
+                require(!(background == null && secondBackground != null)) {
+                    "Color $name has secondBackground defined, but background is not defined."
+                }
+                require(!(background == null && contrastCurve != null)) {
+                    "Color $name has contrastCurve defined, but background is not defined."
+                }
+                require(!(background != null && contrastCurve == null)) {
+                    "Color $name has background defined, but contrastCurve is not defined."
+                }
 
                 val tone = this.tone ?: getInitialToneFromBackground(this.background)
                 return DynamicColor(
@@ -443,29 +464,33 @@ public class DynamicColor(
 
             private fun validateExtendedColor(
                 specVersion: ColorSpec.SpecVersion?,
-                extendedColor: DynamicColor
+                extendedColor: DynamicColor,
             ) {
                 require(this.name == extendedColor.name) {
-                    ("Attempting to extend color "
-                        + this.name
-                        + " with color "
-                        + extendedColor.name
-                        + " of different name for spec version "
-                        + specVersion
-                        + ".")
+                    (
+                        "Attempting to extend color " +
+                            this.name +
+                            " with color " +
+                            extendedColor.name +
+                            " of different name for spec version " +
+                            specVersion +
+                            "."
+                    )
                 }
                 require(this.isBackground == extendedColor.isBackground) {
-                    ("Attempting to extend color "
-                        + this.name
-                        + " as a "
-                        + (if (this.isBackground) "background" else "foreground")
-                        + " with color "
-                        + extendedColor.name
-                        + " as a "
-                        + (if (extendedColor.isBackground) "background" else "foreground")
-                        + " for spec version "
-                        + specVersion
-                        + ".")
+                    (
+                        "Attempting to extend color " +
+                            this.name +
+                            " as a " +
+                            (if (this.isBackground) "background" else "foreground") +
+                            " with color " +
+                            extendedColor.name +
+                            " as a " +
+                            (if (extendedColor.isBackground) "background" else "foreground") +
+                            " for spec version " +
+                            specVersion +
+                            "."
+                    )
                 }
             }
         }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/MaterialDynamicColors.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/MaterialDynamicColors.kt
@@ -15,14 +15,9 @@
  */
 package com.materialkolor.dynamiccolor
 
-import com.materialkolor.dislike.DislikeAnalyzer
-import com.materialkolor.hct.Hct
 import com.materialkolor.scheme.DynamicScheme
-import com.materialkolor.scheme.Variant
 import dev.drewhamilton.poko.Poko
-import kotlin.math.abs
-import kotlin.math.max
-import kotlin.reflect.KFunction0
+import kotlin.reflect.KFunction
 
 /**
  * Named colors, otherwise known as tokens, or roles, in the Material Design system.
@@ -35,871 +30,117 @@ import kotlin.reflect.KFunction0
 public class MaterialDynamicColors(
     private val isExtendedFidelity: Boolean = false,
 ) {
-    public fun highestSurface(scheme: DynamicScheme): DynamicColor =
-        if (scheme.isDark) surfaceBright() else surfaceDim()
+    public fun highestSurface(scheme: DynamicScheme): DynamicColor = colorSpec.highestSurface(scheme)
 
     // Compatibility Keys Colors for Android
-    public fun primaryPaletteKeyColor(): DynamicColor =
-        DynamicColor.fromPalette(
-            name = "primary_palette_key_color",
-            palette = { scheme -> scheme.primaryPalette },
-            tone = { scheme -> scheme.primaryPalette.keyColor.tone },
-        )
+    public fun primaryPaletteKeyColor(): DynamicColor = colorSpec.primaryPaletteKeyColor()
 
-    public fun secondaryPaletteKeyColor(): DynamicColor =
-        DynamicColor.fromPalette(
-            name = "secondary_palette_key_color",
-            palette = { scheme -> scheme.secondaryPalette },
-            tone = { scheme -> scheme.secondaryPalette.keyColor.tone },
-        )
+    public fun secondaryPaletteKeyColor(): DynamicColor = colorSpec.secondaryPaletteKeyColor()
 
-    public fun tertiaryPaletteKeyColor(): DynamicColor =
-        DynamicColor.fromPalette(
-            name = "tertiary_palette_key_color",
-            palette = { scheme -> scheme.tertiaryPalette },
-            tone = { scheme -> scheme.tertiaryPalette.keyColor.tone },
-        )
+    public fun tertiaryPaletteKeyColor(): DynamicColor = colorSpec.tertiaryPaletteKeyColor()
 
-    public fun errorPaletteKeyColor(): DynamicColor =
-        DynamicColor.fromPalette(
-            name = "error_palette_key_color",
-            palette = { scheme -> scheme.errorPalette },
-            tone = { scheme -> scheme.errorPalette.keyColor.tone },
-        )
+    public fun errorPaletteKeyColor(): DynamicColor = colorSpec.errorPaletteKeyColor()
 
-    public fun neutralPaletteKeyColor(): DynamicColor =
-        DynamicColor.fromPalette(
-            name = "neutral_palette_key_color",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme -> scheme.neutralPalette.keyColor.tone },
-        )
+    public fun neutralPaletteKeyColor(): DynamicColor = colorSpec.neutralPaletteKeyColor()
 
-    public fun neutralVariantPaletteKeyColor(): DynamicColor =
-        DynamicColor.fromPalette(
-            name = "neutral_variant_palette_key_color",
-            palette = { scheme -> scheme.neutralVariantPalette },
-            tone = { scheme -> scheme.neutralVariantPalette.keyColor.tone },
-        )
+    public fun neutralVariantPaletteKeyColor(): DynamicColor = colorSpec.neutralVariantPaletteKeyColor()
+    public fun background(): DynamicColor = colorSpec.background()
 
-    public fun background(): DynamicColor =
-        DynamicColor(
-            name = "background",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme -> if (scheme.isDark) 6.0 else 98.0 },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun onBackground(): DynamicColor = colorSpec.onBackground()
 
-    public fun onBackground(): DynamicColor =
-        DynamicColor(
-            name = "on_background",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme -> if (scheme.isDark) 90.0 else 10.0 },
-            isBackground = false,
-            background = { background() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 3.0, 4.5, 7.0),
-            toneDeltaPair = null,
-        )
+    public fun surface(): DynamicColor = colorSpec.surface()
 
-    public fun surface(): DynamicColor =
-        DynamicColor(
-            name = "surface",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme -> if (scheme.isDark) 6.0 else 98.0 },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun surfaceDim(): DynamicColor = colorSpec.surfaceDim()
 
-    public fun surfaceDim(): DynamicColor =
-        DynamicColor(
-            name = "surface_dim",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme ->
-                if (scheme.isDark) {
-                    6.0
-                } else {
-                    ContrastCurve(87.0, 87.0, 80.0, 75.0).get(scheme.contrastLevel)
-                }
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun surfaceBright(): DynamicColor = colorSpec.surfaceBright()
 
-    public fun surfaceBright(): DynamicColor =
-        DynamicColor(
-            name = "surface_bright",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme ->
-                if (scheme.isDark) {
-                    ContrastCurve(24.0, 24.0, 29.0, 34.0).get(scheme.contrastLevel)
-                } else {
-                    98.0
-                }
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun surfaceContainerLowest(): DynamicColor = colorSpec.surfaceContainerLowest()
 
-    public fun surfaceContainerLowest(): DynamicColor =
-        DynamicColor(
-            name = "surface_container_lowest",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme ->
-                if (scheme.isDark) {
-                    ContrastCurve(4.0, 4.0, 2.0, 0.0).get(scheme.contrastLevel)
-                } else {
-                    100.0
-                }
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun surfaceContainerLow(): DynamicColor = colorSpec.surfaceContainerLow()
 
-    public fun surfaceContainerLow(): DynamicColor =
-        DynamicColor(
-            name = "surface_container_low",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme ->
-                if (scheme.isDark) {
-                    ContrastCurve(10.0, 10.0, 11.0, 12.0).get(scheme.contrastLevel)
-                } else {
-                    ContrastCurve(96.0, 96.0, 96.0, 95.0).get(scheme.contrastLevel)
-                }
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun surfaceContainer(): DynamicColor = colorSpec.surfaceContainer()
 
-    public fun surfaceContainer(): DynamicColor =
-        DynamicColor(
-            name = "surface_container",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme ->
-                if (scheme.isDark) {
-                    ContrastCurve(12.0, 12.0, 16.0, 20.0).get(scheme.contrastLevel)
-                } else {
-                    ContrastCurve(94.0, 94.0, 92.0, 90.0).get(scheme.contrastLevel)
-                }
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun surfaceContainerHigh(): DynamicColor = colorSpec.surfaceContainerHigh()
 
-    public fun surfaceContainerHigh(): DynamicColor =
-        DynamicColor(
-            name = "surface_container_high",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme ->
-                if (scheme.isDark) {
-                    ContrastCurve(17.0, 17.0, 21.0, 25.0).get(scheme.contrastLevel)
-                } else {
-                    ContrastCurve(92.0, 92.0, 88.0, 85.0).get(scheme.contrastLevel)
-                }
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun surfaceContainerHighest(): DynamicColor = colorSpec.surfaceContainerHighest()
 
-    public fun surfaceContainerHighest(): DynamicColor =
-        DynamicColor(
-            name = "surface_container_highest",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme ->
-                if (scheme.isDark) {
-                    ContrastCurve(22.0, 22.0, 26.0, 30.0).get(scheme.contrastLevel)
-                } else {
-                    ContrastCurve(90.0, 90.0, 84.0, 80.0).get(scheme.contrastLevel)
-                }
-            },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun onSurface(): DynamicColor = colorSpec.onSurface()
 
-    public fun onSurface(): DynamicColor =
-        DynamicColor(
-            name = "on_surface",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme -> if (scheme.isDark) 90.0 else 10.0 },
-            isBackground = false,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null,
-        )
+    public fun surfaceVariant(): DynamicColor = colorSpec.surfaceVariant()
 
-    public fun surfaceVariant(): DynamicColor =
-        DynamicColor(
-            name = "surface_variant",
-            palette = { scheme -> scheme.neutralVariantPalette },
-            tone = { scheme -> if (scheme.isDark) 30.0 else 90.0 },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun onSurfaceVariant(): DynamicColor = colorSpec.onSurfaceVariant()
 
-    public fun onSurfaceVariant(): DynamicColor =
-        DynamicColor(
-            name = "on_surface_variant",
-            palette = { scheme -> scheme.neutralVariantPalette },
-            tone = { scheme -> if (scheme.isDark) 80.0 else 30.0 },
-            isBackground = false,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = null,
-        )
+    public fun inverseSurface(): DynamicColor = colorSpec.inverseSurface()
 
-    public fun inverseSurface(): DynamicColor =
-        DynamicColor(
-            name = "inverse_surface",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme -> if (scheme.isDark) 90.0 else 20.0 },
-            isBackground = false,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun inverseOnSurface(): DynamicColor = colorSpec.inverseOnSurface()
 
-    public fun inverseOnSurface(): DynamicColor =
-        DynamicColor(
-            name = "inverse_on_surface",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme -> if (scheme.isDark) 20.0 else 95.0 },
-            isBackground = false,
-            background = { inverseSurface() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null,
-        )
+    public fun outline(): DynamicColor = colorSpec.outline()
 
-    public fun outline(): DynamicColor =
-        DynamicColor(
-            name = "outline",
-            palette = { scheme -> scheme.neutralVariantPalette },
-            tone = { scheme -> if (scheme.isDark) 60.0 else 50.0 },
-            isBackground = false,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.5, 3.0, 4.5, 7.0),
-            toneDeltaPair = null,
-        )
+    public fun outlineVariant(): DynamicColor = colorSpec.outlineVariant()
 
-    public fun outlineVariant(): DynamicColor =
-        DynamicColor(
-            name = "outline_variant",
-            palette = { scheme -> scheme.neutralVariantPalette },
-            tone = { scheme -> if (scheme.isDark) 30.0 else 80.0 },
-            isBackground = false,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = null,
-        )
+    public fun shadow(): DynamicColor = colorSpec.shadow()
 
-    public fun shadow(): DynamicColor =
-        DynamicColor(
-            name = "shadow",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { 0.0 },
-            isBackground = false,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun scrim(): DynamicColor = colorSpec.scrim()
 
-    public fun scrim(): DynamicColor =
-        DynamicColor(
-            name = "scrim",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { 0.0 },
-            isBackground = false,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun surfaceTint(): DynamicColor = colorSpec.surfaceTint()
 
-    public fun surfaceTint(): DynamicColor =
-        DynamicColor(
-            name = "surface_tint",
-            palette = { scheme -> scheme.primaryPalette },
-            tone = { scheme -> if (scheme.isDark) 80.0 else 40.0 },
-            isBackground = true,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-        )
+    public fun primary(): DynamicColor = colorSpec.primary()
 
-    public fun primary(): DynamicColor =
-        DynamicColor(
-            name = "primary",
-            palette = { scheme -> scheme.primaryPalette },
-            tone = { scheme ->
-                when {
-                    isMonochrome(scheme) -> if (scheme.isDark) 100.0 else 0.0
-                    else -> if (scheme.isDark) 80.0 else 40.0
-                }
-            },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = primaryContainer(),
-                    roleB = primary(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
-                )
-            },
-        )
+    public fun onPrimary(): DynamicColor = colorSpec.onPrimary()
 
-    public fun onPrimary(): DynamicColor =
-        DynamicColor(
-            name = "on_primary",
-            palette = { scheme -> scheme.primaryPalette },
-            tone = { scheme ->
-                when {
-                    isMonochrome(scheme) -> if (scheme.isDark) 10.0 else 90.0
-                    else -> if (scheme.isDark) 20.0 else 100.0
-                }
-            },
-            isBackground = false,
-            background = { primary() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null,
-        )
+    public fun primaryContainer(): DynamicColor = colorSpec.primaryContainer()
 
-    public fun primaryContainer(): DynamicColor =
-        DynamicColor(
-            name = "primary_container",
-            palette = { scheme -> scheme.primaryPalette },
-            tone = { scheme ->
-                when {
-                    isFidelity(scheme) -> scheme.sourceColorHct.tone
-                    isMonochrome(scheme) -> if (scheme.isDark) 85.0 else 25.0
-                    else -> if (scheme.isDark) 30.0 else 90.0
-                }
-            },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = primaryContainer(),
-                    roleB = primary(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
-                )
-            },
-        )
+    public fun onPrimaryContainer(): DynamicColor = colorSpec.onPrimaryContainer()
 
-    public fun onPrimaryContainer(): DynamicColor =
-        DynamicColor(
-            name = "on_primary_container",
-            palette = { scheme -> scheme.primaryPalette },
-            tone = { scheme ->
-                when {
-                    isFidelity(scheme) -> {
-                        DynamicColor.foregroundTone(primaryContainer().tone(scheme), 4.5)
-                    }
+    public fun inversePrimary(): DynamicColor = colorSpec.inversePrimary()
 
-                    isMonochrome(scheme) -> if (scheme.isDark) 0.0 else 100.0
-                    else -> if (scheme.isDark) 90.0 else 30.0
-                }
-            },
-            isBackground = false,
-            background = { primaryContainer() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = null,
-        )
+    public fun secondary(): DynamicColor = colorSpec.secondary()
 
-    public fun inversePrimary(): DynamicColor =
-        DynamicColor(
-            name = "inverse_primary",
-            palette = { scheme -> scheme.primaryPalette },
-            tone = { scheme -> if (scheme.isDark) 40.0 else 80.0 },
-            isBackground = false,
-            background = { inverseSurface() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
-            toneDeltaPair = null,
-        )
+    public fun onSecondary(): DynamicColor = colorSpec.onSecondary()
 
-    public fun secondary(): DynamicColor =
-        DynamicColor(
-            name = "secondary",
-            palette = { scheme -> scheme.secondaryPalette },
-            tone = { scheme -> if (scheme.isDark) 80.0 else 40.0 },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = secondaryContainer(),
-                    roleB = secondary(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
-                )
-            },
-        )
+    public fun secondaryContainer(): DynamicColor = colorSpec.secondaryContainer()
 
-    public fun onSecondary(): DynamicColor =
-        DynamicColor(
-            name = "on_secondary",
-            palette = { scheme -> scheme.secondaryPalette },
-            tone = { scheme ->
-                when {
-                    isMonochrome(scheme) -> if (scheme.isDark) 10.0 else 100.0
-                    else -> if (scheme.isDark) 20.0 else 100.0
-                }
-            },
-            isBackground = false,
-            background = { secondary() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null,
-        )
+    public fun onSecondaryContainer(): DynamicColor = colorSpec.onSecondaryContainer()
 
-    public fun secondaryContainer(): DynamicColor =
-        DynamicColor(
-            name = "secondary_container",
-            palette = { scheme -> scheme.secondaryPalette },
-            tone = { scheme ->
-                val initialTone = if (scheme.isDark) 30.0 else 90.0
-                when {
-                    isMonochrome(scheme) -> if (scheme.isDark) 30.0 else 85.0
-                    !isFidelity(scheme) -> initialTone
-                    else -> findDesiredChromaByTone(
-                        hue = scheme.secondaryPalette.hue,
-                        chroma = scheme.secondaryPalette.chroma,
-                        tone = initialTone,
-                        byDecreasingTone = !scheme.isDark,
-                    )
-                }
-            },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = secondaryContainer(),
-                    roleB = secondary(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
-                )
-            },
-        )
+    public fun tertiary(): DynamicColor = colorSpec.tertiary()
 
-    public fun onSecondaryContainer(): DynamicColor =
-        DynamicColor(
-            name = "on_secondary_container",
-            palette = { scheme -> scheme.secondaryPalette },
-            tone = { scheme ->
-                when {
-                    isMonochrome(scheme) -> if (scheme.isDark) 90.0 else 10.0
-                    !isFidelity(scheme) -> if (scheme.isDark) 90.0 else 30.0
-                    else -> DynamicColor.foregroundTone(secondaryContainer().tone(scheme), 4.5)
-                }
-            },
-            isBackground = false,
-            background = { secondaryContainer() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = null,
-        )
+    public fun onTertiary(): DynamicColor = colorSpec.onTertiary()
 
-    public fun tertiary(): DynamicColor =
-        DynamicColor(
-            name = "tertiary",
-            palette = { scheme -> scheme.tertiaryPalette },
-            tone = { scheme ->
-                when {
-                    isMonochrome(scheme) -> if (scheme.isDark) 90.0 else 25.0
-                    else -> if (scheme.isDark) 80.0 else 40.0
-                }
-            },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = tertiaryContainer(),
-                    roleB = tertiary(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
-                )
-            },
-        )
+    public fun tertiaryContainer(): DynamicColor = colorSpec.tertiaryContainer()
 
-    public fun onTertiary(): DynamicColor =
-        DynamicColor(
-            name = "on_tertiary",
-            palette = { scheme -> scheme.tertiaryPalette },
-            tone = { scheme ->
-                when {
-                    isMonochrome(scheme) -> if (scheme.isDark) 10.0 else 90.0
-                    else -> if (scheme.isDark) 20.0 else 100.0
-                }
-            },
-            isBackground = false,
-            background = { tertiary() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null,
-        )
+    public fun onTertiaryContainer(): DynamicColor = colorSpec.onTertiaryContainer()
 
-    public fun tertiaryContainer(): DynamicColor =
-        DynamicColor(
-            name = "tertiary_container",
-            palette = { scheme -> scheme.tertiaryPalette },
-            tone = { scheme ->
-                when {
-                    isMonochrome(scheme) -> if (scheme.isDark) 60.0 else 49.0
-                    !isFidelity(scheme) -> if (scheme.isDark) 30.0 else 90.0
-                    else -> {
-                        val proposedHct = scheme.tertiaryPalette.getHct(scheme.sourceColorHct.tone)
-                        DislikeAnalyzer.fixIfDisliked(proposedHct).tone
-                    }
-                }
-            },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = tertiaryContainer(),
-                    roleB = tertiary(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
-                )
-            },
-        )
+    public fun error(): DynamicColor = colorSpec.error()
 
-    public fun onTertiaryContainer(): DynamicColor =
-        DynamicColor(
-            name = "on_tertiary_container",
-            palette = { scheme -> scheme.tertiaryPalette },
-            tone = { scheme ->
-                when {
-                    isMonochrome(scheme) -> if (scheme.isDark) 0.0 else 100.0
-                    !isFidelity(scheme) -> if (scheme.isDark) 90.0 else 30.0
-                    else -> DynamicColor.foregroundTone(tertiaryContainer().tone(scheme), 4.5)
-                }
-            },
-            isBackground = false,
-            background = { tertiaryContainer() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = null,
-        )
+    public fun onError(): DynamicColor = colorSpec.onError()
 
-    public fun error(): DynamicColor =
-        DynamicColor(
-            name = "error",
-            palette = { scheme -> scheme.errorPalette },
-            tone = { scheme -> if (scheme.isDark) 80.0 else 40.0 },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 7.0),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = errorContainer(),
-                    roleB = error(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
-                )
-            },
-        )
+    public fun errorContainer(): DynamicColor = colorSpec.errorContainer()
 
-    public fun onError(): DynamicColor =
-        DynamicColor(
-            name = "on_error",
-            palette = { scheme -> scheme.errorPalette },
-            tone = { scheme -> if (scheme.isDark) 20.0 else 100.0 },
-            isBackground = false,
-            background = { error() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null,
-        )
+    public fun onErrorContainer(): DynamicColor = colorSpec.onErrorContainer()
 
-    public fun errorContainer(): DynamicColor =
-        DynamicColor(
-            name = "error_container",
-            palette = { scheme -> scheme.errorPalette },
-            tone = { scheme -> if (scheme.isDark) 30.0 else 90.0 },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = errorContainer(),
-                    roleB = error(),
-                    delta = 10.0,
-                    polarity = TonePolarity.NEARER,
-                    stayTogether = false,
-                )
-            },
-        )
+    public fun primaryFixed(): DynamicColor = colorSpec.primaryFixed()
 
-    public fun onErrorContainer(): DynamicColor =
-        DynamicColor(
-            name = "on_error_container",
-            palette = { scheme -> scheme.errorPalette },
-            tone = { scheme ->
-                when {
-                    isMonochrome(scheme) -> if (scheme.isDark) 90.0 else 10.0
-                    else -> if (scheme.isDark) 90.0 else 10.0
-                }
-            },
-            isBackground = false,
-            background = { errorContainer() },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = null,
-        )
+    public fun primaryFixedDim(): DynamicColor = colorSpec.primaryFixedDim()
 
-    public fun primaryFixed(): DynamicColor =
-        DynamicColor(
-            name = "primary_fixed",
-            palette = { scheme -> scheme.primaryPalette },
-            tone = { scheme -> if (isMonochrome(scheme)) 40.0 else 90.0 },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = primaryFixed(),
-                    roleB = primaryFixedDim(),
-                    delta = 10.0,
-                    polarity = TonePolarity.LIGHTER,
-                    stayTogether = true,
-                )
-            },
-        )
+    public fun onPrimaryFixed(): DynamicColor = colorSpec.onPrimaryFixed()
 
-    public fun primaryFixedDim(): DynamicColor =
-        DynamicColor(
-            name = "primary_fixed_dim",
-            palette = { scheme -> scheme.primaryPalette },
-            tone = { scheme -> if (isMonochrome(scheme)) 30.0 else 80.0 },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = primaryFixed(),
-                    roleB = primaryFixedDim(),
-                    delta = 10.0,
-                    polarity = TonePolarity.LIGHTER,
-                    stayTogether = true,
-                )
-            },
-        )
+    public fun onPrimaryFixedVariant(): DynamicColor = colorSpec.onPrimaryFixedVariant()
 
-    public fun onPrimaryFixed(): DynamicColor =
-        DynamicColor(
-            name = "on_primary_fixed",
-            palette = { scheme -> scheme.primaryPalette },
-            tone = { scheme -> if (isMonochrome(scheme)) 100.0 else 10.0 },
-            isBackground = false,
-            background = { primaryFixedDim() },
-            secondBackground = { primaryFixed() },
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null,
-        )
+    public fun secondaryFixed(): DynamicColor = colorSpec.secondaryFixed()
 
-    public fun onPrimaryFixedVariant(): DynamicColor =
-        DynamicColor(
-            name = "on_primary_fixed_variant",
-            palette = { scheme -> scheme.primaryPalette },
-            tone = { scheme -> if (isMonochrome(scheme)) 90.0 else 30.0 },
-            isBackground = false,
-            background = { primaryFixedDim() },
-            secondBackground = { primaryFixed() },
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = null,
-        )
+    public fun secondaryFixedDim(): DynamicColor = colorSpec.secondaryFixedDim()
 
-    public fun secondaryFixed(): DynamicColor =
-        DynamicColor(
-            name = "secondary_fixed",
-            palette = { scheme -> scheme.secondaryPalette },
-            tone = { scheme -> if (isMonochrome(scheme)) 80.0 else 90.0 },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = secondaryFixed(),
-                    roleB = secondaryFixedDim(),
-                    delta = 10.0,
-                    polarity = TonePolarity.LIGHTER,
-                    stayTogether = true,
-                )
-            },
-        )
+    public fun onSecondaryFixed(): DynamicColor = colorSpec.onSecondaryFixed()
 
-    public fun secondaryFixedDim(): DynamicColor =
-        DynamicColor(
-            name = "secondary_fixed_dim",
-            palette = { scheme -> scheme.secondaryPalette },
-            tone = { scheme -> if (isMonochrome(scheme)) 70.0 else 80.0 },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = secondaryFixed(),
-                    roleB = secondaryFixedDim(),
-                    delta = 10.0,
-                    polarity = TonePolarity.LIGHTER,
-                    stayTogether = true,
-                )
-            },
-        )
+    public fun onSecondaryFixedVariant(): DynamicColor = colorSpec.onSecondaryFixedVariant()
 
-    public fun onSecondaryFixed(): DynamicColor =
-        DynamicColor(
-            name = "on_secondary_fixed",
-            palette = { scheme -> scheme.secondaryPalette },
-            tone = { 10.0 },
-            isBackground = false,
-            background = { secondaryFixedDim() },
-            secondBackground = { secondaryFixed() },
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null,
-        )
+    public fun tertiaryFixed(): DynamicColor = colorSpec.tertiaryFixed()
 
-    public fun onSecondaryFixedVariant(): DynamicColor =
-        DynamicColor(
-            name = "on_secondary_fixed_variant",
-            palette = { scheme -> scheme.secondaryPalette },
-            tone = { scheme -> if (isMonochrome(scheme)) 25.0 else 30.0 },
-            isBackground = false,
-            background = { secondaryFixedDim() },
-            secondBackground = { secondaryFixed() },
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = null,
-        )
+    public fun tertiaryFixedDim(): DynamicColor = colorSpec.tertiaryFixedDim()
 
-    public fun tertiaryFixed(): DynamicColor =
-        DynamicColor(
-            name = "tertiary_fixed",
-            palette = { scheme -> scheme.tertiaryPalette },
-            tone = { scheme -> if (isMonochrome(scheme)) 40.0 else 90.0 },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = tertiaryFixed(),
-                    roleB = tertiaryFixedDim(),
-                    delta = 10.0,
-                    polarity = TonePolarity.LIGHTER,
-                    stayTogether = true,
-                )
-            },
-        )
+    public fun onTertiaryFixed(): DynamicColor = colorSpec.onTertiaryFixed()
 
-    public fun tertiaryFixedDim(): DynamicColor =
-        DynamicColor(
-            name = "tertiary_fixed_dim",
-            palette = { scheme -> scheme.tertiaryPalette },
-            tone = { scheme -> if (isMonochrome(scheme)) 30.0 else 80.0 },
-            isBackground = true,
-            background = { scheme -> highestSurface(scheme) },
-            secondBackground = null,
-            contrastCurve = ContrastCurve(1.0, 1.0, 3.0, 4.5),
-            toneDeltaPair = {
-                ToneDeltaPair(
-                    roleA = tertiaryFixed(),
-                    roleB = tertiaryFixedDim(),
-                    delta = 10.0,
-                    polarity = TonePolarity.LIGHTER,
-                    stayTogether = true,
-                )
-            },
-        )
-
-    public fun onTertiaryFixed(): DynamicColor =
-        DynamicColor(
-            name = "on_tertiary_fixed",
-            palette = { scheme -> scheme.tertiaryPalette },
-            tone = { scheme -> if (isMonochrome(scheme)) 100.0 else 10.0 },
-            isBackground = false,
-            background = { tertiaryFixedDim() },
-            secondBackground = { tertiaryFixed() },
-            contrastCurve = ContrastCurve(4.5, 7.0, 11.0, 21.0),
-            toneDeltaPair = null,
-        )
-
-    public fun onTertiaryFixedVariant(): DynamicColor =
-        DynamicColor(
-            name = "on_tertiary_fixed_variant",
-            palette = { scheme -> scheme.tertiaryPalette },
-            tone = { scheme -> if (isMonochrome(scheme)) 90.0 else 30.0 },
-            isBackground = false,
-            background = { tertiaryFixedDim() },
-            secondBackground = { tertiaryFixed() },
-            contrastCurve = ContrastCurve(3.0, 4.5, 7.0, 11.0),
-            toneDeltaPair = null,
-        )
+    public fun onTertiaryFixedVariant(): DynamicColor = colorSpec.onTertiaryFixedVariant()
 
     /**
      * These colors were present in Android framework before Android U, and used by MDC controls. They
@@ -915,24 +156,14 @@ public class MaterialDynamicColors(
      * For example, if the same color is on a white background _and_ black background, there's no
      * way to increase contrast with either without losing contrast with the other.
      */
-    public fun controlActivated(): DynamicColor =
-        DynamicColor.fromPalette(
-            name = "control_activated",
-            palette = { scheme -> scheme.primaryPalette },
-            tone = { scheme -> if (scheme.isDark) 30.0 else 90.0 },
-        )
+    public fun controlActivated(): DynamicColor = colorSpec.controlActivated()
 
     /**
      * colorControlNormal documented as textColorSecondary in M3 & GM3.
      * In Material, textColorSecondary points to onSurfaceVariant in the non-disabled state,
      * which is Neutral Variant T30/80 in light/dark.
      */
-    public fun controlNormal(): DynamicColor =
-        DynamicColor.fromPalette(
-            name = "control_normal",
-            palette = { scheme -> scheme.neutralVariantPalette },
-            tone = { scheme -> if (scheme.isDark) 80.0 else 30.0 },
-        )
+    public fun controlNormal(): DynamicColor = colorSpec.controlNormal()
 
     /**
      * colorControlHighlight documented, in both M3 & GM3:
@@ -947,76 +178,43 @@ public class MaterialDynamicColors(
      * depending on how MDC resolved alpha for the other cases.
      * Returning black in dark mode, white in light mode.
      */
-    public fun controlHighlight(): DynamicColor =
-        DynamicColor(
-            name = "control_highlight",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme -> if (scheme.isDark) 100.0 else 0.0 },
-            isBackground = false,
-            background = null,
-            secondBackground = null,
-            contrastCurve = null,
-            toneDeltaPair = null,
-            opacity = { scheme -> if (scheme.isDark) 0.20 else 0.12 },
-        )
+    public fun controlHighlight(): DynamicColor = colorSpec.controlHighlight()
 
     /**
      * textColorPrimaryInverse documented, in both M3 & GM3, documented as N10/N90.
      */
-    public fun textPrimaryInverse(): DynamicColor =
-        DynamicColor.fromPalette(
-            name = "text_primary_inverse",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme -> if (scheme.isDark) 10.0 else 90.0 },
-        )
+    public fun textPrimaryInverse(): DynamicColor = colorSpec.textPrimaryInverse()
 
     /**
      * textColorSecondaryInverse and textColorTertiaryInverse both documented, in both M3 & GM3, as
      * V30/NV80
      */
-    public fun textSecondaryAndTertiaryInverse(): DynamicColor =
-        DynamicColor.fromPalette(
-            name = "text_secondary_and_tertiary_inverse",
-            palette = { scheme -> scheme.neutralVariantPalette },
-            tone = { scheme -> if (scheme.isDark) 30.0 else 80.0 },
-        )
+    public fun textSecondaryAndTertiaryInverse(): DynamicColor = colorSpec.textSecondaryAndTertiaryInverse()
 
     /**
      * textColorPrimaryInverseDisableOnly documented, in both M3 & GM3, as N10/N90
      */
-    public fun textPrimaryInverseDisableOnly(): DynamicColor =
-        DynamicColor.fromPalette(
-            name = "text_primary_inverse_disable_only",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme -> if (scheme.isDark) 10.0 else 90.0 },
-        )
+    public fun textPrimaryInverseDisableOnly(): DynamicColor = colorSpec.textPrimaryInverseDisableOnly()
 
     /**
      * textColorSecondaryInverse and textColorTertiaryInverse in disabled state both documented,
      * in both M3 & GM3, as N10/N90
      */
     public fun textSecondaryAndTertiaryInverseDisabled(): DynamicColor =
-        DynamicColor.fromPalette(
-            name = "text_secondary_and_tertiary_inverse_disabled",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme -> if (scheme.isDark) 10.0 else 90.0 },
-        )
+        colorSpec.textSecondaryAndTertiaryInverseDisabled()
 
     /**
      * textColorHintInverse documented, in both M3 & GM3, as N10/N90
      */
-    public fun textHintInverse(): DynamicColor =
-        DynamicColor.fromPalette(
-            name = "text_hint_inverse",
-            palette = { scheme -> scheme.neutralPalette },
-            tone = { scheme -> if (scheme.isDark) 10.0 else 90.0 },
-        )
+    public fun textHintInverse(): DynamicColor = colorSpec.textHintInverse()
 
-    public fun allDynamicColors(): List<KFunction0<DynamicColor>> =
+    public fun allDynamicColors(): List<KFunction<DynamicColor>> =
         listOf(
+            this::highestSurface,
             this::primaryPaletteKeyColor,
             this::secondaryPaletteKeyColor,
             this::tertiaryPaletteKeyColor,
+            this::errorPaletteKeyColor,
             this::neutralPaletteKeyColor,
             this::neutralVariantPaletteKeyColor,
             this::background,
@@ -1078,49 +276,7 @@ public class MaterialDynamicColors(
             this::textHintInverse,
         )
 
-    private fun isFidelity(scheme: DynamicScheme): Boolean {
-        if (isExtendedFidelity &&
-            scheme.variant != Variant.MONOCHROME &&
-            scheme.variant != Variant.NEUTRAL
-        ) {
-            return true
-        }
-
-        return scheme.variant == Variant.FIDELITY || scheme.variant == Variant.CONTENT
-    }
-
     public companion object {
-        private fun isMonochrome(scheme: DynamicScheme): Boolean = scheme.variant === Variant.MONOCHROME
-
-        private fun findDesiredChromaByTone(
-            hue: Double,
-            chroma: Double,
-            tone: Double,
-            byDecreasingTone: Boolean,
-        ): Double {
-            var answer = tone
-            var closestToChroma = Hct.from(hue, chroma, tone)
-            if (closestToChroma.chroma < chroma) {
-                var chromaPeak = closestToChroma.chroma
-                while (closestToChroma.chroma < chroma) {
-                    answer += if (byDecreasingTone) -1.0 else 1.0
-                    val potentialSolution = Hct.from(hue, chroma, answer)
-                    if (chromaPeak > potentialSolution.chroma) {
-                        break
-                    }
-                    if (abs(potentialSolution.chroma - chroma) < 0.4) {
-                        break
-                    }
-                    val potentialDelta: Double = abs(potentialSolution.chroma - chroma)
-                    val currentDelta: Double = abs(closestToChroma.chroma - chroma)
-                    if (potentialDelta < currentDelta) {
-                        closestToChroma = potentialSolution
-                    }
-                    chromaPeak = max(chromaPeak, potentialSolution.chroma)
-                }
-            }
-
-            return answer
-        }
+        private val colorSpec = ColorSpec2025()
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/MaterialDynamicColors.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/MaterialDynamicColors.kt
@@ -23,7 +23,8 @@ import kotlin.reflect.KFunction
  */
 @Suppress("unused", "MemberVisibilityCanBePrivate")
 public class MaterialDynamicColors {
-    public fun highestSurface(scheme: DynamicScheme): DynamicColor = colorSpec.highestSurface(scheme)
+    public fun highestSurface(scheme: DynamicScheme): DynamicColor =
+        colorSpec.highestSurface(scheme)
 
     // Compatibility Keys Colors for Android
     public fun primaryPaletteKeyColor(): DynamicColor = colorSpec.primaryPaletteKeyColor()
@@ -36,7 +37,8 @@ public class MaterialDynamicColors {
 
     public fun neutralPaletteKeyColor(): DynamicColor = colorSpec.neutralPaletteKeyColor()
 
-    public fun neutralVariantPaletteKeyColor(): DynamicColor = colorSpec.neutralVariantPaletteKeyColor()
+    public fun neutralVariantPaletteKeyColor(): DynamicColor =
+        colorSpec.neutralVariantPaletteKeyColor()
 
     public fun background(): DynamicColor = colorSpec.background()
 
@@ -183,12 +185,14 @@ public class MaterialDynamicColors {
      * textColorSecondaryInverse and textColorTertiaryInverse both documented, in both M3 & GM3, as
      * V30/NV80
      */
-    public fun textSecondaryAndTertiaryInverse(): DynamicColor = colorSpec.textSecondaryAndTertiaryInverse()
+    public fun textSecondaryAndTertiaryInverse(): DynamicColor =
+        colorSpec.textSecondaryAndTertiaryInverse()
 
     /**
      * textColorPrimaryInverseDisableOnly documented, in both M3 & GM3, as N10/N90
      */
-    public fun textPrimaryInverseDisableOnly(): DynamicColor = colorSpec.textPrimaryInverseDisableOnly()
+    public fun textPrimaryInverseDisableOnly(): DynamicColor =
+        colorSpec.textPrimaryInverseDisableOnly()
 
     /**
      * textColorSecondaryInverse and textColorTertiaryInverse in disabled state both documented,

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/MaterialDynamicColors.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/MaterialDynamicColors.kt
@@ -16,20 +16,13 @@
 package com.materialkolor.dynamiccolor
 
 import com.materialkolor.scheme.DynamicScheme
-import dev.drewhamilton.poko.Poko
 import kotlin.reflect.KFunction
 
 /**
  * Named colors, otherwise known as tokens, or roles, in the Material Design system.
- *
- * @param[isExtendedFidelity] Whether to use the extended fidelity color set.
- * see [MaterialColorUtilities](https://github.com/material-foundation/material-color-utilities/commit/c3681e12b72202723657b9ce5cf8dfdf7efb0781)
  */
 @Suppress("unused", "MemberVisibilityCanBePrivate")
-@Poko
-public class MaterialDynamicColors(
-    private val isExtendedFidelity: Boolean = false,
-) {
+public class MaterialDynamicColors {
     public fun highestSurface(scheme: DynamicScheme): DynamicColor = colorSpec.highestSurface(scheme)
 
     // Compatibility Keys Colors for Android

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/MaterialDynamicColors.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/MaterialDynamicColors.kt
@@ -44,6 +44,7 @@ public class MaterialDynamicColors(
     public fun neutralPaletteKeyColor(): DynamicColor = colorSpec.neutralPaletteKeyColor()
 
     public fun neutralVariantPaletteKeyColor(): DynamicColor = colorSpec.neutralVariantPaletteKeyColor()
+
     public fun background(): DynamicColor = colorSpec.background()
 
     public fun onBackground(): DynamicColor = colorSpec.onBackground()

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ToneDeltaPair.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ToneDeltaPair.kt
@@ -53,7 +53,7 @@ public class ToneDeltaPair(
     public val delta: Double,
     public val polarity: TonePolarity,
     public val stayTogether: Boolean = true,
-    public val deltaConstraint: DeltaConstraint = DeltaConstraint.EXACT
+    public val deltaConstraint: DeltaConstraint = DeltaConstraint.EXACT,
 ) {
     /**
      * Describes how to fulfill a tone delta pair constraint.
@@ -61,6 +61,6 @@ public class ToneDeltaPair(
     public enum class DeltaConstraint {
         EXACT,
         NEARER,
-        FARTHER
+        FARTHER,
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ToneDeltaPair.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ToneDeltaPair.kt
@@ -32,9 +32,10 @@ import dev.drewhamilton.poko.Poko
  * For instance, ToneDeltaPair(A, B, 15, 'darker', stayTogether) states that A's tone should be
  * at least 15 darker than B's.
  *
- * 'nearer' and 'farther' describes closeness to the surface roles. For instance,
- * ToneDeltaPair(A, B, 10, 'nearer', stayTogether) states that A should be 10 lighter than B in
- * light mode, and 10 darker than B in dark mode.
+ * 'relative_darker' and 'relative_lighter' describes the tone adjustment relative to the
+ * surface color trend (white in light mode; black in dark mode). For instance, ToneDeltaPair(A,
+ * B, 10, 'relative_lighter', 'farther') states that A should be at least 10 lighter than B in
+ * light mode, and at least 10 darker than B in dark mode.
  *
  * @param[roleA] The first role in a pair.
  * @param[roleB] The second role in a pair.
@@ -43,6 +44,7 @@ import dev.drewhamilton.poko.Poko
  * @param[polarity] The relative relation between tones of roleA and roleB, as described above.
  * @param[stayTogether] Whether these two roles should stay on the same side of the "awkward zone"
  * (T50-59). This is necessary for certain cases where one role has two backgrounds.
+ * @param[deltaConstraint] How to fulfill a tone delta pair constraint.
  */
 @Poko
 public class ToneDeltaPair(
@@ -50,5 +52,15 @@ public class ToneDeltaPair(
     public val roleB: DynamicColor,
     public val delta: Double,
     public val polarity: TonePolarity,
-    public val stayTogether: Boolean,
-)
+    public val stayTogether: Boolean = true,
+    public val deltaConstraint: DeltaConstraint = DeltaConstraint.EXACT
+) {
+    /**
+     * Describes how to fulfill a tone delta pair constraint.
+     */
+    public enum class DeltaConstraint {
+        EXACT,
+        NEARER,
+        FARTHER
+    }
+}

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/TonePolarity.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/TonePolarity.kt
@@ -18,15 +18,22 @@ package com.materialkolor.dynamiccolor
 /**
  * Describes the relationship in lightness between two colors.
  *
- * 'nearer' and 'farther' describes closeness to the surface roles. For instance,
- * ToneDeltaPair(A, B, 10, 'nearer', stayTogether) states that A should be 10 lighter than B in
- * light mode, and 10 darker than B in dark mode.
+ * 'relative_darker' and 'relative_lighter' describes the tone adjustment relative to the surface
+ * color trend (white in light mode; black in dark mode). For instance, ToneDeltaPair(A, B, 10,
+ * 'relative_lighter', 'farther') states that A should be at least 10 lighter than B in light mode,
+ * and at least 10 darker than B in dark mode.
  *
- * See `ToneDeltaPair` for details.
+ * @see ToneDeltaPair for details.
  */
 public enum class TonePolarity {
     DARKER,
     LIGHTER,
+    RELATIVE_DARKER,
+    RELATIVE_LIGHTER,
+
+    @Deprecated(message = "Use DeltaConstraint instead.")
     NEARER,
-    FARTHER,
+
+    @Deprecated(message = "Use DeltaConstraint instead.")
+    FARTHER;
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/TonePolarity.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/TonePolarity.kt
@@ -35,5 +35,5 @@ public enum class TonePolarity {
     NEARER,
 
     @Deprecated(message = "Use DeltaConstraint instead.")
-    FARTHER;
+    FARTHER,
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/Cam16.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/Cam16.kt
@@ -181,7 +181,8 @@ public class Cam16 private constructor(
          *
          * @param argb ARGB representation of a color.
          */
-        public fun fromInt(argb: Int): Cam16 = fromIntInViewingConditions(argb, ViewingConditions.DEFAULT)
+        public fun fromInt(argb: Int): Cam16 =
+            fromIntInViewingConditions(argb, ViewingConditions.DEFAULT)
 
         /**
          * Create a CAM16 color from a color in defined viewing conditions.

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/Hct.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/Hct.kt
@@ -110,6 +110,12 @@ public class Hct private constructor(
         return from(recastInVc.hue, recastInVc.chroma, lstarFromY(viewedInVc[1]))
     }
 
+    public fun isBlue(): Boolean = hue >= 250 && hue < 270
+
+    public fun isYellow(): Boolean = hue >= 105 && hue < 125
+
+    public fun isCyan(): Boolean = hue >= 170 && hue < 207
+
     public companion object {
         /**
          * Create an HCT color from hue, chroma, and tone.

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/ViewingConditions.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/hct/ViewingConditions.kt
@@ -89,11 +89,14 @@ public class ViewingConditions private constructor(
             // Transform white point XYZ to 'cone'/'rgb' responses
             val matrix = Cam16.XYZ_TO_CAM16RGB
             val rW =
-                whitePoint[0] * matrix[0][0] + whitePoint[1] * matrix[0][1] + whitePoint[2] * matrix[0][2]
+                whitePoint[0] * matrix[0][0] + whitePoint[1] * matrix[0][1] +
+                    whitePoint[2] * matrix[0][2]
             val gW =
-                whitePoint[0] * matrix[1][0] + whitePoint[1] * matrix[1][1] + whitePoint[2] * matrix[1][2]
+                whitePoint[0] * matrix[1][0] + whitePoint[1] * matrix[1][1] +
+                    whitePoint[2] * matrix[1][2]
             val bW =
-                whitePoint[0] * matrix[2][0] + whitePoint[1] * matrix[2][1] + whitePoint[2] * matrix[2][2]
+                whitePoint[0] * matrix[2][0] + whitePoint[1] * matrix[2][1] +
+                    whitePoint[2] * matrix[2][2]
             val f = 0.8 + surround / 10.0
             val c =
                 if (f >= 0.9) {

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerWu.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/quantize/QuantizerWu.kt
@@ -156,7 +156,8 @@ internal class QuantizerWu : Quantizer {
                 val r = volume(cube, momentsR) / weight
                 val g = volume(cube, momentsG) / weight
                 val b = volume(cube, momentsB) / weight
-                val color = 255 shl 24 or (r and 0x0ff shl 16) or (g and 0x0ff shl 8) or (b and 0x0ff)
+                val color =
+                    255 shl 24 or (r and 0x0ff shl 16) or (g and 0x0ff shl 8) or (b and 0x0ff)
                 colors.add(color)
             }
         }
@@ -195,9 +196,12 @@ internal class QuantizerWu : Quantizer {
         val wholeG = volume(one, momentsG)
         val wholeB = volume(one, momentsB)
         val wholeW = volume(one, weights)
-        val maxRResult = maximize(one, Direction.RED, one!!.r0 + 1, one.r1, wholeR, wholeG, wholeB, wholeW)
-        val maxGResult = maximize(one, Direction.GREEN, one.g0 + 1, one.g1, wholeR, wholeG, wholeB, wholeW)
-        val maxBResult = maximize(one, Direction.BLUE, one.b0 + 1, one.b1, wholeR, wholeG, wholeB, wholeW)
+        val maxRResult =
+            maximize(one, Direction.RED, one!!.r0 + 1, one.r1, wholeR, wholeG, wholeB, wholeW)
+        val maxGResult =
+            maximize(one, Direction.GREEN, one.g0 + 1, one.g1, wholeR, wholeG, wholeB, wholeW)
+        val maxBResult =
+            maximize(one, Direction.BLUE, one.b0 + 1, one.b1, wholeR, wholeG, wholeB, wholeW)
         val cutDirection: Direction
         val maxR = maxRResult.maximum
         val maxG = maxGResult.maximum

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/DynamicScheme.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/DynamicScheme.kt
@@ -15,14 +15,33 @@
  */
 package com.materialkolor.scheme
 
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.dynamiccolor.DynamicColor
+import com.materialkolor.dynamiccolor.MaterialDynamicColors
 import com.materialkolor.hct.Hct
 import com.materialkolor.palettes.TonalPalette
 import com.materialkolor.utils.MathUtils
+import kotlin.math.min
 
 /**
  * Provides important settings for creating colors dynamically, and 6 color palettes. Requires: 1. A
  * color. (source color) 2. A theme. (Variant) 3. Whether or not its dark mode. 4. Contrast level.
  * (-1 to 1, currently contrast ratio 3.0 and 7.0)
+ *
+ * @property sourceColorHct The source color HCT.
+ * @property variant The theme.
+ * @property isDark Whether or not the theme is in dark mode.
+ * @property platform The platform on which this scheme is intended to be used.
+ * @property contrastLevel Value from -1 to 1. -1 represents minimum contrast. 0 represents standard
+ * (i.e. the design as spec'd), and 1 represents maximum contrast.
+ * @property specVersion The version of the color specification.
+ * @property primaryPalette The primary color palette.
+ * @property secondaryPalette The secondary color palette.
+ * @property tertiaryPalette The tertiary color palette.
+ * @property neutralPalette Palette The neutral color palette.
+ * @property neutralVariantPalette The neutral variant color palette.
+ * @property errorPalette The error color palette.
+ * @constructor Creates a DynamicScheme.
  */
 public open class DynamicScheme(
     public val sourceColorHct: Hct,
@@ -34,43 +53,347 @@ public open class DynamicScheme(
     public val tertiaryPalette: TonalPalette,
     public val neutralPalette: TonalPalette,
     public val neutralVariantPalette: TonalPalette,
+    public val platform: Platform = Platform.PHONE,
+    public val specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.SPEC_2021,
     public val errorPalette: TonalPalette = TonalPalette.fromHueAndChroma(hue = 25.0, chroma = 84.0),
 ) {
+    /**
+     * The platform on which this scheme is intended to be used.
+     */
+    public enum class Platform {
+        PHONE,
+        WATCH,
+        ;
+
+        public companion object {
+            public val Default: Platform = PHONE
+        }
+    }
+
+    public constructor(
+        sourceColorHct: Hct,
+        variant: Variant,
+        isDark: Boolean,
+        contrastLevel: Double,
+        platform: Platform = Platform.PHONE,
+        specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.SPEC_2021,
+        primaryPalette: TonalPalette,
+        secondaryPalette: TonalPalette,
+        tertiaryPalette: TonalPalette,
+        neutralPalette: TonalPalette,
+        neutralVariantPalette: TonalPalette,
+        errorPalette: TonalPalette?
+    ) : this(
+        sourceColorHct = sourceColorHct,
+        variant = variant,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        platform = platform,
+        specVersion = specVersion,
+        primaryPalette = primaryPalette,
+        secondaryPalette = secondaryPalette,
+        tertiaryPalette = tertiaryPalette,
+        neutralPalette = neutralPalette,
+        neutralVariantPalette = neutralVariantPalette,
+        errorPalette = errorPalette ?: TonalPalette.fromHueAndChroma(hue = 25.0, chroma = 84.0)
+    )
+
+    private val materialColors: MaterialDynamicColors = MaterialDynamicColors()
+
     public val sourceColorArgb: Int = sourceColorHct.toInt()
+
+    public fun getHct(dynamicColor: DynamicColor): Hct = dynamicColor.getHct(this)
+
+    public fun getArgb(dynamicColor: DynamicColor): Int = dynamicColor.getArgb(this)
+
+    public val primaryPaletteKeyColor: Int
+        get() = getArgb(materialColors.primaryPaletteKeyColor())
+
+    public val secondaryPaletteKeyColor: Int
+        get() = getArgb(materialColors.secondaryPaletteKeyColor())
+
+    public val tertiaryPaletteKeyColor: Int
+        get() = getArgb(materialColors.tertiaryPaletteKeyColor())
+
+    public val neutralPaletteKeyColor: Int
+        get() = getArgb(materialColors.neutralPaletteKeyColor())
+
+    public val neutralVariantPaletteKeyColor: Int
+        get() = getArgb(materialColors.neutralVariantPaletteKeyColor())
+
+    public val background: Int
+        get() = getArgb(materialColors.background())
+
+    public val onBackground: Int
+        get() = getArgb(materialColors.onBackground())
+
+    public val surface: Int
+        get() = getArgb(materialColors.surface())
+
+    public val surfaceDim: Int
+        get() = getArgb(materialColors.surfaceDim())
+
+    public val surfaceBright: Int
+        get() = getArgb(materialColors.surfaceBright())
+
+    public val surfaceContainerLowest: Int
+        get() = getArgb(materialColors.surfaceContainerLowest())
+
+    public val surfaceContainerLow: Int
+        get() = getArgb(materialColors.surfaceContainerLow())
+
+    public val surfaceContainer: Int
+        get() = getArgb(materialColors.surfaceContainer())
+
+    public val surfaceContainerHigh: Int
+        get() = getArgb(materialColors.surfaceContainerHigh())
+
+    public val surfaceContainerHighest: Int
+        get() = getArgb(materialColors.surfaceContainerHighest())
+
+    public val onSurface: Int
+        get() = getArgb(materialColors.onSurface())
+
+    public val surfaceVariant: Int
+        get() = getArgb(materialColors.surfaceVariant())
+
+    public val onSurfaceVariant: Int
+        get() = getArgb(materialColors.onSurfaceVariant())
+
+    public val inverseSurface: Int
+        get() = getArgb(materialColors.inverseSurface())
+
+    public val inverseOnSurface: Int
+        get() = getArgb(materialColors.inverseOnSurface())
+
+    public val outline: Int
+        get() = getArgb(materialColors.outline())
+
+    public val outlineVariant: Int
+        get() = getArgb(materialColors.outlineVariant())
+
+    public val shadow: Int
+        get() = getArgb(materialColors.shadow())
+
+    public val scrim: Int
+        get() = getArgb(materialColors.scrim())
+
+    public val surfaceTint: Int
+        get() = getArgb(materialColors.surfaceTint())
+
+    public val primary: Int
+        get() = getArgb(materialColors.primary())
+
+    public val onPrimary: Int
+        get() = getArgb(materialColors.onPrimary())
+
+    public val primaryContainer: Int
+        get() = getArgb(materialColors.primaryContainer())
+
+    public val onPrimaryContainer: Int
+        get() = getArgb(materialColors.onPrimaryContainer())
+
+    public val inversePrimary: Int
+        get() = getArgb(materialColors.inversePrimary())
+
+    public val secondary: Int
+        get() = getArgb(materialColors.secondary())
+
+    public val onSecondary: Int
+        get() = getArgb(materialColors.onSecondary())
+
+    public val secondaryContainer: Int
+        get() = getArgb(materialColors.secondaryContainer())
+
+    public val onSecondaryContainer: Int
+        get() = getArgb(materialColors.onSecondaryContainer())
+
+    public val tertiary: Int
+        get() = getArgb(materialColors.tertiary())
+
+    public val onTertiary: Int
+        get() = getArgb(materialColors.onTertiary())
+
+    public val tertiaryContainer: Int
+        get() = getArgb(materialColors.tertiaryContainer())
+
+    public val onTertiaryContainer: Int
+        get() = getArgb(materialColors.onTertiaryContainer())
+
+    public val error: Int
+        get() = getArgb(materialColors.error())
+
+    public val onError: Int
+        get() = getArgb(materialColors.onError())
+
+    public val errorContainer: Int
+        get() = getArgb(materialColors.errorContainer())
+
+    public val onErrorContainer: Int
+        get() = getArgb(materialColors.onErrorContainer())
+
+    public val primaryFixed: Int
+        get() = getArgb(materialColors.primaryFixed())
+
+    public val primaryFixedDim: Int
+        get() = getArgb(materialColors.primaryFixedDim())
+
+    public val onPrimaryFixed: Int
+        get() = getArgb(materialColors.onPrimaryFixed())
+
+    public val onPrimaryFixedVariant: Int
+        get() = getArgb(materialColors.onPrimaryFixedVariant())
+
+    public val secondaryFixed: Int
+        get() = getArgb(materialColors.secondaryFixed())
+
+    public val secondaryFixedDim: Int
+        get() = getArgb(materialColors.secondaryFixedDim())
+
+    public val onSecondaryFixed: Int
+        get() = getArgb(materialColors.onSecondaryFixed())
+
+    public val onSecondaryFixedVariant: Int
+        get() = getArgb(materialColors.onSecondaryFixedVariant())
+
+    public val tertiaryFixed: Int
+        get() = getArgb(materialColors.tertiaryFixed())
+
+    public val tertiaryFixedDim: Int
+        get() = getArgb(materialColors.tertiaryFixedDim())
+
+    public val onTertiaryFixed: Int
+        get() = getArgb(materialColors.onTertiaryFixed())
+
+    public val onTertiaryFixedVariant: Int
+        get() = getArgb(materialColors.onTertiaryFixedVariant())
+
+    public val controlActivated: Int
+        get() = getArgb(materialColors.controlActivated())
+
+    public val controlNormal: Int
+        get() = getArgb(materialColors.controlNormal())
+
+    public val controlHighlight: Int
+        get() = getArgb(materialColors.controlHighlight())
+
+    public val textPrimaryInverse: Int
+        get() = getArgb(materialColors.textPrimaryInverse())
+
+    public val textSecondaryAndTertiaryInverse: Int
+        get() = getArgb(materialColors.textSecondaryAndTertiaryInverse())
+
+    public val textPrimaryInverseDisableOnly: Int
+        get() = getArgb(materialColors.textPrimaryInverseDisableOnly())
+
+    public val textSecondaryAndTertiaryInverseDisabled: Int
+        get() = getArgb(materialColors.textSecondaryAndTertiaryInverseDisabled())
+
+    public val textHintInverse: Int
+        get() = getArgb(materialColors.textHintInverse())
 
     public companion object {
         /**
-         * Given a set of hues and set of hue rotations, locate which hues the source color's hue is
-         * between, apply the rotation at the same index as the first hue in the range, and return the
-         * rotated hue.
+         * Returns a new DynamicScheme instance with the same properties as the given scheme, but with
+         * the given dark mode setting.
+         */
+        public fun from(other: DynamicScheme, isDark: Boolean): DynamicScheme = DynamicScheme(
+            sourceColorHct = other.sourceColorHct,
+            variant = other.variant,
+            isDark = isDark,
+            contrastLevel = other.contrastLevel,
+            primaryPalette = other.primaryPalette,
+            secondaryPalette = other.secondaryPalette,
+            tertiaryPalette = other.tertiaryPalette,
+            neutralPalette = other.neutralPalette,
+            neutralVariantPalette = other.neutralVariantPalette,
+            platform = other.platform,
+            specVersion = other.specVersion,
+            errorPalette = other.errorPalette,
+        )
+
+        /**
+         * Returns a new hue based on a piecewise function and input color hue.
          *
-         * @param sourceColorHct The color whose hue should be rotated.
-         * @param hues A set of hues.
-         * @param rotations A set of hue rotations.
-         * @return Color's hue with a rotation applied.
+         * For example, for the following function:
+         *
+         * ```
+         * result = 26, if 0 <= hue < 101;
+         * result = 39, if 101 <= hue < 210;
+         * result = 28, if 210 <= hue < 360.
+         * ```
+         *
+         * Call the function as:
+         *
+         * ```
+         * val hueBreakpoints = listOf(0, 101, 210, 360)
+         * val hues = listOf(26, 39, 28)
+         * val result = scheme.piecewise(sourceColor, hueBreakpoints, hues)
+         * ```
+         *
+         * @param sourceColorHct The input value.
+         * @param hueBreakpoints The breakpoints, in sorted order. No default lower or upper bounds are
+         * assumed.
+         * @param hues The hues that should be applied when source color's hue is >= the same index in
+         * hueBreakpoints array, and < the hue at the next index in hueBreakpoints array. Otherwise,
+         * the source color's hue is returned.
+         */
+        public fun getPiecewiseValue(
+            sourceColorHct: Hct,
+            hueBreakpoints: DoubleArray,
+            hues: DoubleArray
+        ): Double {
+            val size = min(hueBreakpoints.size - 1, hues.size)
+            val sourceHue: Double = sourceColorHct.hue
+            for (i in 0..<size) {
+                if (sourceHue >= hueBreakpoints[i] && sourceHue < hueBreakpoints[i + 1]) {
+                    return MathUtils.sanitizeDegrees(hues[i])
+                }
+            }
+            // No condition matched, return the source value.
+            return sourceHue
+        }
+
+        /**
+         * Returns a shifted hue based on a piecewise function and input color hue.
+         *
+         *
+         * For example, for the following function:
+         *
+         * ```
+         * result = hue + 26, if 0 <= hue < 101
+         * result = hue - 39, if 101 <= hue < 210
+         * result = hue + 28, if 210 <= hue < 360
+         * ```
+         *
+         *
+         * call the function as:
+         *
+         * ```
+         * val hueBreakpoints = listOf(0, 101, 210, 360)
+         * val rotations = listOf(26, -39, 28)
+         * val result = scheme.getRotatedHue(sourceColor, hueBreakpoints, rotations)
+         * ```
+         *
+         * @param sourceColorHct the source color of the theme, in HCT.
+         * @param hueBreakpoints The "breakpoints", i.e. the hues at which a rotation should be apply. No
+         * default lower or upper bounds are assumed.
+         * @param rotations The rotation that should be applied when source color's hue is >= the same
+         * index in hues array, and < the hue at the next index in hues array. Otherwise, the source
+         * color's hue is returned.
          */
         public fun getRotatedHue(
             sourceColorHct: Hct,
-            hues: DoubleArray,
-            rotations: DoubleArray,
+            hueBreakpoints: DoubleArray,
+            rotations: DoubleArray
         ): Double {
-            val sourceHue: Double = sourceColorHct.hue
-            if (rotations.size == 1) {
-                return MathUtils.sanitizeDegrees(sourceHue + rotations[0])
+            var rotation: Double = getPiecewiseValue(sourceColorHct, hueBreakpoints, rotations)
+            if (min(hueBreakpoints.size - 1, rotations.size) <= 0) {
+                // No condition matched, return the source hue.
+                rotation = 0.0
             }
 
-            val size = hues.size
-            for (i in 0..size - 2) {
-                val thisHue = hues[i]
-                val nextHue = hues[i + 1]
-                if (thisHue < sourceHue && sourceHue < nextHue) {
-                    return MathUtils.sanitizeDegrees(sourceHue + rotations[i])
-                }
-            }
-
-            // If this statement executes, something is wrong, there should have been a rotation
-            // found using the arrays.
-            return sourceHue
+            return MathUtils.sanitizeDegrees(sourceColorHct.hue + rotation)
         }
     }
 }

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/DynamicScheme.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/DynamicScheme.kt
@@ -82,7 +82,7 @@ public open class DynamicScheme(
         tertiaryPalette: TonalPalette,
         neutralPalette: TonalPalette,
         neutralVariantPalette: TonalPalette,
-        errorPalette: TonalPalette?
+        errorPalette: TonalPalette?,
     ) : this(
         sourceColorHct = sourceColorHct,
         variant = variant,
@@ -95,7 +95,7 @@ public open class DynamicScheme(
         tertiaryPalette = tertiaryPalette,
         neutralPalette = neutralPalette,
         neutralVariantPalette = neutralVariantPalette,
-        errorPalette = errorPalette ?: TonalPalette.fromHueAndChroma(hue = 25.0, chroma = 84.0)
+        errorPalette = errorPalette ?: TonalPalette.fromHueAndChroma(hue = 25.0, chroma = 84.0),
     )
 
     private val materialColors: MaterialDynamicColors = MaterialDynamicColors()
@@ -297,20 +297,24 @@ public open class DynamicScheme(
          * Returns a new DynamicScheme instance with the same properties as the given scheme, but with
          * the given dark mode setting.
          */
-        public fun from(other: DynamicScheme, isDark: Boolean): DynamicScheme = DynamicScheme(
-            sourceColorHct = other.sourceColorHct,
-            variant = other.variant,
-            isDark = isDark,
-            contrastLevel = other.contrastLevel,
-            primaryPalette = other.primaryPalette,
-            secondaryPalette = other.secondaryPalette,
-            tertiaryPalette = other.tertiaryPalette,
-            neutralPalette = other.neutralPalette,
-            neutralVariantPalette = other.neutralVariantPalette,
-            platform = other.platform,
-            specVersion = other.specVersion,
-            errorPalette = other.errorPalette,
-        )
+        public fun from(
+            other: DynamicScheme,
+            isDark: Boolean,
+        ): DynamicScheme =
+            DynamicScheme(
+                sourceColorHct = other.sourceColorHct,
+                variant = other.variant,
+                isDark = isDark,
+                contrastLevel = other.contrastLevel,
+                primaryPalette = other.primaryPalette,
+                secondaryPalette = other.secondaryPalette,
+                tertiaryPalette = other.tertiaryPalette,
+                neutralPalette = other.neutralPalette,
+                neutralVariantPalette = other.neutralVariantPalette,
+                platform = other.platform,
+                specVersion = other.specVersion,
+                errorPalette = other.errorPalette,
+            )
 
         /**
          * Returns a new hue based on a piecewise function and input color hue.
@@ -341,7 +345,7 @@ public open class DynamicScheme(
         public fun getPiecewiseValue(
             sourceColorHct: Hct,
             hueBreakpoints: DoubleArray,
-            hues: DoubleArray
+            hues: DoubleArray,
         ): Double {
             val size = min(hueBreakpoints.size - 1, hues.size)
             val sourceHue: Double = sourceColorHct.hue
@@ -385,7 +389,7 @@ public open class DynamicScheme(
         public fun getRotatedHue(
             sourceColorHct: Hct,
             hueBreakpoints: DoubleArray,
-            rotations: DoubleArray
+            rotations: DoubleArray,
         ): Double {
             var rotation: Double = getPiecewiseValue(sourceColorHct, hueBreakpoints, rotations)
             if (min(hueBreakpoints.size - 1, rotations.size) <= 0) {

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/DynamicScheme.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/DynamicScheme.kt
@@ -55,7 +55,10 @@ public open class DynamicScheme(
     public val neutralVariantPalette: TonalPalette,
     public val platform: Platform = Platform.PHONE,
     public val specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.SPEC_2021,
-    public val errorPalette: TonalPalette = TonalPalette.fromHueAndChroma(hue = 25.0, chroma = 84.0),
+    public val errorPalette: TonalPalette = TonalPalette.fromHueAndChroma(
+        hue = 25.0,
+        chroma = 84.0,
+    ),
 ) {
     /**
      * The platform on which this scheme is intended to be used.

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeContent.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeContent.kt
@@ -15,11 +15,9 @@
  */
 package com.materialkolor.scheme
 
-import com.materialkolor.dislike.DislikeAnalyzer
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.dynamiccolor.ColorSpecs
 import com.materialkolor.hct.Hct
-import com.materialkolor.palettes.TonalPalette
-import com.materialkolor.temperature.TemperatureCache
-import kotlin.math.max
 
 /**
  * A scheme that places the source color in Scheme.primaryContainer.
@@ -38,29 +36,62 @@ public class SchemeContent(
     isDark: Boolean,
     contrastLevel: Double,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.CONTENT,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = sourceColorHct.chroma,
+    sourceColorHct = sourceColorHct,
+    variant = Variant.CONTENT,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getPrimaryPalette(
+            variant = Variant.CONTENT,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = Platform.PHONE,
+            contrastLevel = contrastLevel,
         ),
-        secondaryPalette = TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = max(sourceColorHct.chroma - 32.0, sourceColorHct.chroma * 0.5),
+    secondaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getSecondaryPalette(
+            variant = Variant.CONTENT,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = Platform.PHONE,
+            contrastLevel = contrastLevel,
         ),
-        tertiaryPalette = TonalPalette.fromHct(
-            hct = DislikeAnalyzer.fixIfDisliked(
-                hct = TemperatureCache(sourceColorHct).getAnalogousColors(count = 3, divisions = 6)[2],
-            ),
+    tertiaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getTertiaryPalette(
+            variant = Variant.CONTENT,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = Platform.PHONE,
+            contrastLevel = contrastLevel,
         ),
-        neutralPalette = TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = sourceColorHct.chroma / 8.0,
+    neutralPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getNeutralPalette(
+            variant = Variant.CONTENT,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = Platform.PHONE,
+            contrastLevel = contrastLevel,
         ),
-        neutralVariantPalette = TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = sourceColorHct.chroma / 8.0 + 4.0,
+    neutralVariantPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getNeutralVariantPalette(
+            variant = Variant.CONTENT,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = Platform.PHONE,
+            contrastLevel = contrastLevel,
         ),
-    )
+    errorPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getErrorPalette(
+            variant = Variant.CONTENT,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = Platform.PHONE,
+            contrastLevel = contrastLevel,
+        ),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeContent.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeContent.kt
@@ -36,62 +36,62 @@ public class SchemeContent(
     isDark: Boolean,
     contrastLevel: Double,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.CONTENT,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getPrimaryPalette(
-            variant = Variant.CONTENT,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = Platform.PHONE,
-            contrastLevel = contrastLevel,
-        ),
-    secondaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getSecondaryPalette(
-            variant = Variant.CONTENT,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = Platform.PHONE,
-            contrastLevel = contrastLevel,
-        ),
-    tertiaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getTertiaryPalette(
-            variant = Variant.CONTENT,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = Platform.PHONE,
-            contrastLevel = contrastLevel,
-        ),
-    neutralPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getNeutralPalette(
-            variant = Variant.CONTENT,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = Platform.PHONE,
-            contrastLevel = contrastLevel,
-        ),
-    neutralVariantPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getNeutralVariantPalette(
-            variant = Variant.CONTENT,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = Platform.PHONE,
-            contrastLevel = contrastLevel,
-        ),
-    errorPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getErrorPalette(
-            variant = Variant.CONTENT,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = Platform.PHONE,
-            contrastLevel = contrastLevel,
-        ),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.CONTENT,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getPrimaryPalette(
+                variant = Variant.CONTENT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        secondaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getSecondaryPalette(
+                variant = Variant.CONTENT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        tertiaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getTertiaryPalette(
+                variant = Variant.CONTENT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        neutralPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getNeutralPalette(
+                variant = Variant.CONTENT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        neutralVariantPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getNeutralVariantPalette(
+                variant = Variant.CONTENT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        errorPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getErrorPalette(
+                variant = Variant.CONTENT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeExpressive.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeExpressive.kt
@@ -29,26 +29,26 @@ public class SchemeExpressive(
     specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
     platform: Platform = Platform.Default,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.EXPRESSIVE,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(specVersion)
-        .getPrimaryPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
-    secondaryPalette = ColorSpecs
-        .get(specVersion)
-        .getSecondaryPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
-    tertiaryPalette = ColorSpecs
-        .get(specVersion)
-        .getTertiaryPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
-    neutralPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
-    neutralVariantPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralVariantPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
-    errorPalette = ColorSpecs
-        .get(specVersion)
-        .getErrorPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.EXPRESSIVE,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(specVersion)
+            .getPrimaryPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+        secondaryPalette = ColorSpecs
+            .get(specVersion)
+            .getSecondaryPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+        tertiaryPalette = ColorSpecs
+            .get(specVersion)
+            .getTertiaryPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+        neutralPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+        neutralVariantPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralVariantPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+        errorPalette = ColorSpecs
+            .get(specVersion)
+            .getErrorPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeExpressive.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeExpressive.kt
@@ -15,9 +15,9 @@
  */
 package com.materialkolor.scheme
 
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.dynamiccolor.ColorSpecs
 import com.materialkolor.hct.Hct
-import com.materialkolor.palettes.TonalPalette
-import com.materialkolor.utils.MathUtils
 
 /**
  * A playful theme - the source color's hue does not appear in the theme.
@@ -26,40 +26,29 @@ public class SchemeExpressive(
     sourceColorHct: Hct,
     isDark: Boolean,
     contrastLevel: Double,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: Platform = Platform.Default,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.EXPRESSIVE,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = TonalPalette.fromHueAndChroma(
-            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 240.0),
-            chroma = 40.0,
-        ),
-        secondaryPalette = TonalPalette.fromHueAndChroma(
-            hue = getRotatedHue(sourceColorHct, HUES, SECONDARY_ROTATIONS),
-            chroma = 24.0,
-        ),
-        tertiaryPalette = TonalPalette.fromHueAndChroma(
-            hue = getRotatedHue(sourceColorHct, HUES, TERTIARY_ROTATIONS),
-            chroma = 32.0,
-        ),
-        neutralPalette = TonalPalette.fromHueAndChroma(
-            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 15.0),
-            chroma = 8.0,
-        ),
-        neutralVariantPalette = TonalPalette.fromHueAndChroma(
-            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 15.0),
-            chroma = 12.0,
-        ),
-    ) {
-    private companion object {
-        // NOMUTANTS--arbitrary increments/decrements, correctly, still passes tests.
-        private val HUES = doubleArrayOf(0.0, 21.0, 51.0, 121.0, 151.0, 191.0, 271.0, 321.0, 360.0)
-
-        private val SECONDARY_ROTATIONS =
-            doubleArrayOf(45.0, 95.0, 45.0, 20.0, 45.0, 90.0, 45.0, 45.0, 45.0)
-
-        private val TERTIARY_ROTATIONS =
-            doubleArrayOf(120.0, 120.0, 20.0, 45.0, 20.0, 15.0, 20.0, 120.0, 120.0)
-    }
-}
+    sourceColorHct = sourceColorHct,
+    variant = Variant.EXPRESSIVE,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(specVersion)
+        .getPrimaryPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+    secondaryPalette = ColorSpecs
+        .get(specVersion)
+        .getSecondaryPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+    tertiaryPalette = ColorSpecs
+        .get(specVersion)
+        .getTertiaryPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+    neutralPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+    neutralVariantPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralVariantPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+    errorPalette = ColorSpecs
+        .get(specVersion)
+        .getErrorPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeExpressive.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeExpressive.kt
@@ -38,16 +38,34 @@ public class SchemeExpressive(
             .getPrimaryPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
         secondaryPalette = ColorSpecs
             .get(specVersion)
-            .getSecondaryPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+            .getSecondaryPalette(
+                Variant.EXPRESSIVE,
+                sourceColorHct,
+                isDark,
+                platform,
+                contrastLevel,
+            ),
         tertiaryPalette = ColorSpecs
             .get(specVersion)
-            .getTertiaryPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+            .getTertiaryPalette(
+                Variant.EXPRESSIVE,
+                sourceColorHct,
+                isDark,
+                platform,
+                contrastLevel,
+            ),
         neutralPalette = ColorSpecs
             .get(specVersion)
             .getNeutralPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
         neutralVariantPalette = ColorSpecs
             .get(specVersion)
-            .getNeutralVariantPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),
+            .getNeutralVariantPalette(
+                Variant.EXPRESSIVE,
+                sourceColorHct,
+                isDark,
+                platform,
+                contrastLevel,
+            ),
         errorPalette = ColorSpecs
             .get(specVersion)
             .getErrorPalette(Variant.EXPRESSIVE, sourceColorHct, isDark, platform, contrastLevel),

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFidelity.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFidelity.kt
@@ -34,28 +34,62 @@ public class SchemeFidelity(
     isDark: Boolean,
     contrastLevel: Double,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.FIDELITY,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getPrimaryPalette(Variant.FIDELITY, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    secondaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getSecondaryPalette(Variant.FIDELITY, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    tertiaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getTertiaryPalette(Variant.FIDELITY, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    neutralPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getNeutralPalette(Variant.FIDELITY, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    neutralVariantPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getNeutralVariantPalette(Variant.FIDELITY, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    errorPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getErrorPalette(
-            Variant.FIDELITY, sourceColorHct, isDark, Platform.PHONE, contrastLevel,
-        ),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.FIDELITY,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getPrimaryPalette(
+                variant = Variant.FIDELITY,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        secondaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getSecondaryPalette(
+                variant = Variant.FIDELITY,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        tertiaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getTertiaryPalette(
+                variant = Variant.FIDELITY,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        neutralPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getNeutralPalette(
+                variant = Variant.FIDELITY,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        neutralVariantPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getNeutralVariantPalette(
+                variant = Variant.FIDELITY,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        errorPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getErrorPalette(
+                variant = Variant.FIDELITY,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFidelity.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFidelity.kt
@@ -15,11 +15,9 @@
  */
 package com.materialkolor.scheme
 
-import com.materialkolor.dislike.DislikeAnalyzer
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.dynamiccolor.ColorSpecs
 import com.materialkolor.hct.Hct
-import com.materialkolor.palettes.TonalPalette
-import com.materialkolor.temperature.TemperatureCache
-import kotlin.math.max
 
 /**
  * A scheme that places the source color in Scheme.primaryContainer.
@@ -36,27 +34,28 @@ public class SchemeFidelity(
     isDark: Boolean,
     contrastLevel: Double,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.FIDELITY,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = sourceColorHct.chroma,
+    sourceColorHct = sourceColorHct,
+    variant = Variant.FIDELITY,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getPrimaryPalette(Variant.FIDELITY, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    secondaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getSecondaryPalette(Variant.FIDELITY, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    tertiaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getTertiaryPalette(Variant.FIDELITY, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    neutralPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getNeutralPalette(Variant.FIDELITY, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    neutralVariantPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getNeutralVariantPalette(Variant.FIDELITY, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    errorPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getErrorPalette(
+            Variant.FIDELITY, sourceColorHct, isDark, Platform.PHONE, contrastLevel,
         ),
-        secondaryPalette = TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = max(sourceColorHct.chroma - 32.0, sourceColorHct.chroma * 0.5),
-        ),
-        tertiaryPalette = TonalPalette.fromHct(
-            hct = DislikeAnalyzer.fixIfDisliked(TemperatureCache(sourceColorHct).complement),
-        ),
-        neutralPalette = TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = sourceColorHct.chroma / 8.0,
-        ),
-        neutralVariantPalette = TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = sourceColorHct.chroma / 8.0 + 4.0,
-        ),
-    )
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFruitSalad.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFruitSalad.kt
@@ -15,9 +15,9 @@
  */
 package com.materialkolor.scheme
 
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.dynamiccolor.ColorSpecs
 import com.materialkolor.hct.Hct
-import com.materialkolor.palettes.TonalPalette
-import com.materialkolor.utils.MathUtils
 
 /**
  * A playful theme - the source color's hue does not appear in the theme.
@@ -27,22 +27,26 @@ public class SchemeFruitSalad(
     isDark: Boolean,
     contrastLevel: Double,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.FRUIT_SALAD,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = TonalPalette.fromHueAndChroma(
-            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue - 50.0),
-            chroma = 48.0,
-        ),
-        secondaryPalette = TonalPalette.fromHueAndChroma(
-            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue - 50.0),
-            chroma = 36.0,
-        ),
-        tertiaryPalette = TonalPalette.fromHueAndChroma(
-            hue = sourceColorHct.hue,
-            chroma = 36.0,
-        ),
-        neutralPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, 10.0),
-        neutralVariantPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, 16.0),
-    )
+    sourceColorHct = sourceColorHct,
+    variant = Variant.FRUIT_SALAD,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getPrimaryPalette(Variant.FRUIT_SALAD, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    secondaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getSecondaryPalette(Variant.FRUIT_SALAD, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    tertiaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getTertiaryPalette(Variant.FRUIT_SALAD, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    neutralPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getNeutralPalette(Variant.FRUIT_SALAD, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    neutralVariantPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getNeutralVariantPalette(Variant.FRUIT_SALAD, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    errorPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getErrorPalette(Variant.FRUIT_SALAD, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFruitSalad.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFruitSalad.kt
@@ -27,26 +27,62 @@ public class SchemeFruitSalad(
     isDark: Boolean,
     contrastLevel: Double,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.FRUIT_SALAD,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getPrimaryPalette(Variant.FRUIT_SALAD, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    secondaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getSecondaryPalette(Variant.FRUIT_SALAD, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    tertiaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getTertiaryPalette(Variant.FRUIT_SALAD, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    neutralPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getNeutralPalette(Variant.FRUIT_SALAD, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    neutralVariantPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getNeutralVariantPalette(Variant.FRUIT_SALAD, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    errorPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getErrorPalette(Variant.FRUIT_SALAD, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.FRUIT_SALAD,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getPrimaryPalette(
+                variant = Variant.FRUIT_SALAD,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        secondaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getSecondaryPalette(
+                variant = Variant.FRUIT_SALAD,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        tertiaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getTertiaryPalette(
+                variant = Variant.FRUIT_SALAD,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        neutralPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getNeutralPalette(
+                variant = Variant.FRUIT_SALAD,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        neutralVariantPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getNeutralVariantPalette(
+                variant = Variant.FRUIT_SALAD,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        errorPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getErrorPalette(
+                variant = Variant.FRUIT_SALAD,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeMonochrome.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeMonochrome.kt
@@ -27,26 +27,62 @@ public class SchemeMonochrome(
     isDark: Boolean,
     contrastLevel: Double,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.MONOCHROME,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getPrimaryPalette(Variant.MONOCHROME, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    secondaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getSecondaryPalette(Variant.MONOCHROME, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    tertiaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getTertiaryPalette(Variant.MONOCHROME, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    neutralPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getNeutralPalette(Variant.MONOCHROME, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    neutralVariantPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getNeutralVariantPalette(Variant.MONOCHROME, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    errorPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getErrorPalette(Variant.MONOCHROME, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.MONOCHROME,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getPrimaryPalette(
+                variant = Variant.MONOCHROME,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        secondaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getSecondaryPalette(
+                variant = Variant.MONOCHROME,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        tertiaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getTertiaryPalette(
+                variant = Variant.MONOCHROME,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        neutralPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getNeutralPalette(
+                variant = Variant.MONOCHROME,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        neutralVariantPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getNeutralVariantPalette(
+                variant = Variant.MONOCHROME,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+        errorPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getErrorPalette(
+                variant = Variant.MONOCHROME,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = Platform.PHONE,
+                contrastLevel = contrastLevel,
+            ),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeMonochrome.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeMonochrome.kt
@@ -15,8 +15,9 @@
  */
 package com.materialkolor.scheme
 
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.dynamiccolor.ColorSpecs
 import com.materialkolor.hct.Hct
-import com.materialkolor.palettes.TonalPalette
 
 /**
  * A monochrome theme, colors are purely black / white / gray.
@@ -26,13 +27,26 @@ public class SchemeMonochrome(
     isDark: Boolean,
     contrastLevel: Double,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.MONOCHROME,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 0.0),
-        secondaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 0.0),
-        tertiaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 0.0),
-        neutralPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 0.0),
-        neutralVariantPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 0.0),
-    )
+    sourceColorHct = sourceColorHct,
+    variant = Variant.MONOCHROME,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getPrimaryPalette(Variant.MONOCHROME, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    secondaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getSecondaryPalette(Variant.MONOCHROME, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    tertiaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getTertiaryPalette(Variant.MONOCHROME, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    neutralPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getNeutralPalette(Variant.MONOCHROME, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    neutralVariantPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getNeutralVariantPalette(Variant.MONOCHROME, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    errorPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getErrorPalette(Variant.MONOCHROME, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeNeutral.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeNeutral.kt
@@ -47,7 +47,13 @@ public class SchemeNeutral(
             .getNeutralPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
         neutralVariantPalette = ColorSpecs
             .get(specVersion)
-            .getNeutralVariantPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
+            .getNeutralVariantPalette(
+                Variant.NEUTRAL,
+                sourceColorHct,
+                isDark,
+                platform,
+                contrastLevel,
+            ),
         errorPalette = ColorSpecs
             .get(specVersion)
             .getErrorPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeNeutral.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeNeutral.kt
@@ -29,26 +29,26 @@ public class SchemeNeutral(
     specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
     platform: Platform = Platform.Default,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.NEUTRAL,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(specVersion)
-        .getPrimaryPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
-    secondaryPalette = ColorSpecs
-        .get(specVersion)
-        .getSecondaryPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
-    tertiaryPalette = ColorSpecs
-        .get(specVersion)
-        .getTertiaryPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
-    neutralPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
-    neutralVariantPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralVariantPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
-    errorPalette = ColorSpecs
-        .get(specVersion)
-        .getErrorPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.NEUTRAL,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(specVersion)
+            .getPrimaryPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
+        secondaryPalette = ColorSpecs
+            .get(specVersion)
+            .getSecondaryPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
+        tertiaryPalette = ColorSpecs
+            .get(specVersion)
+            .getTertiaryPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
+        neutralPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
+        neutralVariantPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralVariantPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
+        errorPalette = ColorSpecs
+            .get(specVersion)
+            .getErrorPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeNeutral.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeNeutral.kt
@@ -15,8 +15,9 @@
  */
 package com.materialkolor.scheme
 
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.dynamiccolor.ColorSpecs
 import com.materialkolor.hct.Hct
-import com.materialkolor.palettes.TonalPalette
 
 /**
  * A theme that's slightly more chromatic than monochrome, which is purely black / white / gray.
@@ -25,14 +26,29 @@ public class SchemeNeutral(
     sourceColorHct: Hct,
     isDark: Boolean,
     contrastLevel: Double,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: Platform = Platform.Default,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.NEUTRAL,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 12.0),
-        secondaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 8.0),
-        tertiaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 16.0),
-        neutralPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 2.0),
-        neutralVariantPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 2.0),
-    )
+    sourceColorHct = sourceColorHct,
+    variant = Variant.NEUTRAL,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(specVersion)
+        .getPrimaryPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
+    secondaryPalette = ColorSpecs
+        .get(specVersion)
+        .getSecondaryPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
+    tertiaryPalette = ColorSpecs
+        .get(specVersion)
+        .getTertiaryPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
+    neutralPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
+    neutralVariantPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralVariantPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
+    errorPalette = ColorSpecs
+        .get(specVersion)
+        .getErrorPalette(Variant.NEUTRAL, sourceColorHct, isDark, platform, contrastLevel),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeRainbow.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeRainbow.kt
@@ -15,9 +15,9 @@
  */
 package com.materialkolor.scheme
 
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.dynamiccolor.ColorSpecs
 import com.materialkolor.hct.Hct
-import com.materialkolor.palettes.TonalPalette
-import com.materialkolor.utils.MathUtils
 
 /**
  * A playful theme - the source color's hue does not appear in the theme.
@@ -27,16 +27,26 @@ public class SchemeRainbow(
     isDark: Boolean,
     contrastLevel: Double,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.RAINBOW,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 48.0),
-        secondaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 16.0),
-        tertiaryPalette = TonalPalette.fromHueAndChroma(
-            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 60.0),
-            chroma = 24.0,
-        ),
-        neutralPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 0.0),
-        neutralVariantPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 0.0),
-    )
+    sourceColorHct = sourceColorHct,
+    variant = Variant.RAINBOW,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getPrimaryPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    secondaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getSecondaryPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    tertiaryPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getTertiaryPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    neutralPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getNeutralPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    neutralVariantPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getNeutralVariantPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    errorPalette = ColorSpecs
+        .get(ColorSpec.SpecVersion.SPEC_2021)
+        .getErrorPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeRainbow.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeRainbow.kt
@@ -33,20 +33,56 @@ public class SchemeRainbow(
         contrastLevel = contrastLevel,
         primaryPalette = ColorSpecs
             .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getPrimaryPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+            .getPrimaryPalette(
+                Variant.RAINBOW,
+                sourceColorHct,
+                isDark,
+                Platform.PHONE,
+                contrastLevel,
+            ),
         secondaryPalette = ColorSpecs
             .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getSecondaryPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+            .getSecondaryPalette(
+                Variant.RAINBOW,
+                sourceColorHct,
+                isDark,
+                Platform.PHONE,
+                contrastLevel,
+            ),
         tertiaryPalette = ColorSpecs
             .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getTertiaryPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+            .getTertiaryPalette(
+                Variant.RAINBOW,
+                sourceColorHct,
+                isDark,
+                Platform.PHONE,
+                contrastLevel,
+            ),
         neutralPalette = ColorSpecs
             .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getNeutralPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+            .getNeutralPalette(
+                Variant.RAINBOW,
+                sourceColorHct,
+                isDark,
+                Platform.PHONE,
+                contrastLevel,
+            ),
         neutralVariantPalette = ColorSpecs
             .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getNeutralVariantPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+            .getNeutralVariantPalette(
+                Variant.RAINBOW,
+                sourceColorHct,
+                isDark,
+                Platform.PHONE,
+                contrastLevel,
+            ),
         errorPalette = ColorSpecs
             .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getErrorPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+            .getErrorPalette(
+                Variant.RAINBOW,
+                sourceColorHct,
+                isDark,
+                Platform.PHONE,
+                contrastLevel,
+            ),
     )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeRainbow.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeRainbow.kt
@@ -27,26 +27,26 @@ public class SchemeRainbow(
     isDark: Boolean,
     contrastLevel: Double,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.RAINBOW,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getPrimaryPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    secondaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getSecondaryPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    tertiaryPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getTertiaryPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    neutralPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getNeutralPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    neutralVariantPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getNeutralVariantPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-    errorPalette = ColorSpecs
-        .get(ColorSpec.SpecVersion.SPEC_2021)
-        .getErrorPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.RAINBOW,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getPrimaryPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+        secondaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getSecondaryPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+        tertiaryPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getTertiaryPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+        neutralPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getNeutralPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+        neutralVariantPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getNeutralVariantPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+        errorPalette = ColorSpecs
+            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .getErrorPalette(Variant.RAINBOW, sourceColorHct, isDark, Platform.PHONE, contrastLevel),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeTonalSpot.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeTonalSpot.kt
@@ -38,16 +38,34 @@ public class SchemeTonalSpot(
             .getPrimaryPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
         secondaryPalette = ColorSpecs
             .get(specVersion)
-            .getSecondaryPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+            .getSecondaryPalette(
+                Variant.TONAL_SPOT,
+                sourceColorHct,
+                isDark,
+                platform,
+                contrastLevel,
+            ),
         tertiaryPalette = ColorSpecs
             .get(specVersion)
-            .getTertiaryPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+            .getTertiaryPalette(
+                Variant.TONAL_SPOT,
+                sourceColorHct,
+                isDark,
+                platform,
+                contrastLevel,
+            ),
         neutralPalette = ColorSpecs
             .get(specVersion)
             .getNeutralPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
         neutralVariantPalette = ColorSpecs
             .get(specVersion)
-            .getNeutralVariantPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+            .getNeutralVariantPalette(
+                Variant.TONAL_SPOT,
+                sourceColorHct,
+                isDark,
+                platform,
+                contrastLevel,
+            ),
         errorPalette = ColorSpecs
             .get(specVersion)
             .getErrorPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeTonalSpot.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeTonalSpot.kt
@@ -29,26 +29,26 @@ public class SchemeTonalSpot(
     specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
     platform: Platform = Platform.Default,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.TONAL_SPOT,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(specVersion)
-        .getPrimaryPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
-    secondaryPalette = ColorSpecs
-        .get(specVersion)
-        .getSecondaryPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
-    tertiaryPalette = ColorSpecs
-        .get(specVersion)
-        .getTertiaryPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
-    neutralPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
-    neutralVariantPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralVariantPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
-    errorPalette = ColorSpecs
-        .get(specVersion)
-        .getErrorPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.TONAL_SPOT,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(specVersion)
+            .getPrimaryPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+        secondaryPalette = ColorSpecs
+            .get(specVersion)
+            .getSecondaryPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+        tertiaryPalette = ColorSpecs
+            .get(specVersion)
+            .getTertiaryPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+        neutralPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+        neutralVariantPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralVariantPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+        errorPalette = ColorSpecs
+            .get(specVersion)
+            .getErrorPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeTonalSpot.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeTonalSpot.kt
@@ -15,9 +15,9 @@
  */
 package com.materialkolor.scheme
 
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.dynamiccolor.ColorSpecs
 import com.materialkolor.hct.Hct
-import com.materialkolor.palettes.TonalPalette
-import com.materialkolor.utils.MathUtils
 
 /**
  * A calm theme, sedated colors that aren't particularly chromatic.
@@ -26,17 +26,29 @@ public class SchemeTonalSpot(
     sourceColorHct: Hct,
     isDark: Boolean,
     contrastLevel: Double,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: Platform = Platform.Default,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.TONAL_SPOT,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 36.0),
-        secondaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 16.0),
-        tertiaryPalette = TonalPalette.fromHueAndChroma(
-            hue = MathUtils.sanitizeDegrees(sourceColorHct.hue + 60.0),
-            chroma = 24.0,
-        ),
-        neutralPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 6.0),
-        neutralVariantPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 8.0),
-    )
+    sourceColorHct = sourceColorHct,
+    variant = Variant.TONAL_SPOT,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(specVersion)
+        .getPrimaryPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+    secondaryPalette = ColorSpecs
+        .get(specVersion)
+        .getSecondaryPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+    tertiaryPalette = ColorSpecs
+        .get(specVersion)
+        .getTertiaryPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+    neutralPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+    neutralVariantPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralVariantPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+    errorPalette = ColorSpecs
+        .get(specVersion)
+        .getErrorPalette(Variant.TONAL_SPOT, sourceColorHct, isDark, platform, contrastLevel),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeVibrant.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeVibrant.kt
@@ -15,8 +15,9 @@
  */
 package com.materialkolor.scheme
 
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.dynamiccolor.ColorSpecs
 import com.materialkolor.hct.Hct
-import com.materialkolor.palettes.TonalPalette
 
 /**
  * A loud theme, colorfulness is maximum for Primary palette, increased for others.
@@ -25,31 +26,29 @@ public class SchemeVibrant(
     sourceColorHct: Hct,
     isDark: Boolean,
     contrastLevel: Double,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: Platform = Platform.Default,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.VIBRANT,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 200.0),
-        secondaryPalette = TonalPalette.fromHueAndChroma(
-            hue = getRotatedHue(sourceColorHct, HUES, SECONDARY_ROTATIONS),
-            chroma = 24.0,
-        ),
-        tertiaryPalette = TonalPalette.fromHueAndChroma(
-            hue = getRotatedHue(sourceColorHct, HUES, TERTIARY_ROTATIONS),
-            chroma = 32.0,
-        ),
-        neutralPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 10.0),
-        neutralVariantPalette = TonalPalette.fromHueAndChroma(sourceColorHct.hue, chroma = 12.0),
-    ) {
-    private companion object {
-        private val HUES =
-            doubleArrayOf(0.0, 41.0, 61.0, 101.0, 131.0, 181.0, 251.0, 301.0, 360.0)
-
-        private val SECONDARY_ROTATIONS =
-            doubleArrayOf(18.0, 15.0, 10.0, 12.0, 15.0, 18.0, 15.0, 12.0, 12.0)
-
-        private val TERTIARY_ROTATIONS =
-            doubleArrayOf(35.0, 30.0, 20.0, 25.0, 30.0, 35.0, 30.0, 25.0, 25.0)
-    }
-}
+    sourceColorHct = sourceColorHct,
+    variant = Variant.VIBRANT,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(specVersion)
+        .getPrimaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+    secondaryPalette = ColorSpecs
+        .get(specVersion)
+        .getSecondaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+    tertiaryPalette = ColorSpecs
+        .get(specVersion)
+        .getTertiaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+    neutralPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+    neutralVariantPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralVariantPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+    errorPalette = ColorSpecs
+        .get(specVersion)
+        .getErrorPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeVibrant.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeVibrant.kt
@@ -29,26 +29,26 @@ public class SchemeVibrant(
     specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
     platform: Platform = Platform.Default,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.VIBRANT,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(specVersion)
-        .getPrimaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-    secondaryPalette = ColorSpecs
-        .get(specVersion)
-        .getSecondaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-    tertiaryPalette = ColorSpecs
-        .get(specVersion)
-        .getTertiaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-    neutralPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-    neutralVariantPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralVariantPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-    errorPalette = ColorSpecs
-        .get(specVersion)
-        .getErrorPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.VIBRANT,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(specVersion)
+            .getPrimaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+        secondaryPalette = ColorSpecs
+            .get(specVersion)
+            .getSecondaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+        tertiaryPalette = ColorSpecs
+            .get(specVersion)
+            .getTertiaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+        neutralPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+        neutralVariantPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralVariantPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+        errorPalette = ColorSpecs
+            .get(specVersion)
+            .getErrorPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeVibrant.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeVibrant.kt
@@ -47,7 +47,13 @@ public class SchemeVibrant(
             .getNeutralPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
         neutralVariantPalette = ColorSpecs
             .get(specVersion)
-            .getNeutralVariantPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+            .getNeutralVariantPalette(
+                Variant.VIBRANT,
+                sourceColorHct,
+                isDark,
+                platform,
+                contrastLevel,
+            ),
         errorPalette = ColorSpecs
             .get(specVersion)
             .getErrorPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/score/Score.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/score/Score.kt
@@ -89,7 +89,13 @@ public object Score {
                 continue
             }
             val proportionScore = proportion * 100.0 * WEIGHT_PROPORTION
-            val chromaWeight = if (hct.chroma < TARGET_CHROMA) WEIGHT_CHROMA_BELOW else WEIGHT_CHROMA_ABOVE
+            val chromaWeight = if (hct.chroma <
+                TARGET_CHROMA
+            ) {
+                WEIGHT_CHROMA_BELOW
+            } else {
+                WEIGHT_CHROMA_ABOVE
+            }
             val chromaScore = (hct.chroma - TARGET_CHROMA) * chromaWeight
             val score = proportionScore + chromaScore
             scoredHcts.add(ScoredHCT(hct, score))

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/temperature/TemperatureCache.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/temperature/TemperatureCache.kt
@@ -255,7 +255,8 @@ public class TemperatureCache(
             val hcts: MutableList<Hct> = hctsByHue?.toMutableList() ?: mutableListOf()
             hcts.add(input)
 
-            val temperaturesComparator: Comparator<Hct> = compareBy { arg: Hct -> tempsByHct!![arg] }
+            val temperaturesComparator: Comparator<Hct> =
+                compareBy { arg: Hct -> tempsByHct!![arg] }
             hcts.sortWith(temperaturesComparator)
             precomputedHctsByTemp = hcts
             return precomputedHctsByTemp

--- a/material-kolor/api/android/material-kolor.api
+++ b/material-kolor/api/android/material-kolor.api
@@ -10,25 +10,25 @@ public final class com/materialkolor/Contrast : java/lang/Enum {
 }
 
 public final class com/materialkolor/DynamicColorSchemeKt {
-	public static final fun dynamicColorScheme-mm0v_cE (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
-	public static synthetic fun dynamicColorScheme-mm0v_cE$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
-	public static final fun dynamicColorScheme-vPsaOWw (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
-	public static synthetic fun dynamicColorScheme-vPsaOWw$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
-	public static final fun rememberDynamicColorScheme-GZ6Kjrw (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
-	public static final fun rememberDynamicColorScheme-_oUZ5uA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
-	public static final fun toColorScheme (Lcom/materialkolor/scheme/DynamicScheme;ZZLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
-	public static synthetic fun toColorScheme$default (Lcom/materialkolor/scheme/DynamicScheme;ZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
+	public static final fun dynamicColorScheme-SVMyCjU (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
+	public static synthetic fun dynamicColorScheme-SVMyCjU$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
+	public static final fun dynamicColorScheme-wpyEEbs (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
+	public static synthetic fun dynamicColorScheme-wpyEEbs$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
+	public static final fun rememberDynamicColorScheme-O7PEUBc (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
+	public static final fun rememberDynamicColorScheme-_tapC-E (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
+	public static final fun toColorScheme (Lcom/materialkolor/scheme/DynamicScheme;ZLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
+	public static synthetic fun toColorScheme$default (Lcom/materialkolor/scheme/DynamicScheme;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
 }
 
 public final class com/materialkolor/DynamicMaterialThemeKt {
 	public static final fun DynamicMaterialTheme (Lcom/materialkolor/DynamicMaterialThemeState;Landroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun DynamicMaterialTheme-7VznAdA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
-	public static final fun DynamicMaterialTheme-XkNKMuA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DynamicMaterialTheme-5nOaqmY (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DynamicMaterialTheme-cvmOG-8 (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/materialkolor/DynamicMaterialThemeState {
 	public static final field $stable I
-	public synthetic fun <init> (JZZLcom/materialkolor/PaletteStyle;DZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JZZLcom/materialkolor/PaletteStyle;DLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getColorScheme (Landroidx/compose/runtime/Composer;I)Landroidx/compose/material3/ColorScheme;
 	public final fun getContrastLevel ()D
 	public final fun getDynamicScheme (Landroidx/compose/runtime/Composer;I)Lcom/materialkolor/scheme/DynamicScheme;
@@ -43,12 +43,10 @@ public final class com/materialkolor/DynamicMaterialThemeState {
 	public final fun getTertiary-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
 	public final fun isAmoled ()Z
 	public final fun isDark ()Z
-	public final fun isExtendedFidelity ()Z
 	public final fun setAmoled (Z)V
 	public final fun setContrastLevel (D)V
 	public final fun setDark (Z)V
 	public final fun setError-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
-	public final fun setExtendedFidelity (Z)V
 	public final fun setNeutral-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 	public final fun setNeutralVariant-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 	public final fun setPrimary-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
@@ -59,8 +57,8 @@ public final class com/materialkolor/DynamicMaterialThemeState {
 }
 
 public final class com/materialkolor/DynamicMaterialThemeStateKt {
-	public static final fun rememberDynamicMaterialThemeState-GZ6Kjrw (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
-	public static final fun rememberDynamicMaterialThemeState-_oUZ5uA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
+	public static final fun rememberDynamicMaterialThemeState-O7PEUBc (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
+	public static final fun rememberDynamicMaterialThemeState-_tapC-E (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
 }
 
 public final class com/materialkolor/LocalDynamicMaterialThemeSeedKt {
@@ -69,8 +67,8 @@ public final class com/materialkolor/LocalDynamicMaterialThemeSeedKt {
 
 public final class com/materialkolor/MaterialKolors {
 	public static final field $stable I
-	public fun <init> (Lcom/materialkolor/scheme/DynamicScheme;ZZ)V
-	public synthetic fun <init> (Lcom/materialkolor/scheme/DynamicScheme;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/materialkolor/scheme/DynamicScheme;Z)V
+	public synthetic fun <init> (Lcom/materialkolor/scheme/DynamicScheme;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun background-0d7_KjU ()J
 	public final fun controlActivated-0d7_KjU ()J
 	public final fun controlHighlight-0d7_KjU ()J

--- a/material-kolor/api/android/material-kolor.api
+++ b/material-kolor/api/android/material-kolor.api
@@ -10,25 +10,25 @@ public final class com/materialkolor/Contrast : java/lang/Enum {
 }
 
 public final class com/materialkolor/DynamicColorSchemeKt {
-	public static final fun dynamicColorScheme-SVMyCjU (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
-	public static synthetic fun dynamicColorScheme-SVMyCjU$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
-	public static final fun dynamicColorScheme-wpyEEbs (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
-	public static synthetic fun dynamicColorScheme-wpyEEbs$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
-	public static final fun rememberDynamicColorScheme-O7PEUBc (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
-	public static final fun rememberDynamicColorScheme-_tapC-E (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
+	public static final fun dynamicColorScheme-N98v4SY (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
+	public static synthetic fun dynamicColorScheme-N98v4SY$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
+	public static final fun dynamicColorScheme-onzyBm0 (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
+	public static synthetic fun dynamicColorScheme-onzyBm0$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
+	public static final fun rememberDynamicColorScheme-CdFb-wI (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
+	public static final fun rememberDynamicColorScheme-UQznLDA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
 	public static final fun toColorScheme (Lcom/materialkolor/scheme/DynamicScheme;ZLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
 	public static synthetic fun toColorScheme$default (Lcom/materialkolor/scheme/DynamicScheme;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
 }
 
 public final class com/materialkolor/DynamicMaterialThemeKt {
 	public static final fun DynamicMaterialTheme (Lcom/materialkolor/DynamicMaterialThemeState;Landroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun DynamicMaterialTheme-5nOaqmY (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
-	public static final fun DynamicMaterialTheme-cvmOG-8 (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DynamicMaterialTheme-0OstJqQ (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Landroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DynamicMaterialTheme-bLGS3X0 (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Landroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/materialkolor/DynamicMaterialThemeState {
 	public static final field $stable I
-	public synthetic fun <init> (JZZLcom/materialkolor/PaletteStyle;DLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JZZLcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getColorScheme (Landroidx/compose/runtime/Composer;I)Landroidx/compose/material3/ColorScheme;
 	public final fun getContrastLevel ()D
 	public final fun getDynamicScheme (Landroidx/compose/runtime/Composer;I)Lcom/materialkolor/scheme/DynamicScheme;
@@ -36,9 +36,11 @@ public final class com/materialkolor/DynamicMaterialThemeState {
 	public final fun getModifyColorScheme ()Lkotlin/jvm/functions/Function2;
 	public final fun getNeutral-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
 	public final fun getNeutralVariant-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
+	public final fun getPlatform ()Lcom/materialkolor/scheme/DynamicScheme$Platform;
 	public final fun getPrimary-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
 	public final fun getSecondary-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
 	public final fun getSeedColor-0d7_KjU ()J
+	public final fun getSpecVersion ()Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
 	public final fun getStyle ()Lcom/materialkolor/PaletteStyle;
 	public final fun getTertiary-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
 	public final fun isAmoled ()Z
@@ -49,16 +51,18 @@ public final class com/materialkolor/DynamicMaterialThemeState {
 	public final fun setError-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 	public final fun setNeutral-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 	public final fun setNeutralVariant-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
+	public final fun setPlatform (Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
 	public final fun setPrimary-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 	public final fun setSecondary-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 	public final fun setSeedColor-8_81llA (J)V
+	public final fun setSpecVersion (Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;)V
 	public final fun setStyle (Lcom/materialkolor/PaletteStyle;)V
 	public final fun setTertiary-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 }
 
 public final class com/materialkolor/DynamicMaterialThemeStateKt {
-	public static final fun rememberDynamicMaterialThemeState-O7PEUBc (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
-	public static final fun rememberDynamicMaterialThemeState-_tapC-E (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
+	public static final fun rememberDynamicMaterialThemeState-CdFb-wI (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
+	public static final fun rememberDynamicMaterialThemeState-UQznLDA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
 }
 
 public final class com/materialkolor/LocalDynamicMaterialThemeSeedKt {
@@ -207,12 +211,12 @@ public final class com/materialkolor/ktx/DynamicColorKt {
 }
 
 public final class com/materialkolor/ktx/DynamicSchemeKt {
-	public static final fun DynamicScheme-9lyMwEc (JZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;D)Lcom/materialkolor/scheme/DynamicScheme;
-	public static synthetic fun DynamicScheme-9lyMwEc$default (JZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DILjava/lang/Object;)Lcom/materialkolor/scheme/DynamicScheme;
+	public static final fun DynamicScheme-dtSySfE (JZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)Lcom/materialkolor/scheme/DynamicScheme;
+	public static synthetic fun DynamicScheme-dtSySfE$default (JZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILjava/lang/Object;)Lcom/materialkolor/scheme/DynamicScheme;
 	public static final fun getSourceColor (Lcom/materialkolor/scheme/DynamicScheme;)J
-	public static final fun rememberDynamicScheme-CKb8kmc (JZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/runtime/Composer;II)Lcom/materialkolor/scheme/DynamicScheme;
-	public static final fun toDynamicScheme-Iv8Zu3U (JZLcom/materialkolor/PaletteStyle;D)Lcom/materialkolor/scheme/DynamicScheme;
-	public static synthetic fun toDynamicScheme-Iv8Zu3U$default (JZLcom/materialkolor/PaletteStyle;DILjava/lang/Object;)Lcom/materialkolor/scheme/DynamicScheme;
+	public static final fun rememberDynamicScheme-k1ZVges (JZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/scheme/DynamicScheme;
+	public static final fun toDynamicScheme-KTwxG1Y (JZLcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)Lcom/materialkolor/scheme/DynamicScheme;
+	public static synthetic fun toDynamicScheme-KTwxG1Y$default (JZLcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILjava/lang/Object;)Lcom/materialkolor/scheme/DynamicScheme;
 }
 
 public final class com/materialkolor/ktx/HarmonizeKt {

--- a/material-kolor/api/jvm/material-kolor.api
+++ b/material-kolor/api/jvm/material-kolor.api
@@ -10,25 +10,25 @@ public final class com/materialkolor/Contrast : java/lang/Enum {
 }
 
 public final class com/materialkolor/DynamicColorSchemeKt {
-	public static final fun dynamicColorScheme-mm0v_cE (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
-	public static synthetic fun dynamicColorScheme-mm0v_cE$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
-	public static final fun dynamicColorScheme-vPsaOWw (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
-	public static synthetic fun dynamicColorScheme-vPsaOWw$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
-	public static final fun rememberDynamicColorScheme-GZ6Kjrw (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
-	public static final fun rememberDynamicColorScheme-_oUZ5uA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
-	public static final fun toColorScheme (Lcom/materialkolor/scheme/DynamicScheme;ZZLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
-	public static synthetic fun toColorScheme$default (Lcom/materialkolor/scheme/DynamicScheme;ZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
+	public static final fun dynamicColorScheme-SVMyCjU (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
+	public static synthetic fun dynamicColorScheme-SVMyCjU$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
+	public static final fun dynamicColorScheme-wpyEEbs (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
+	public static synthetic fun dynamicColorScheme-wpyEEbs$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
+	public static final fun rememberDynamicColorScheme-O7PEUBc (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
+	public static final fun rememberDynamicColorScheme-_tapC-E (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
+	public static final fun toColorScheme (Lcom/materialkolor/scheme/DynamicScheme;ZLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
+	public static synthetic fun toColorScheme$default (Lcom/materialkolor/scheme/DynamicScheme;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
 }
 
 public final class com/materialkolor/DynamicMaterialThemeKt {
 	public static final fun DynamicMaterialTheme (Lcom/materialkolor/DynamicMaterialThemeState;Landroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun DynamicMaterialTheme-7VznAdA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
-	public static final fun DynamicMaterialTheme-XkNKMuA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DynamicMaterialTheme-5nOaqmY (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DynamicMaterialTheme-cvmOG-8 (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/materialkolor/DynamicMaterialThemeState {
 	public static final field $stable I
-	public synthetic fun <init> (JZZLcom/materialkolor/PaletteStyle;DZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JZZLcom/materialkolor/PaletteStyle;DLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getColorScheme (Landroidx/compose/runtime/Composer;I)Landroidx/compose/material3/ColorScheme;
 	public final fun getContrastLevel ()D
 	public final fun getDynamicScheme (Landroidx/compose/runtime/Composer;I)Lcom/materialkolor/scheme/DynamicScheme;
@@ -43,12 +43,10 @@ public final class com/materialkolor/DynamicMaterialThemeState {
 	public final fun getTertiary-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
 	public final fun isAmoled ()Z
 	public final fun isDark ()Z
-	public final fun isExtendedFidelity ()Z
 	public final fun setAmoled (Z)V
 	public final fun setContrastLevel (D)V
 	public final fun setDark (Z)V
 	public final fun setError-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
-	public final fun setExtendedFidelity (Z)V
 	public final fun setNeutral-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 	public final fun setNeutralVariant-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 	public final fun setPrimary-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
@@ -59,8 +57,8 @@ public final class com/materialkolor/DynamicMaterialThemeState {
 }
 
 public final class com/materialkolor/DynamicMaterialThemeStateKt {
-	public static final fun rememberDynamicMaterialThemeState-GZ6Kjrw (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
-	public static final fun rememberDynamicMaterialThemeState-_oUZ5uA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
+	public static final fun rememberDynamicMaterialThemeState-O7PEUBc (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
+	public static final fun rememberDynamicMaterialThemeState-_tapC-E (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
 }
 
 public final class com/materialkolor/LocalDynamicMaterialThemeSeedKt {
@@ -69,8 +67,8 @@ public final class com/materialkolor/LocalDynamicMaterialThemeSeedKt {
 
 public final class com/materialkolor/MaterialKolors {
 	public static final field $stable I
-	public fun <init> (Lcom/materialkolor/scheme/DynamicScheme;ZZ)V
-	public synthetic fun <init> (Lcom/materialkolor/scheme/DynamicScheme;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/materialkolor/scheme/DynamicScheme;Z)V
+	public synthetic fun <init> (Lcom/materialkolor/scheme/DynamicScheme;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun background-0d7_KjU ()J
 	public final fun controlActivated-0d7_KjU ()J
 	public final fun controlHighlight-0d7_KjU ()J

--- a/material-kolor/api/jvm/material-kolor.api
+++ b/material-kolor/api/jvm/material-kolor.api
@@ -10,25 +10,25 @@ public final class com/materialkolor/Contrast : java/lang/Enum {
 }
 
 public final class com/materialkolor/DynamicColorSchemeKt {
-	public static final fun dynamicColorScheme-SVMyCjU (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
-	public static synthetic fun dynamicColorScheme-SVMyCjU$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
-	public static final fun dynamicColorScheme-wpyEEbs (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
-	public static synthetic fun dynamicColorScheme-wpyEEbs$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
-	public static final fun rememberDynamicColorScheme-O7PEUBc (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
-	public static final fun rememberDynamicColorScheme-_tapC-E (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
+	public static final fun dynamicColorScheme-N98v4SY (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
+	public static synthetic fun dynamicColorScheme-N98v4SY$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
+	public static final fun dynamicColorScheme-onzyBm0 (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
+	public static synthetic fun dynamicColorScheme-onzyBm0$default (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
+	public static final fun rememberDynamicColorScheme-CdFb-wI (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
+	public static final fun rememberDynamicColorScheme-UQznLDA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Landroidx/compose/material3/ColorScheme;
 	public static final fun toColorScheme (Lcom/materialkolor/scheme/DynamicScheme;ZLkotlin/jvm/functions/Function1;)Landroidx/compose/material3/ColorScheme;
 	public static synthetic fun toColorScheme$default (Lcom/materialkolor/scheme/DynamicScheme;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/material3/ColorScheme;
 }
 
 public final class com/materialkolor/DynamicMaterialThemeKt {
 	public static final fun DynamicMaterialTheme (Lcom/materialkolor/DynamicMaterialThemeState;Landroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun DynamicMaterialTheme-5nOaqmY (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
-	public static final fun DynamicMaterialTheme-cvmOG-8 (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DynamicMaterialTheme-0OstJqQ (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Landroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DynamicMaterialTheme-bLGS3X0 (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Landroidx/compose/material3/Shapes;Landroidx/compose/material3/Typography;ZLandroidx/compose/animation/core/FiniteAnimationSpec;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/materialkolor/DynamicMaterialThemeState {
 	public static final field $stable I
-	public synthetic fun <init> (JZZLcom/materialkolor/PaletteStyle;DLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JZZLcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getColorScheme (Landroidx/compose/runtime/Composer;I)Landroidx/compose/material3/ColorScheme;
 	public final fun getContrastLevel ()D
 	public final fun getDynamicScheme (Landroidx/compose/runtime/Composer;I)Lcom/materialkolor/scheme/DynamicScheme;
@@ -36,9 +36,11 @@ public final class com/materialkolor/DynamicMaterialThemeState {
 	public final fun getModifyColorScheme ()Lkotlin/jvm/functions/Function2;
 	public final fun getNeutral-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
 	public final fun getNeutralVariant-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
+	public final fun getPlatform ()Lcom/materialkolor/scheme/DynamicScheme$Platform;
 	public final fun getPrimary-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
 	public final fun getSecondary-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
 	public final fun getSeedColor-0d7_KjU ()J
+	public final fun getSpecVersion ()Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;
 	public final fun getStyle ()Lcom/materialkolor/PaletteStyle;
 	public final fun getTertiary-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
 	public final fun isAmoled ()Z
@@ -49,16 +51,18 @@ public final class com/materialkolor/DynamicMaterialThemeState {
 	public final fun setError-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 	public final fun setNeutral-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 	public final fun setNeutralVariant-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
+	public final fun setPlatform (Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
 	public final fun setPrimary-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 	public final fun setSecondary-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 	public final fun setSeedColor-8_81llA (J)V
+	public final fun setSpecVersion (Lcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;)V
 	public final fun setStyle (Lcom/materialkolor/PaletteStyle;)V
 	public final fun setTertiary-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 }
 
 public final class com/materialkolor/DynamicMaterialThemeStateKt {
-	public static final fun rememberDynamicMaterialThemeState-O7PEUBc (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
-	public static final fun rememberDynamicMaterialThemeState-_tapC-E (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
+	public static final fun rememberDynamicMaterialThemeState-CdFb-wI (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
+	public static final fun rememberDynamicMaterialThemeState-UQznLDA (JZZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/DynamicMaterialThemeState;
 }
 
 public final class com/materialkolor/LocalDynamicMaterialThemeSeedKt {
@@ -207,12 +211,12 @@ public final class com/materialkolor/ktx/DynamicColorKt {
 }
 
 public final class com/materialkolor/ktx/DynamicSchemeKt {
-	public static final fun DynamicScheme-9lyMwEc (JZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;D)Lcom/materialkolor/scheme/DynamicScheme;
-	public static synthetic fun DynamicScheme-9lyMwEc$default (JZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DILjava/lang/Object;)Lcom/materialkolor/scheme/DynamicScheme;
+	public static final fun DynamicScheme-dtSySfE (JZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)Lcom/materialkolor/scheme/DynamicScheme;
+	public static synthetic fun DynamicScheme-dtSySfE$default (JZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILjava/lang/Object;)Lcom/materialkolor/scheme/DynamicScheme;
 	public static final fun getSourceColor (Lcom/materialkolor/scheme/DynamicScheme;)J
-	public static final fun rememberDynamicScheme-CKb8kmc (JZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLandroidx/compose/runtime/Composer;II)Lcom/materialkolor/scheme/DynamicScheme;
-	public static final fun toDynamicScheme-Iv8Zu3U (JZLcom/materialkolor/PaletteStyle;D)Lcom/materialkolor/scheme/DynamicScheme;
-	public static synthetic fun toDynamicScheme-Iv8Zu3U$default (JZLcom/materialkolor/PaletteStyle;DILjava/lang/Object;)Lcom/materialkolor/scheme/DynamicScheme;
+	public static final fun rememberDynamicScheme-k1ZVges (JZLandroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;Landroidx/compose/runtime/Composer;III)Lcom/materialkolor/scheme/DynamicScheme;
+	public static final fun toDynamicScheme-KTwxG1Y (JZLcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)Lcom/materialkolor/scheme/DynamicScheme;
+	public static synthetic fun toDynamicScheme-KTwxG1Y$default (JZLcom/materialkolor/PaletteStyle;DLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILjava/lang/Object;)Lcom/materialkolor/scheme/DynamicScheme;
 }
 
 public final class com/materialkolor/ktx/HarmonizeKt {

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicColorScheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicColorScheme.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import com.materialkolor.dynamiccolor.ColorSpec
 import com.materialkolor.ktx.DynamicScheme
 import com.materialkolor.scheme.DynamicScheme
 
@@ -23,6 +24,8 @@ import com.materialkolor.scheme.DynamicScheme
  * @param[error] The error color of the scheme.
  * @param[style] The style of the scheme.
  * @param[contrastLevel] The contrast level of the scheme.
+ * @param[specVersion] The version of the color scheme.
+ * @param[platform] The platform of the color scheme.
  * @param[modifyColorScheme] A lambda to modify the created [ColorScheme].
  */
 @Composable
@@ -38,6 +41,8 @@ public fun rememberDynamicColorScheme(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: DynamicScheme.Platform = DynamicScheme.Platform.Default,
     modifyColorScheme: ((ColorScheme) -> ColorScheme)? = null,
 ): ColorScheme =
     remember(
@@ -52,6 +57,8 @@ public fun rememberDynamicColorScheme(
         error,
         style,
         contrastLevel,
+        specVersion,
+        platform,
         modifyColorScheme,
     ) {
         dynamicColorScheme(
@@ -86,6 +93,8 @@ public fun rememberDynamicColorScheme(
  * @param[error] The error color of the scheme.
  * @param[style] The style of the scheme.
  * @param[contrastLevel] The contrast level of the scheme.
+ * @param[specVersion] The version of the color scheme.
+ * @param[platform] The platform of the color scheme.
  * @param[modifyColorScheme] A lambda to modify the created [ColorScheme].
  */
 public fun dynamicColorScheme(
@@ -100,6 +109,8 @@ public fun dynamicColorScheme(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: DynamicScheme.Platform = DynamicScheme.Platform.Default,
     modifyColorScheme: ((ColorScheme) -> ColorScheme)? = null,
 ): ColorScheme {
     val scheme = DynamicScheme(
@@ -113,6 +124,8 @@ public fun dynamicColorScheme(
         error = error,
         style = style,
         contrastLevel = contrastLevel,
+        specVersion = specVersion,
+        platform = platform,
     )
 
     return scheme.toColorScheme(isAmoled, modifyColorScheme)
@@ -133,6 +146,8 @@ public fun dynamicColorScheme(
  * @param[error] The error color of the scheme.
  * @param[style] The style of the scheme.
  * @param[contrastLevel] The contrast level of the scheme.
+ * @param[specVersion] The version of the color scheme.
+ * @param[platform] The platform of the color scheme.
  * @param[modifyColorScheme] A lambda to modify the created [ColorScheme].
  */
 @Composable
@@ -147,6 +162,8 @@ public fun rememberDynamicColorScheme(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: DynamicScheme.Platform = DynamicScheme.Platform.Default,
     modifyColorScheme: ((ColorScheme) -> ColorScheme)? = null,
 ): ColorScheme =
     remember(
@@ -161,6 +178,8 @@ public fun rememberDynamicColorScheme(
         style,
         contrastLevel,
         modifyColorScheme,
+        specVersion,
+        platform,
     ) {
         dynamicColorScheme(
             primary = primary,
@@ -173,6 +192,8 @@ public fun rememberDynamicColorScheme(
             error = error,
             style = style,
             contrastLevel = contrastLevel,
+            specVersion = specVersion,
+            platform = platform,
             modifyColorScheme = modifyColorScheme,
         )
     }
@@ -192,6 +213,8 @@ public fun rememberDynamicColorScheme(
  * @param[error] The error color of the scheme.
  * @param[style] The style of the scheme.
  * @param[contrastLevel] The contrast level of the scheme.
+ * @param[specVersion] The version of the color scheme.
+ * @param[platform] The platform of the color scheme.
  * @param[modifyColorScheme] A lambda to modify the created [ColorScheme].
  */
 public fun dynamicColorScheme(
@@ -205,6 +228,8 @@ public fun dynamicColorScheme(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: DynamicScheme.Platform = DynamicScheme.Platform.Default,
     modifyColorScheme: ((ColorScheme) -> ColorScheme)? = null,
 ): ColorScheme =
     dynamicColorScheme(
@@ -219,6 +244,8 @@ public fun dynamicColorScheme(
         error = error,
         style = style,
         contrastLevel = contrastLevel,
+        specVersion = specVersion,
+        platform = platform,
         modifyColorScheme = modifyColorScheme,
     )
 

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicColorScheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicColorScheme.kt
@@ -4,7 +4,6 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
-import com.materialkolor.dynamiccolor.MaterialDynamicColors
 import com.materialkolor.ktx.DynamicScheme
 import com.materialkolor.scheme.DynamicScheme
 
@@ -24,7 +23,6 @@ import com.materialkolor.scheme.DynamicScheme
  * @param[error] The error color of the scheme.
  * @param[style] The style of the scheme.
  * @param[contrastLevel] The contrast level of the scheme.
- * @param[isExtendedFidelity] Whether to use the extended fidelity color set. See [MaterialDynamicColors].
  * @param[modifyColorScheme] A lambda to modify the created [ColorScheme].
  */
 @Composable
@@ -40,7 +38,6 @@ public fun rememberDynamicColorScheme(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
-    isExtendedFidelity: Boolean = false,
     modifyColorScheme: ((ColorScheme) -> ColorScheme)? = null,
 ): ColorScheme =
     remember(
@@ -55,7 +52,6 @@ public fun rememberDynamicColorScheme(
         error,
         style,
         contrastLevel,
-        isExtendedFidelity,
         modifyColorScheme,
     ) {
         dynamicColorScheme(
@@ -70,7 +66,6 @@ public fun rememberDynamicColorScheme(
             error = error,
             style = style,
             contrastLevel = contrastLevel,
-            isExtendedFidelity = isExtendedFidelity,
             modifyColorScheme = modifyColorScheme,
         )
     }
@@ -91,7 +86,6 @@ public fun rememberDynamicColorScheme(
  * @param[error] The error color of the scheme.
  * @param[style] The style of the scheme.
  * @param[contrastLevel] The contrast level of the scheme.
- * @param[isExtendedFidelity] Whether to use the extended fidelity color set. See [MaterialDynamicColors].
  * @param[modifyColorScheme] A lambda to modify the created [ColorScheme].
  */
 public fun dynamicColorScheme(
@@ -106,7 +100,6 @@ public fun dynamicColorScheme(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
-    isExtendedFidelity: Boolean = false,
     modifyColorScheme: ((ColorScheme) -> ColorScheme)? = null,
 ): ColorScheme {
     val scheme = DynamicScheme(
@@ -122,7 +115,7 @@ public fun dynamicColorScheme(
         contrastLevel = contrastLevel,
     )
 
-    return scheme.toColorScheme(isAmoled, isExtendedFidelity, modifyColorScheme)
+    return scheme.toColorScheme(isAmoled, modifyColorScheme)
 }
 
 /**
@@ -140,7 +133,6 @@ public fun dynamicColorScheme(
  * @param[error] The error color of the scheme.
  * @param[style] The style of the scheme.
  * @param[contrastLevel] The contrast level of the scheme.
- * @param[isExtendedFidelity] Whether to use the extended fidelity color set. See [MaterialDynamicColors].
  * @param[modifyColorScheme] A lambda to modify the created [ColorScheme].
  */
 @Composable
@@ -155,7 +147,6 @@ public fun rememberDynamicColorScheme(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
-    isExtendedFidelity: Boolean = false,
     modifyColorScheme: ((ColorScheme) -> ColorScheme)? = null,
 ): ColorScheme =
     remember(
@@ -169,7 +160,6 @@ public fun rememberDynamicColorScheme(
         error,
         style,
         contrastLevel,
-        isExtendedFidelity,
         modifyColorScheme,
     ) {
         dynamicColorScheme(
@@ -183,7 +173,6 @@ public fun rememberDynamicColorScheme(
             error = error,
             style = style,
             contrastLevel = contrastLevel,
-            isExtendedFidelity = isExtendedFidelity,
             modifyColorScheme = modifyColorScheme,
         )
     }
@@ -203,7 +192,6 @@ public fun rememberDynamicColorScheme(
  * @param[error] The error color of the scheme.
  * @param[style] The style of the scheme.
  * @param[contrastLevel] The contrast level of the scheme.
- * @param[isExtendedFidelity] Whether to use the extended fidelity color set. See [MaterialDynamicColors].
  * @param[modifyColorScheme] A lambda to modify the created [ColorScheme].
  */
 public fun dynamicColorScheme(
@@ -217,7 +205,6 @@ public fun dynamicColorScheme(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
-    isExtendedFidelity: Boolean = false,
     modifyColorScheme: ((ColorScheme) -> ColorScheme)? = null,
 ): ColorScheme =
     dynamicColorScheme(
@@ -232,7 +219,6 @@ public fun dynamicColorScheme(
         error = error,
         style = style,
         contrastLevel = contrastLevel,
-        isExtendedFidelity = isExtendedFidelity,
         modifyColorScheme = modifyColorScheme,
     )
 
@@ -241,10 +227,9 @@ public fun dynamicColorScheme(
  */
 public fun DynamicScheme.toColorScheme(
     isAmoled: Boolean = false,
-    isExtendedFidelity: Boolean = false,
     modifyColorScheme: ((ColorScheme) -> ColorScheme)? = null,
 ): ColorScheme {
-    val colors = MaterialKolors(scheme = this, isAmoled, isExtendedFidelity)
+    val colors = MaterialKolors(scheme = this, isAmoled)
     return ColorScheme(
         background = colors.background(),
         error = colors.error(),

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
@@ -8,8 +8,10 @@ import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
+import com.materialkolor.dynamiccolor.ColorSpec
 import com.materialkolor.ktx.animateColorScheme
 import com.materialkolor.ktx.defaultColorSpring
+import com.materialkolor.scheme.DynamicScheme
 
 /**
  * A Material Theme that adapts to the given seed color and the provided custom colors.
@@ -29,6 +31,10 @@ import com.materialkolor.ktx.defaultColorSpring
  * @param[error] The custom error color of the color scheme.
  * @param[style] The style of the color scheme.
  * @param[contrastLevel] The contrast level of the color scheme.
+ * @param[specVersion] The spec version of the color scheme.
+ * @param[platform] The platform of the color scheme.
+ * @param[shapes] The shapes of the theme.
+ * @param[typography] The typography of the theme.
  * @param[animate] Whether to animate the color scheme or not.
  * @param[animationSpec] The animation spec to use for animating the color scheme.
  * @param[content] The Composable content of the theme.
@@ -46,6 +52,8 @@ public fun DynamicMaterialTheme(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: DynamicScheme.Platform = DynamicScheme.Platform.Default,
     shapes: Shapes = MaterialTheme.shapes,
     typography: Typography = MaterialTheme.typography,
     animate: Boolean = false,
@@ -64,6 +72,8 @@ public fun DynamicMaterialTheme(
         error = error,
         style = style,
         contrastLevel = contrastLevel,
+        specVersion = specVersion,
+        platform = platform,
     )
 
     DynamicMaterialTheme(
@@ -93,6 +103,10 @@ public fun DynamicMaterialTheme(
  * @param[error] The custom error color of the color scheme.
  * @param[style] The style of the color scheme.
  * @param[contrastLevel] The contrast level of the color scheme.
+ * @param[specVersion] The spec version of the color scheme.
+ * @param[platform] The platform of the color scheme.
+ * @param[shapes] The shapes of the theme.
+ * @param[typography] The typography of the theme.
  * @param[animate] Whether to animate the color scheme or not.
  * @param[animationSpec] The animation spec to use for animating the color scheme.
  * @param[content] The Composable content of the theme.
@@ -109,6 +123,8 @@ public fun DynamicMaterialTheme(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: DynamicScheme.Platform = DynamicScheme.Platform.Default,
     shapes: Shapes = MaterialTheme.shapes,
     typography: Typography = MaterialTheme.typography,
     animate: Boolean = false,
@@ -126,6 +142,8 @@ public fun DynamicMaterialTheme(
         error = error,
         style = style,
         contrastLevel = contrastLevel,
+        specVersion = specVersion,
+        platform = platform,
     )
 
     DynamicMaterialTheme(

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
-import com.materialkolor.dynamiccolor.MaterialDynamicColors
 import com.materialkolor.ktx.animateColorScheme
 import com.materialkolor.ktx.defaultColorSpring
 
@@ -21,7 +20,7 @@ import com.materialkolor.ktx.defaultColorSpring
  * @see PaletteStyle
  * @param[seedColor] The seed color to use for generating the color scheme.
  * @param[useDarkTheme] Whether to use a dark theme or not.
- * @param[withAmoled] Whether the dark scheme is used with Amoled screen (Pure dark).
+ * @param[isAmoled] Whether the dark scheme is used with Amoled screen (Pure dark).
  * @param[primary] The custom primary color of the color scheme.
  * @param[secondary] The custom secondary color of the color scheme.
  * @param[tertiary] The custom tertiary color of the color scheme.
@@ -30,7 +29,6 @@ import com.materialkolor.ktx.defaultColorSpring
  * @param[error] The custom error color of the color scheme.
  * @param[style] The style of the color scheme.
  * @param[contrastLevel] The contrast level of the color scheme.
- * @param[isExtendedFidelity] Whether to use the extended fidelity color set. See [MaterialDynamicColors].
  * @param[animate] Whether to animate the color scheme or not.
  * @param[animationSpec] The animation spec to use for animating the color scheme.
  * @param[content] The Composable content of the theme.
@@ -39,7 +37,7 @@ import com.materialkolor.ktx.defaultColorSpring
 public fun DynamicMaterialTheme(
     seedColor: Color,
     useDarkTheme: Boolean = isSystemInDarkTheme(),
-    withAmoled: Boolean = false,
+    isAmoled: Boolean = false,
     primary: Color? = null,
     secondary: Color? = null,
     tertiary: Color? = null,
@@ -50,7 +48,6 @@ public fun DynamicMaterialTheme(
     contrastLevel: Double = Contrast.Default.value,
     shapes: Shapes = MaterialTheme.shapes,
     typography: Typography = MaterialTheme.typography,
-    isExtendedFidelity: Boolean = false,
     animate: Boolean = false,
     animationSpec: FiniteAnimationSpec<Color> = defaultColorSpring,
     content: @Composable () -> Unit,
@@ -58,7 +55,7 @@ public fun DynamicMaterialTheme(
     val state = rememberDynamicMaterialThemeState(
         seedColor = seedColor,
         isDark = useDarkTheme,
-        isAmoled = withAmoled,
+        isAmoled = isAmoled,
         primary = primary,
         secondary = secondary,
         tertiary = tertiary,
@@ -67,7 +64,6 @@ public fun DynamicMaterialTheme(
         error = error,
         style = style,
         contrastLevel = contrastLevel,
-        extendedFidelity = isExtendedFidelity,
     )
 
     DynamicMaterialTheme(
@@ -89,7 +85,7 @@ public fun DynamicMaterialTheme(
  * @see PaletteStyle
  * @param[primary] The primary color of the color scheme.
  * @param[useDarkTheme] Whether to use a dark theme or not.
- * @param[withAmoled] Whether the dark scheme is used with Amoled screen (Pure dark).
+ * @param[isAmoled] Whether the dark scheme is used with Amoled screen (Pure dark).
  * @param[secondary] The custom secondary color of the color scheme.
  * @param[tertiary] The custom tertiary color of the color scheme.
  * @param[neutral] The custom neutral color of the color scheme.
@@ -97,7 +93,6 @@ public fun DynamicMaterialTheme(
  * @param[error] The custom error color of the color scheme.
  * @param[style] The style of the color scheme.
  * @param[contrastLevel] The contrast level of the color scheme.
- * @param[isExtendedFidelity] Whether to use the extended fidelity color set. See [MaterialDynamicColors].
  * @param[animate] Whether to animate the color scheme or not.
  * @param[animationSpec] The animation spec to use for animating the color scheme.
  * @param[content] The Composable content of the theme.
@@ -106,7 +101,7 @@ public fun DynamicMaterialTheme(
 public fun DynamicMaterialTheme(
     primary: Color,
     useDarkTheme: Boolean = isSystemInDarkTheme(),
-    withAmoled: Boolean = false,
+    isAmoled: Boolean = false,
     secondary: Color? = null,
     tertiary: Color? = null,
     neutral: Color? = null,
@@ -116,7 +111,6 @@ public fun DynamicMaterialTheme(
     contrastLevel: Double = Contrast.Default.value,
     shapes: Shapes = MaterialTheme.shapes,
     typography: Typography = MaterialTheme.typography,
-    isExtendedFidelity: Boolean = false,
     animate: Boolean = false,
     animationSpec: FiniteAnimationSpec<Color> = defaultColorSpring,
     content: @Composable () -> Unit,
@@ -124,7 +118,7 @@ public fun DynamicMaterialTheme(
     val state = rememberDynamicMaterialThemeState(
         primary = primary,
         isDark = useDarkTheme,
-        isAmoled = withAmoled,
+        isAmoled = isAmoled,
         secondary = secondary,
         tertiary = tertiary,
         neutral = neutral,
@@ -132,7 +126,6 @@ public fun DynamicMaterialTheme(
         error = error,
         style = style,
         contrastLevel = contrastLevel,
-        extendedFidelity = isExtendedFidelity,
     )
 
     DynamicMaterialTheme(

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialThemeState.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialThemeState.kt
@@ -25,7 +25,6 @@ import com.materialkolor.scheme.DynamicScheme
  * @param[error] A custom color to modify the error color in the generated color scheme.
  * @param[style] The initial palette style.
  * @param[contrastLevel] The initial contrast level.
- * @param[extendedFidelity] The initial extended fidelity state.
  * @param[modifyColorScheme] Use this callback to modify the color scheme once it has been generated.
  * Note that if you modify a color in the scheme, the on* color might not have enough contrast.
  */
@@ -42,7 +41,6 @@ public fun rememberDynamicMaterialThemeState(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
-    extendedFidelity: Boolean = false,
     modifyColorScheme: (DynamicMaterialThemeState.(ColorScheme) -> ColorScheme)? = null,
 ): DynamicMaterialThemeState =
     remember(
@@ -57,7 +55,6 @@ public fun rememberDynamicMaterialThemeState(
         error,
         style,
         contrastLevel,
-        extendedFidelity,
         modifyColorScheme,
     ) {
         DynamicMaterialThemeState(
@@ -66,7 +63,6 @@ public fun rememberDynamicMaterialThemeState(
             initialIsAmoled = isAmoled,
             initialStyle = style,
             initialContrastLevel = contrastLevel,
-            initialExtendedFidelity = extendedFidelity,
             initialPrimary = primary,
             initialSecondary = secondary,
             initialTertiary = tertiary,
@@ -92,7 +88,6 @@ public fun rememberDynamicMaterialThemeState(
  * @param[error] A custom color to modify the error color in the generated color scheme.
  * @param[style] The initial palette style.
  * @param[contrastLevel] The initial contrast level.
- * @param[extendedFidelity] The initial extended fidelity state.
  * @param[modifyColorScheme] Use this callback to modify the color scheme once it has been generated.
  * Note that if you modify a color in the scheme, the on* color might not have enough contrast.
  */
@@ -108,7 +103,6 @@ public fun rememberDynamicMaterialThemeState(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
-    extendedFidelity: Boolean = false,
     modifyColorScheme: (DynamicMaterialThemeState.(ColorScheme) -> ColorScheme)? = null,
 ): DynamicMaterialThemeState =
     remember(
@@ -122,7 +116,6 @@ public fun rememberDynamicMaterialThemeState(
         error,
         style,
         contrastLevel,
-        extendedFidelity,
         modifyColorScheme,
     ) {
         DynamicMaterialThemeState(
@@ -131,7 +124,6 @@ public fun rememberDynamicMaterialThemeState(
             initialIsAmoled = isAmoled,
             initialStyle = style,
             initialContrastLevel = contrastLevel,
-            initialExtendedFidelity = extendedFidelity,
             initialPrimary = primary,
             initialSecondary = secondary,
             initialTertiary = tertiary,
@@ -152,7 +144,6 @@ public fun rememberDynamicMaterialThemeState(
  * @param[initialIsAmoled] The initial Amoled state.
  * @param[initialStyle] The initial palette style.
  * @param[initialContrastLevel] The initial contrast level.
- * @param[initialExtendedFidelity] The initial extended fidelity state.
  * @param[initialPrimary] A custom color to modify the primary color in the generated color scheme.
  * @param[initialSecondary] A custom color to modify the secondary color in the generated color scheme.
  * @param[initialTertiary] A custom color to modify the tertiary color in the generated color scheme.
@@ -170,7 +161,6 @@ public class DynamicMaterialThemeState internal constructor(
     initialIsAmoled: Boolean,
     initialStyle: PaletteStyle,
     initialContrastLevel: Double,
-    initialExtendedFidelity: Boolean,
     initialPrimary: Color? = null,
     initialSecondary: Color? = null,
     initialTertiary: Color? = null,
@@ -214,13 +204,6 @@ public class DynamicMaterialThemeState internal constructor(
      * @see dynamicColorScheme
      */
     public var contrastLevel: Double by mutableStateOf(initialContrastLevel)
-
-    /**
-     * The extended fidelity state.
-     *
-     * @see dynamicColorScheme
-     */
-    public var isExtendedFidelity: Boolean by mutableStateOf(initialExtendedFidelity)
 
     /**
      * A custom color to modify the primary color in the generated color scheme.
@@ -318,7 +301,6 @@ public class DynamicMaterialThemeState internal constructor(
                     error = error,
                     style = style,
                     contrastLevel = contrastLevel,
-                    isExtendedFidelity = isExtendedFidelity,
                     modifyColorScheme = callback,
                 )
                 isCustomScheme -> rememberDynamicColorScheme(
@@ -333,7 +315,6 @@ public class DynamicMaterialThemeState internal constructor(
                     error = error,
                     style = style,
                     contrastLevel = contrastLevel,
-                    isExtendedFidelity = isExtendedFidelity,
                     modifyColorScheme = callback,
                 )
                 else -> rememberDynamicColorScheme(
@@ -343,7 +324,6 @@ public class DynamicMaterialThemeState internal constructor(
                     primary = null,
                     style = style,
                     contrastLevel = contrastLevel,
-                    isExtendedFidelity = isExtendedFidelity,
                     modifyColorScheme = callback,
                 )
             }

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialThemeState.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialThemeState.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
+import com.materialkolor.dynamiccolor.ColorSpec
 import com.materialkolor.ktx.rememberDynamicScheme
 import com.materialkolor.scheme.DynamicScheme
 
@@ -25,6 +26,8 @@ import com.materialkolor.scheme.DynamicScheme
  * @param[error] A custom color to modify the error color in the generated color scheme.
  * @param[style] The initial palette style.
  * @param[contrastLevel] The initial contrast level.
+ * @param[specVersion] The initial spec version.
+ * @param[platform] The initial platform.
  * @param[modifyColorScheme] Use this callback to modify the color scheme once it has been generated.
  * Note that if you modify a color in the scheme, the on* color might not have enough contrast.
  */
@@ -41,6 +44,8 @@ public fun rememberDynamicMaterialThemeState(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: DynamicScheme.Platform = DynamicScheme.Platform.Default,
     modifyColorScheme: (DynamicMaterialThemeState.(ColorScheme) -> ColorScheme)? = null,
 ): DynamicMaterialThemeState =
     remember(
@@ -55,6 +60,8 @@ public fun rememberDynamicMaterialThemeState(
         error,
         style,
         contrastLevel,
+        specVersion,
+        platform,
         modifyColorScheme,
     ) {
         DynamicMaterialThemeState(
@@ -63,6 +70,8 @@ public fun rememberDynamicMaterialThemeState(
             initialIsAmoled = isAmoled,
             initialStyle = style,
             initialContrastLevel = contrastLevel,
+            initialSpecVersion = specVersion,
+            initialPlatform = platform,
             initialPrimary = primary,
             initialSecondary = secondary,
             initialTertiary = tertiary,
@@ -88,6 +97,8 @@ public fun rememberDynamicMaterialThemeState(
  * @param[error] A custom color to modify the error color in the generated color scheme.
  * @param[style] The initial palette style.
  * @param[contrastLevel] The initial contrast level.
+ * @param[specVersion] The initial spec version.
+ * @param[platform] The initial platform.
  * @param[modifyColorScheme] Use this callback to modify the color scheme once it has been generated.
  * Note that if you modify a color in the scheme, the on* color might not have enough contrast.
  */
@@ -103,6 +114,8 @@ public fun rememberDynamicMaterialThemeState(
     error: Color? = null,
     style: PaletteStyle = PaletteStyle.TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: DynamicScheme.Platform = DynamicScheme.Platform.Default,
     modifyColorScheme: (DynamicMaterialThemeState.(ColorScheme) -> ColorScheme)? = null,
 ): DynamicMaterialThemeState =
     remember(
@@ -116,6 +129,8 @@ public fun rememberDynamicMaterialThemeState(
         error,
         style,
         contrastLevel,
+        specVersion,
+        platform,
         modifyColorScheme,
     ) {
         DynamicMaterialThemeState(
@@ -124,6 +139,8 @@ public fun rememberDynamicMaterialThemeState(
             initialIsAmoled = isAmoled,
             initialStyle = style,
             initialContrastLevel = contrastLevel,
+            initialSpecVersion = specVersion,
+            initialPlatform = platform,
             initialPrimary = primary,
             initialSecondary = secondary,
             initialTertiary = tertiary,
@@ -144,6 +161,8 @@ public fun rememberDynamicMaterialThemeState(
  * @param[initialIsAmoled] The initial Amoled state.
  * @param[initialStyle] The initial palette style.
  * @param[initialContrastLevel] The initial contrast level.
+ * @param[initialSpecVersion] The initial spec version.
+ * @param[initialPlatform] The initial platform.
  * @param[initialPrimary] A custom color to modify the primary color in the generated color scheme.
  * @param[initialSecondary] A custom color to modify the secondary color in the generated color scheme.
  * @param[initialTertiary] A custom color to modify the tertiary color in the generated color scheme.
@@ -161,6 +180,8 @@ public class DynamicMaterialThemeState internal constructor(
     initialIsAmoled: Boolean,
     initialStyle: PaletteStyle,
     initialContrastLevel: Double,
+    initialSpecVersion: ColorSpec.SpecVersion,
+    initialPlatform: DynamicScheme.Platform,
     initialPrimary: Color? = null,
     initialSecondary: Color? = null,
     initialTertiary: Color? = null,
@@ -204,6 +225,20 @@ public class DynamicMaterialThemeState internal constructor(
      * @see dynamicColorScheme
      */
     public var contrastLevel: Double by mutableStateOf(initialContrastLevel)
+
+    /**
+     * The spec version.
+     *
+     * @see dynamicColorScheme
+     */
+    public var specVersion: ColorSpec.SpecVersion by mutableStateOf(initialSpecVersion)
+
+    /**
+     * The platform.
+     *
+     * @see dynamicColorScheme
+     */
+    public var platform: DynamicScheme.Platform by mutableStateOf(initialPlatform)
 
     /**
      * A custom color to modify the primary color in the generated color scheme.
@@ -257,6 +292,8 @@ public class DynamicMaterialThemeState internal constructor(
                     error = error,
                     style = style,
                     contrastLevel = contrastLevel,
+                    specVersion = specVersion,
+                    platform = platform,
                 )
                 isCustomScheme -> rememberDynamicScheme(
                     seedColor = seedColor,
@@ -269,12 +306,16 @@ public class DynamicMaterialThemeState internal constructor(
                     error = error,
                     style = style,
                     contrastLevel = contrastLevel,
+                    specVersion = specVersion,
+                    platform = platform,
                 )
                 else -> rememberDynamicScheme(
                     seedColor = seedColor,
                     isDark = isDark,
                     style = style,
                     contrastLevel = contrastLevel,
+                    specVersion = specVersion,
+                    platform = platform,
                 )
             }
         }
@@ -301,6 +342,8 @@ public class DynamicMaterialThemeState internal constructor(
                     error = error,
                     style = style,
                     contrastLevel = contrastLevel,
+                    specVersion = specVersion,
+                    platform = platform,
                     modifyColorScheme = callback,
                 )
                 isCustomScheme -> rememberDynamicColorScheme(
@@ -315,6 +358,8 @@ public class DynamicMaterialThemeState internal constructor(
                     error = error,
                     style = style,
                     contrastLevel = contrastLevel,
+                    specVersion = specVersion,
+                    platform = platform,
                     modifyColorScheme = callback,
                 )
                 else -> rememberDynamicColorScheme(
@@ -324,6 +369,8 @@ public class DynamicMaterialThemeState internal constructor(
                     primary = null,
                     style = style,
                     contrastLevel = contrastLevel,
+                    specVersion = specVersion,
+                    platform = platform,
                     modifyColorScheme = callback,
                 )
             }

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/MaterialKolors.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/MaterialKolors.kt
@@ -10,14 +10,12 @@ import com.materialkolor.scheme.DynamicScheme
  *
  * @property scheme The dynamic scheme used to generate colors.
  * @property isAmoled A flag indicating whether the device is AMOLED.
- * @param isExtendedFidelity A flag indicating whether extended fidelity is enabled.
  */
 public class MaterialKolors(
     private val scheme: DynamicScheme,
     private val isAmoled: Boolean = false,
-    isExtendedFidelity: Boolean = false,
 ) {
-    private val colors = MaterialDynamicColors(isExtendedFidelity)
+    private val colors = MaterialDynamicColors()
 
     /**
      * Returns the highest surface color based on the given scheme.

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/MaterialKolors.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/MaterialKolors.kt
@@ -23,7 +23,8 @@ public class MaterialKolors(
      * @param scheme The dynamic scheme used to generate the color.
      * @see MaterialDynamicColors.highestSurface
      */
-    public fun highestSurface(scheme: DynamicScheme): Color = colors.highestSurface(scheme).getColor(scheme)
+    public fun highestSurface(scheme: DynamicScheme): Color =
+        colors.highestSurface(scheme).getColor(scheme)
 
     /**
      * Returns the primary palette key color.
@@ -37,7 +38,8 @@ public class MaterialKolors(
      *
      * @see MaterialDynamicColors.secondaryPaletteKeyColor
      */
-    public fun secondaryPaletteKeyColor(): Color = colors.secondaryPaletteKeyColor().getColor(scheme)
+    public fun secondaryPaletteKeyColor(): Color =
+        colors.secondaryPaletteKeyColor().getColor(scheme)
 
     /**
      * Returns the tertiary palette key color.

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/Contrast.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/Contrast.kt
@@ -86,4 +86,5 @@ public enum class ContrastThreshold(
     public operator fun compareTo(value: Double): Int = threshold.compareTo(value)
 }
 
-private operator fun Double.compareTo(threshold: ContrastThreshold): Int = compareTo(threshold.threshold)
+private operator fun Double.compareTo(threshold: ContrastThreshold): Int =
+    compareTo(threshold.threshold)

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/DynamicScheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/DynamicScheme.kt
@@ -5,6 +5,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import com.materialkolor.Contrast
 import com.materialkolor.PaletteStyle
+import com.materialkolor.PaletteStyle.Content
+import com.materialkolor.PaletteStyle.Expressive
+import com.materialkolor.PaletteStyle.Fidelity
+import com.materialkolor.PaletteStyle.FruitSalad
+import com.materialkolor.PaletteStyle.Monochrome
+import com.materialkolor.PaletteStyle.Neutral
+import com.materialkolor.PaletteStyle.Rainbow
+import com.materialkolor.PaletteStyle.TonalSpot
+import com.materialkolor.PaletteStyle.Vibrant
+import com.materialkolor.dynamiccolor.ColorSpec
 import com.materialkolor.internal.asVariant
 import com.materialkolor.scheme.DynamicScheme
 import com.materialkolor.scheme.SchemeContent
@@ -29,24 +39,28 @@ public val DynamicScheme.sourceColor: Color
  * @param[isDark] Whether the scheme should be dark or light.
  * @param[style] The style of the scheme, see [PaletteStyle].
  * @param[contrastLevel] The contrast level of the scheme.
+ * @param[specVersion] The version of the spec to use.
+ * @param[platform] The platform to use.
  * @return The generated [DynamicScheme].
  */
 public fun Color.toDynamicScheme(
     isDark: Boolean,
     style: PaletteStyle,
     contrastLevel: Double = Contrast.Default.value,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: DynamicScheme.Platform = DynamicScheme.Platform.Default,
 ): DynamicScheme {
     val hct = toHct()
     return when (style) {
-        PaletteStyle.TonalSpot -> SchemeTonalSpot(hct, isDark, contrastLevel)
-        PaletteStyle.Neutral -> SchemeNeutral(hct, isDark, contrastLevel)
-        PaletteStyle.Vibrant -> SchemeVibrant(hct, isDark, contrastLevel)
-        PaletteStyle.Expressive -> SchemeExpressive(hct, isDark, contrastLevel)
-        PaletteStyle.Rainbow -> SchemeRainbow(hct, isDark, contrastLevel)
-        PaletteStyle.FruitSalad -> SchemeFruitSalad(hct, isDark, contrastLevel)
-        PaletteStyle.Monochrome -> SchemeMonochrome(hct, isDark, contrastLevel)
-        PaletteStyle.Fidelity -> SchemeFidelity(hct, isDark, contrastLevel)
-        PaletteStyle.Content -> SchemeContent(hct, isDark, contrastLevel)
+        TonalSpot -> SchemeTonalSpot(hct, isDark, contrastLevel, specVersion, platform)
+        Neutral -> SchemeNeutral(hct, isDark, contrastLevel, specVersion, platform)
+        Vibrant -> SchemeVibrant(hct, isDark, contrastLevel, specVersion, platform)
+        Expressive -> SchemeExpressive(hct, isDark, contrastLevel, specVersion, platform)
+        Rainbow -> SchemeRainbow(hct, isDark, contrastLevel)
+        FruitSalad -> SchemeFruitSalad(hct, isDark, contrastLevel)
+        Monochrome -> SchemeMonochrome(hct, isDark, contrastLevel)
+        Fidelity -> SchemeFidelity(hct, isDark, contrastLevel)
+        Content -> SchemeContent(hct, isDark, contrastLevel)
     }
 }
 
@@ -65,6 +79,8 @@ public fun Color.toDynamicScheme(
  * @param[error] The error color of the scheme.
  * @param[style] The style of the scheme.
  * @param[contrastLevel] The contrast level of the scheme.
+ * @param[specVersion] The version of the color specification to use.
+ * @param[platform] The platform to use for the scheme.
  */
 @Composable
 public fun rememberDynamicScheme(
@@ -76,8 +92,10 @@ public fun rememberDynamicScheme(
     neutral: Color? = null,
     neutralVariant: Color? = null,
     error: Color? = null,
-    style: PaletteStyle = PaletteStyle.TonalSpot,
+    style: PaletteStyle = TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: DynamicScheme.Platform = DynamicScheme.Platform.Default,
 ): DynamicScheme =
     remember(
         seedColor,
@@ -90,6 +108,8 @@ public fun rememberDynamicScheme(
         error,
         style,
         contrastLevel,
+        specVersion,
+        platform,
     ) {
         DynamicScheme(
             seedColor = seedColor,
@@ -102,6 +122,8 @@ public fun rememberDynamicScheme(
             error = error,
             style = style,
             contrastLevel = contrastLevel,
+            specVersion = specVersion,
+            platform = platform,
         )
     }
 
@@ -120,6 +142,8 @@ public fun rememberDynamicScheme(
  * @param[error] The error color of the scheme.
  * @param[style] The style of the scheme.
  * @param[contrastLevel] The contrast level of the scheme.
+ * @param[specVersion] The version of the color specification to use.
+ * @param[platform] The platform to use for the scheme.
  */
 public fun DynamicScheme(
     seedColor: Color,
@@ -130,10 +154,12 @@ public fun DynamicScheme(
     neutral: Color? = null,
     neutralVariant: Color? = null,
     error: Color? = null,
-    style: PaletteStyle = PaletteStyle.TonalSpot,
+    style: PaletteStyle = TonalSpot,
     contrastLevel: Double = Contrast.Default.value,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: DynamicScheme.Platform = DynamicScheme.Platform.Default,
 ): DynamicScheme {
-    val defaults = seedColor.toDynamicScheme(isDark, style, contrastLevel)
+    val defaults = seedColor.toDynamicScheme(isDark, style, contrastLevel, specVersion, platform)
 
     return DynamicScheme(
         sourceColorHct = seedColor.toHct(),
@@ -146,5 +172,7 @@ public fun DynamicScheme(
         neutralPalette = neutral?.toTonalPalette() ?: defaults.neutralPalette,
         neutralVariantPalette = neutralVariant?.toTonalPalette() ?: defaults.neutralVariantPalette,
         errorPalette = error?.toTonalPalette() ?: defaults.errorPalette,
+        specVersion = specVersion,
+        platform = platform,
     )
 }

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/MaterialDynamicColors.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/MaterialDynamicColors.kt
@@ -11,7 +11,7 @@ import com.materialkolor.dynamiccolor.MaterialDynamicColors
  */
 public val DynamicMaterialThemeState.m3Colors: MaterialDynamicColors
     @Composable
-    get() = remember(isExtendedFidelity, dynamicScheme) {
+    get() = remember(dynamicScheme) {
         MaterialDynamicColors()
     }
 
@@ -23,6 +23,6 @@ public val DynamicMaterialThemeState.colors: MaterialKolors
     get() {
         val scheme = dynamicScheme
         return remember(scheme) {
-            MaterialKolors(scheme, isAmoled, isExtendedFidelity)
+            MaterialKolors(scheme, isAmoled)
         }
     }

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/Temperature.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/Temperature.kt
@@ -36,7 +36,8 @@ public fun TemperatureCache(input: Color): TemperatureCache = TemperatureCache(i
  * @param[color] The color to calculate the cool-warm factor of.
  * @return below 0 is cool, above 0 is warm.
  */
-public fun TemperatureCache.Companion.temperature(color: Color): Double = rawTemperature(color.toHct())
+public fun TemperatureCache.Companion.temperature(color: Color): Double =
+    rawTemperature(color.toHct())
 
 /**
  * Determine a given color is warm.

--- a/mcu-upstream/src/test/java/hct/Cam16Test.kt
+++ b/mcu-upstream/src/test/java/hct/Cam16Test.kt
@@ -151,7 +151,10 @@ class Cam16Test {
     fun xyzInViewingConditions() {
         val expectedArray = doubleArrayOf(1.0, 2.0, 3.0)
         val actualArray = expectedArray.copyOf()
-        val expected = expectedCam1.xyzInViewingConditions(hct.ViewingConditions.DEFAULT, expectedArray)
+        val expected = expectedCam1.xyzInViewingConditions(
+            hct.ViewingConditions.DEFAULT,
+            expectedArray,
+        )
         val actual = actualCam1.xyzInViewingConditions(ViewingConditions.DEFAULT, actualArray)
         expected.toList() shouldContainExactly actual.toList()
     }

--- a/mcu-upstream/src/test/java/palettes/CorePaletteTest.kt
+++ b/mcu-upstream/src/test/java/palettes/CorePaletteTest.kt
@@ -41,7 +41,9 @@ class CorePaletteTest {
         expected.error shouldBeExactly actual.error
     }
 
-    private infix fun TonalPalette.shouldBeExactly(actual: com.materialkolor.palettes.TonalPalette) {
+    private infix fun TonalPalette.shouldBeExactly(
+        actual: com.materialkolor.palettes.TonalPalette,
+    ) {
         this.hue shouldBe actual.hue
         this.chroma shouldBe actual.chroma
         for (tone in 0..100 step 10) {

--- a/mcu-upstream/src/test/java/temperature/TemperatureCacheTest.kt
+++ b/mcu-upstream/src/test/java/temperature/TemperatureCacheTest.kt
@@ -14,7 +14,12 @@ class TemperatureCacheTest {
         for (color in testColors) {
             val kotlinResult = KotlinTemperatureCache.rawTemperature(Hct.fromInt(color.toInt()))
             val javaResult = JavaTemperatureCache.rawTemperature(hct.Hct.fromInt(color.toInt()))
-            assertEquals(kotlinResult, javaResult, 0.001, "Raw temperature mismatch for color $color")
+            assertEquals(
+                kotlinResult,
+                javaResult,
+                0.001,
+                "Raw temperature mismatch for color $color",
+            )
         }
     }
 


### PR DESCRIPTION
**BREAKING CHANGES**

This PR adds support for the 2025 version of the Color spec, here are the changes:

- extendedFidelity has been removed
    - If you used this property, you must remove it
- All of the builder functions have added a `colorSpec` and `platform` property


For the new color spec check out #278 