### PR TITLE
Upstream: Add color spec and platform to each variant

### DIFF
--- a/material-color-utilities/api/android/material-color-utilities.api
+++ b/material-color-utilities/api/android/material-color-utilities.api
@@ -662,7 +662,8 @@ public final class com/materialkolor/scheme/DynamicScheme$Platform$Companion {
 }
 
 public final class com/materialkolor/scheme/SchemeContent : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeExpressive : com/materialkolor/scheme/DynamicScheme {
@@ -671,15 +672,18 @@ public final class com/materialkolor/scheme/SchemeExpressive : com/materialkolor
 }
 
 public final class com/materialkolor/scheme/SchemeFidelity : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeFruitSalad : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeMonochrome : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeNeutral : com/materialkolor/scheme/DynamicScheme {
@@ -688,7 +692,8 @@ public final class com/materialkolor/scheme/SchemeNeutral : com/materialkolor/sc
 }
 
 public final class com/materialkolor/scheme/SchemeRainbow : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeTonalSpot : com/materialkolor/scheme/DynamicScheme {

--- a/material-color-utilities/api/jvm/material-color-utilities.api
+++ b/material-color-utilities/api/jvm/material-color-utilities.api
@@ -662,7 +662,8 @@ public final class com/materialkolor/scheme/DynamicScheme$Platform$Companion {
 }
 
 public final class com/materialkolor/scheme/SchemeContent : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeExpressive : com/materialkolor/scheme/DynamicScheme {
@@ -671,15 +672,18 @@ public final class com/materialkolor/scheme/SchemeExpressive : com/materialkolor
 }
 
 public final class com/materialkolor/scheme/SchemeFidelity : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeFruitSalad : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeMonochrome : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeNeutral : com/materialkolor/scheme/DynamicScheme {
@@ -688,7 +692,8 @@ public final class com/materialkolor/scheme/SchemeNeutral : com/materialkolor/sc
 }
 
 public final class com/materialkolor/scheme/SchemeRainbow : com/materialkolor/scheme/DynamicScheme {
-	public fun <init> (Lcom/materialkolor/hct/Hct;ZD)V
+	public fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;)V
+	public synthetic fun <init> (Lcom/materialkolor/hct/Hct;ZDLcom/materialkolor/dynamiccolor/ColorSpec$SpecVersion;Lcom/materialkolor/scheme/DynamicScheme$Platform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/materialkolor/scheme/SchemeTonalSpot : com/materialkolor/scheme/DynamicScheme {

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeContent.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeContent.kt
@@ -38,62 +38,62 @@ public class SchemeContent(
     specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
     platform: Platform = Platform.Default,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.CONTENT,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(specVersion)
-        .getPrimaryPalette(
-            variant = Variant.CONTENT,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    secondaryPalette = ColorSpecs
-        .get(specVersion)
-        .getSecondaryPalette(
-            variant = Variant.CONTENT,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    tertiaryPalette = ColorSpecs
-        .get(specVersion)
-        .getTertiaryPalette(
-            variant = Variant.CONTENT,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    neutralPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralPalette(
-            variant = Variant.CONTENT,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    neutralVariantPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralVariantPalette(
-            variant = Variant.CONTENT,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    errorPalette = ColorSpecs
-        .get(specVersion)
-        .getErrorPalette(
-            variant = Variant.CONTENT,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.CONTENT,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(specVersion)
+            .getPrimaryPalette(
+                variant = Variant.CONTENT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        secondaryPalette = ColorSpecs
+            .get(specVersion)
+            .getSecondaryPalette(
+                variant = Variant.CONTENT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        tertiaryPalette = ColorSpecs
+            .get(specVersion)
+            .getTertiaryPalette(
+                variant = Variant.CONTENT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        neutralPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralPalette(
+                variant = Variant.CONTENT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        neutralVariantPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralVariantPalette(
+                variant = Variant.CONTENT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        errorPalette = ColorSpecs
+            .get(specVersion)
+            .getErrorPalette(
+                variant = Variant.CONTENT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeContent.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeContent.kt
@@ -35,63 +35,65 @@ public class SchemeContent(
     sourceColorHct: Hct,
     isDark: Boolean,
     contrastLevel: Double,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: Platform = Platform.Default,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.CONTENT,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getPrimaryPalette(
-                variant = Variant.CONTENT,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        secondaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getSecondaryPalette(
-                variant = Variant.CONTENT,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        tertiaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getTertiaryPalette(
-                variant = Variant.CONTENT,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        neutralPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getNeutralPalette(
-                variant = Variant.CONTENT,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        neutralVariantPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getNeutralVariantPalette(
-                variant = Variant.CONTENT,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        errorPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getErrorPalette(
-                variant = Variant.CONTENT,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-    )
+    sourceColorHct = sourceColorHct,
+    variant = Variant.CONTENT,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(specVersion)
+        .getPrimaryPalette(
+            variant = Variant.CONTENT,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    secondaryPalette = ColorSpecs
+        .get(specVersion)
+        .getSecondaryPalette(
+            variant = Variant.CONTENT,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    tertiaryPalette = ColorSpecs
+        .get(specVersion)
+        .getTertiaryPalette(
+            variant = Variant.CONTENT,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    neutralPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralPalette(
+            variant = Variant.CONTENT,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    neutralVariantPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralVariantPalette(
+            variant = Variant.CONTENT,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    errorPalette = ColorSpecs
+        .get(specVersion)
+        .getErrorPalette(
+            variant = Variant.CONTENT,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFidelity.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFidelity.kt
@@ -36,62 +36,62 @@ public class SchemeFidelity(
     specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
     platform: Platform = Platform.Default,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.FIDELITY,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(specVersion)
-        .getPrimaryPalette(
-            variant = Variant.FIDELITY,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    secondaryPalette = ColorSpecs
-        .get(specVersion)
-        .getSecondaryPalette(
-            variant = Variant.FIDELITY,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    tertiaryPalette = ColorSpecs
-        .get(specVersion)
-        .getTertiaryPalette(
-            variant = Variant.FIDELITY,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    neutralPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralPalette(
-            variant = Variant.FIDELITY,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    neutralVariantPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralVariantPalette(
-            variant = Variant.FIDELITY,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    errorPalette = ColorSpecs
-        .get(specVersion)
-        .getErrorPalette(
-            variant = Variant.FIDELITY,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.FIDELITY,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(specVersion)
+            .getPrimaryPalette(
+                variant = Variant.FIDELITY,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        secondaryPalette = ColorSpecs
+            .get(specVersion)
+            .getSecondaryPalette(
+                variant = Variant.FIDELITY,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        tertiaryPalette = ColorSpecs
+            .get(specVersion)
+            .getTertiaryPalette(
+                variant = Variant.FIDELITY,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        neutralPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralPalette(
+                variant = Variant.FIDELITY,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        neutralVariantPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralVariantPalette(
+                variant = Variant.FIDELITY,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        errorPalette = ColorSpecs
+            .get(specVersion)
+            .getErrorPalette(
+                variant = Variant.FIDELITY,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFidelity.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFidelity.kt
@@ -33,63 +33,65 @@ public class SchemeFidelity(
     sourceColorHct: Hct,
     isDark: Boolean,
     contrastLevel: Double,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: Platform = Platform.Default,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.FIDELITY,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getPrimaryPalette(
-                variant = Variant.FIDELITY,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        secondaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getSecondaryPalette(
-                variant = Variant.FIDELITY,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        tertiaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getTertiaryPalette(
-                variant = Variant.FIDELITY,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        neutralPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getNeutralPalette(
-                variant = Variant.FIDELITY,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        neutralVariantPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getNeutralVariantPalette(
-                variant = Variant.FIDELITY,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        errorPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getErrorPalette(
-                variant = Variant.FIDELITY,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-    )
+    sourceColorHct = sourceColorHct,
+    variant = Variant.FIDELITY,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(specVersion)
+        .getPrimaryPalette(
+            variant = Variant.FIDELITY,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    secondaryPalette = ColorSpecs
+        .get(specVersion)
+        .getSecondaryPalette(
+            variant = Variant.FIDELITY,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    tertiaryPalette = ColorSpecs
+        .get(specVersion)
+        .getTertiaryPalette(
+            variant = Variant.FIDELITY,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    neutralPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralPalette(
+            variant = Variant.FIDELITY,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    neutralVariantPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralVariantPalette(
+            variant = Variant.FIDELITY,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    errorPalette = ColorSpecs
+        .get(specVersion)
+        .getErrorPalette(
+            variant = Variant.FIDELITY,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFruitSalad.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeFruitSalad.kt
@@ -26,63 +26,65 @@ public class SchemeFruitSalad(
     sourceColorHct: Hct,
     isDark: Boolean,
     contrastLevel: Double,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: Platform = Platform.Default,
 ) : DynamicScheme(
         sourceColorHct = sourceColorHct,
         variant = Variant.FRUIT_SALAD,
         isDark = isDark,
         contrastLevel = contrastLevel,
         primaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .get(specVersion)
             .getPrimaryPalette(
                 variant = Variant.FRUIT_SALAD,
                 sourceColorHct = sourceColorHct,
                 isDark = isDark,
-                platform = Platform.PHONE,
+                platform = platform,
                 contrastLevel = contrastLevel,
             ),
         secondaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .get(specVersion)
             .getSecondaryPalette(
                 variant = Variant.FRUIT_SALAD,
                 sourceColorHct = sourceColorHct,
                 isDark = isDark,
-                platform = Platform.PHONE,
+                platform = platform,
                 contrastLevel = contrastLevel,
             ),
         tertiaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .get(specVersion)
             .getTertiaryPalette(
                 variant = Variant.FRUIT_SALAD,
                 sourceColorHct = sourceColorHct,
                 isDark = isDark,
-                platform = Platform.PHONE,
+                platform = platform,
                 contrastLevel = contrastLevel,
             ),
         neutralPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .get(specVersion)
             .getNeutralPalette(
                 variant = Variant.FRUIT_SALAD,
                 sourceColorHct = sourceColorHct,
                 isDark = isDark,
-                platform = Platform.PHONE,
+                platform = platform,
                 contrastLevel = contrastLevel,
             ),
         neutralVariantPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .get(specVersion)
             .getNeutralVariantPalette(
                 variant = Variant.FRUIT_SALAD,
                 sourceColorHct = sourceColorHct,
                 isDark = isDark,
-                platform = Platform.PHONE,
+                platform = platform,
                 contrastLevel = contrastLevel,
             ),
         errorPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
+            .get(specVersion)
             .getErrorPalette(
                 variant = Variant.FRUIT_SALAD,
                 sourceColorHct = sourceColorHct,
                 isDark = isDark,
-                platform = Platform.PHONE,
+                platform = platform,
                 contrastLevel = contrastLevel,
             ),
     )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeMonochrome.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeMonochrome.kt
@@ -26,63 +26,65 @@ public class SchemeMonochrome(
     sourceColorHct: Hct,
     isDark: Boolean,
     contrastLevel: Double,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: Platform = Platform.Default,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.MONOCHROME,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getPrimaryPalette(
-                variant = Variant.MONOCHROME,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        secondaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getSecondaryPalette(
-                variant = Variant.MONOCHROME,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        tertiaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getTertiaryPalette(
-                variant = Variant.MONOCHROME,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        neutralPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getNeutralPalette(
-                variant = Variant.MONOCHROME,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        neutralVariantPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getNeutralVariantPalette(
-                variant = Variant.MONOCHROME,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-        errorPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getErrorPalette(
-                variant = Variant.MONOCHROME,
-                sourceColorHct = sourceColorHct,
-                isDark = isDark,
-                platform = Platform.PHONE,
-                contrastLevel = contrastLevel,
-            ),
-    )
+    sourceColorHct = sourceColorHct,
+    variant = Variant.MONOCHROME,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(specVersion)
+        .getPrimaryPalette(
+            variant = Variant.MONOCHROME,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    secondaryPalette = ColorSpecs
+        .get(specVersion)
+        .getSecondaryPalette(
+            variant = Variant.MONOCHROME,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    tertiaryPalette = ColorSpecs
+        .get(specVersion)
+        .getTertiaryPalette(
+            variant = Variant.MONOCHROME,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    neutralPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralPalette(
+            variant = Variant.MONOCHROME,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    neutralVariantPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralVariantPalette(
+            variant = Variant.MONOCHROME,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    errorPalette = ColorSpecs
+        .get(specVersion)
+        .getErrorPalette(
+            variant = Variant.MONOCHROME,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeMonochrome.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeMonochrome.kt
@@ -29,62 +29,62 @@ public class SchemeMonochrome(
     specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
     platform: Platform = Platform.Default,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.MONOCHROME,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(specVersion)
-        .getPrimaryPalette(
-            variant = Variant.MONOCHROME,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    secondaryPalette = ColorSpecs
-        .get(specVersion)
-        .getSecondaryPalette(
-            variant = Variant.MONOCHROME,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    tertiaryPalette = ColorSpecs
-        .get(specVersion)
-        .getTertiaryPalette(
-            variant = Variant.MONOCHROME,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    neutralPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralPalette(
-            variant = Variant.MONOCHROME,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    neutralVariantPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralVariantPalette(
-            variant = Variant.MONOCHROME,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    errorPalette = ColorSpecs
-        .get(specVersion)
-        .getErrorPalette(
-            variant = Variant.MONOCHROME,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.MONOCHROME,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(specVersion)
+            .getPrimaryPalette(
+                variant = Variant.MONOCHROME,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        secondaryPalette = ColorSpecs
+            .get(specVersion)
+            .getSecondaryPalette(
+                variant = Variant.MONOCHROME,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        tertiaryPalette = ColorSpecs
+            .get(specVersion)
+            .getTertiaryPalette(
+                variant = Variant.MONOCHROME,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        neutralPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralPalette(
+                variant = Variant.MONOCHROME,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        neutralVariantPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralVariantPalette(
+                variant = Variant.MONOCHROME,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        errorPalette = ColorSpecs
+            .get(specVersion)
+            .getErrorPalette(
+                variant = Variant.MONOCHROME,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeRainbow.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeRainbow.kt
@@ -26,63 +26,65 @@ public class SchemeRainbow(
     sourceColorHct: Hct,
     isDark: Boolean,
     contrastLevel: Double,
+    specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
+    platform: Platform = Platform.Default,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.RAINBOW,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getPrimaryPalette(
-                Variant.RAINBOW,
-                sourceColorHct,
-                isDark,
-                Platform.PHONE,
-                contrastLevel,
-            ),
-        secondaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getSecondaryPalette(
-                Variant.RAINBOW,
-                sourceColorHct,
-                isDark,
-                Platform.PHONE,
-                contrastLevel,
-            ),
-        tertiaryPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getTertiaryPalette(
-                Variant.RAINBOW,
-                sourceColorHct,
-                isDark,
-                Platform.PHONE,
-                contrastLevel,
-            ),
-        neutralPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getNeutralPalette(
-                Variant.RAINBOW,
-                sourceColorHct,
-                isDark,
-                Platform.PHONE,
-                contrastLevel,
-            ),
-        neutralVariantPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getNeutralVariantPalette(
-                Variant.RAINBOW,
-                sourceColorHct,
-                isDark,
-                Platform.PHONE,
-                contrastLevel,
-            ),
-        errorPalette = ColorSpecs
-            .get(ColorSpec.SpecVersion.SPEC_2021)
-            .getErrorPalette(
-                Variant.RAINBOW,
-                sourceColorHct,
-                isDark,
-                Platform.PHONE,
-                contrastLevel,
-            ),
-    )
+    sourceColorHct = sourceColorHct,
+    variant = Variant.RAINBOW,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(specVersion)
+        .getPrimaryPalette(
+            variant = Variant.RAINBOW,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    secondaryPalette = ColorSpecs
+        .get(specVersion)
+        .getSecondaryPalette(
+            variant = Variant.RAINBOW,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    tertiaryPalette = ColorSpecs
+        .get(specVersion)
+        .getTertiaryPalette(
+            variant = Variant.RAINBOW,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    neutralPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralPalette(
+            variant = Variant.RAINBOW,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    neutralVariantPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralVariantPalette(
+            variant = Variant.RAINBOW,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    errorPalette = ColorSpecs
+        .get(specVersion)
+        .getErrorPalette(
+            variant = Variant.RAINBOW,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeRainbow.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeRainbow.kt
@@ -29,62 +29,62 @@ public class SchemeRainbow(
     specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
     platform: Platform = Platform.Default,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.RAINBOW,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(specVersion)
-        .getPrimaryPalette(
-            variant = Variant.RAINBOW,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    secondaryPalette = ColorSpecs
-        .get(specVersion)
-        .getSecondaryPalette(
-            variant = Variant.RAINBOW,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    tertiaryPalette = ColorSpecs
-        .get(specVersion)
-        .getTertiaryPalette(
-            variant = Variant.RAINBOW,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    neutralPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralPalette(
-            variant = Variant.RAINBOW,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    neutralVariantPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralVariantPalette(
-            variant = Variant.RAINBOW,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    errorPalette = ColorSpecs
-        .get(specVersion)
-        .getErrorPalette(
-            variant = Variant.RAINBOW,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.RAINBOW,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(specVersion)
+            .getPrimaryPalette(
+                variant = Variant.RAINBOW,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        secondaryPalette = ColorSpecs
+            .get(specVersion)
+            .getSecondaryPalette(
+                variant = Variant.RAINBOW,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        tertiaryPalette = ColorSpecs
+            .get(specVersion)
+            .getTertiaryPalette(
+                variant = Variant.RAINBOW,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        neutralPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralPalette(
+                variant = Variant.RAINBOW,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        neutralVariantPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralVariantPalette(
+                variant = Variant.RAINBOW,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        errorPalette = ColorSpecs
+            .get(specVersion)
+            .getErrorPalette(
+                variant = Variant.RAINBOW,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeTonalSpot.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeTonalSpot.kt
@@ -39,20 +39,20 @@ public class SchemeTonalSpot(
         secondaryPalette = ColorSpecs
             .get(specVersion)
             .getSecondaryPalette(
-                Variant.TONAL_SPOT,
-                sourceColorHct,
-                isDark,
-                platform,
-                contrastLevel,
+                variant = Variant.TONAL_SPOT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
             ),
         tertiaryPalette = ColorSpecs
             .get(specVersion)
             .getTertiaryPalette(
-                Variant.TONAL_SPOT,
-                sourceColorHct,
-                isDark,
-                platform,
-                contrastLevel,
+                variant = Variant.TONAL_SPOT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
             ),
         neutralPalette = ColorSpecs
             .get(specVersion)
@@ -60,11 +60,11 @@ public class SchemeTonalSpot(
         neutralVariantPalette = ColorSpecs
             .get(specVersion)
             .getNeutralVariantPalette(
-                Variant.TONAL_SPOT,
-                sourceColorHct,
-                isDark,
-                platform,
-                contrastLevel,
+                variant = Variant.TONAL_SPOT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
             ),
         errorPalette = ColorSpecs
             .get(specVersion)

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeVibrant.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeVibrant.kt
@@ -29,32 +29,32 @@ public class SchemeVibrant(
     specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
     platform: Platform = Platform.Default,
 ) : DynamicScheme(
-    sourceColorHct = sourceColorHct,
-    variant = Variant.VIBRANT,
-    isDark = isDark,
-    contrastLevel = contrastLevel,
-    primaryPalette = ColorSpecs
-        .get(specVersion)
-        .getPrimaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-    secondaryPalette = ColorSpecs
-        .get(specVersion)
-        .getSecondaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-    tertiaryPalette = ColorSpecs
-        .get(specVersion)
-        .getTertiaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-    neutralPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-    neutralVariantPalette = ColorSpecs
-        .get(specVersion)
-        .getNeutralVariantPalette(
-            variant = Variant.VIBRANT,
-            sourceColorHct = sourceColorHct,
-            isDark = isDark,
-            platform = platform,
-            contrastLevel = contrastLevel,
-        ),
-    errorPalette = ColorSpecs
-        .get(specVersion)
-        .getErrorPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-)
+        sourceColorHct = sourceColorHct,
+        variant = Variant.VIBRANT,
+        isDark = isDark,
+        contrastLevel = contrastLevel,
+        primaryPalette = ColorSpecs
+            .get(specVersion)
+            .getPrimaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+        secondaryPalette = ColorSpecs
+            .get(specVersion)
+            .getSecondaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+        tertiaryPalette = ColorSpecs
+            .get(specVersion)
+            .getTertiaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+        neutralPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+        neutralVariantPalette = ColorSpecs
+            .get(specVersion)
+            .getNeutralVariantPalette(
+                variant = Variant.VIBRANT,
+                sourceColorHct = sourceColorHct,
+                isDark = isDark,
+                platform = platform,
+                contrastLevel = contrastLevel,
+            ),
+        errorPalette = ColorSpecs
+            .get(specVersion)
+            .getErrorPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+    )

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeVibrant.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/scheme/SchemeVibrant.kt
@@ -29,32 +29,32 @@ public class SchemeVibrant(
     specVersion: ColorSpec.SpecVersion = ColorSpec.SpecVersion.Default,
     platform: Platform = Platform.Default,
 ) : DynamicScheme(
-        sourceColorHct = sourceColorHct,
-        variant = Variant.VIBRANT,
-        isDark = isDark,
-        contrastLevel = contrastLevel,
-        primaryPalette = ColorSpecs
-            .get(specVersion)
-            .getPrimaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-        secondaryPalette = ColorSpecs
-            .get(specVersion)
-            .getSecondaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-        tertiaryPalette = ColorSpecs
-            .get(specVersion)
-            .getTertiaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-        neutralPalette = ColorSpecs
-            .get(specVersion)
-            .getNeutralPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-        neutralVariantPalette = ColorSpecs
-            .get(specVersion)
-            .getNeutralVariantPalette(
-                Variant.VIBRANT,
-                sourceColorHct,
-                isDark,
-                platform,
-                contrastLevel,
-            ),
-        errorPalette = ColorSpecs
-            .get(specVersion)
-            .getErrorPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
-    )
+    sourceColorHct = sourceColorHct,
+    variant = Variant.VIBRANT,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    primaryPalette = ColorSpecs
+        .get(specVersion)
+        .getPrimaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+    secondaryPalette = ColorSpecs
+        .get(specVersion)
+        .getSecondaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+    tertiaryPalette = ColorSpecs
+        .get(specVersion)
+        .getTertiaryPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+    neutralPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+    neutralVariantPalette = ColorSpecs
+        .get(specVersion)
+        .getNeutralVariantPalette(
+            variant = Variant.VIBRANT,
+            sourceColorHct = sourceColorHct,
+            isDark = isDark,
+            platform = platform,
+            contrastLevel = contrastLevel,
+        ),
+    errorPalette = ColorSpecs
+        .get(specVersion)
+        .getErrorPalette(Variant.VIBRANT, sourceColorHct, isDark, platform, contrastLevel),
+)

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/DynamicScheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/ktx/DynamicScheme.kt
@@ -56,11 +56,11 @@ public fun Color.toDynamicScheme(
         Neutral -> SchemeNeutral(hct, isDark, contrastLevel, specVersion, platform)
         Vibrant -> SchemeVibrant(hct, isDark, contrastLevel, specVersion, platform)
         Expressive -> SchemeExpressive(hct, isDark, contrastLevel, specVersion, platform)
-        Rainbow -> SchemeRainbow(hct, isDark, contrastLevel)
-        FruitSalad -> SchemeFruitSalad(hct, isDark, contrastLevel)
-        Monochrome -> SchemeMonochrome(hct, isDark, contrastLevel)
-        Fidelity -> SchemeFidelity(hct, isDark, contrastLevel)
-        Content -> SchemeContent(hct, isDark, contrastLevel)
+        Rainbow -> SchemeRainbow(hct, isDark, contrastLevel, specVersion, platform)
+        FruitSalad -> SchemeFruitSalad(hct, isDark, contrastLevel, specVersion, platform)
+        Monochrome -> SchemeMonochrome(hct, isDark, contrastLevel, specVersion, platform)
+        Fidelity -> SchemeFidelity(hct, isDark, contrastLevel, specVersion, platform)
+        Content -> SchemeContent(hct, isDark, contrastLevel, specVersion, platform)
     }
 }
 


### PR DESCRIPTION
For whatever reason these were left out in their initial commit weeks ago, was added recently.
