### PR TITLE
Chore: Unify isDark parameters

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Jordon de Hoog
+Copyright (c) 2025 Jordon de Hoog
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("com.materialkolor:material-kolor:3.0.0-alpha03")
+                implementation("com.materialkolor:material-kolor:3.0.0-alpha04")
             }
         }
     }
@@ -86,7 +86,7 @@ For an Android only project, add the dependency to app level `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.materialkolor:material-kolor:3.0.0-alpha03")
+    implementation("com.materialkolor:material-kolor:3.0.0-alpha04")
 }
 ```
 
@@ -94,10 +94,25 @@ dependencies {
 
 ```toml
 [versions]
-materialKolor = "3.0.0-alpha03"
+materialKolor = "3.0.0-alpha04"
 
 [libraries]
 materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
+```
+
+### Without compose
+
+If you don't use Compose and don't need any of the extension functions provided by `material-kolor`,
+you can use the `material-color-utilities` artifact instead.
+It is a Kotlin Multiplatform port of
+Google's [Material Color Utilities](https://github.com/material-foundation/material-color-utilities).
+
+```toml
+[versions]
+materialKolor = "3.0.0-alpha04"
+
+[libraries]
+materialKolor-utilities = { module = "com.materialkolor:material-color-utilities", version.ref = "materialKolor" }
 ```
 
 ## Usage
@@ -112,11 +127,11 @@ fun MyTheme(
     useDarkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    val colorScheme = rememberDynamicColorScheme(seedColor, useDarkTheme)
+    val colorScheme = rememberDynamicColorScheme(seedColor = seedColor, isDark = useDarkTheme)
 
     MaterialTheme(
         colors = colorScheme,
-        content = content
+        content = content,
     )
 }
 ```
@@ -152,7 +167,7 @@ fun MyTheme(
         seedColor = seedColor,
         isDark = useDarkTheme,
         animate = true,
-        content = content
+        content = content,
     )
 }
 ```
@@ -238,36 +253,8 @@ fun DynamicTheme(image: ImageBitmap, content: @Composable () -> Unit) {
 }
 ```
 
-### Advanced
-
-For a more advanced use-case you can use my other
-library [kmPalette](https://github.com/jordond/kmpalette).
-
-You can get the dominant color from an image, or you can also generate a color palette.
-
-Follow the instructions there to set it up, then as an example. You can use it to generate a color
-theme from a remote image:
-
-```kotlin
-@Composable
-fun SampleTheme(
-    imageUrl: Url, // Url("http://example.com/image.jpg")
-    useDarkTheme: Boolean = isSystemInDarkTheme(),
-    content: @Composable () -> Unit,
-) {
-    val networkLoader = rememberNetworkLoader()
-    val dominantColorState = rememberDominantColorState(loader = networkLoader)
-    LaunchedEffect(imageUrl) {
-        dominantColorState.updateFrom(imageUrl)
-    }
-
-    AnimatedDynamicMaterialTheme(
-        seedColor = dominantColorState.color,
-        isDark = useDarkTheme,
-        content = content
-    )
-}
-```
+**Note:** This approach can be pretty slow, so I wouldn't really recommend using it in your UI
+unless you are eagerly loading the colors.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ seed color:
 @Composable
 fun MyTheme(
     seedColor: Color,
-    useDarkTheme: Boolean = isSystemInDarkTheme(),
+    isDark: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    val colorScheme = rememberDynamicColorScheme(seedColor = seedColor, isDark = useDarkTheme)
+    val colorScheme = rememberDynamicColorScheme(seedColor = seedColor, isDark = isDark)
 
     MaterialTheme(
         colors = colorScheme,
@@ -143,7 +143,7 @@ customize the generated palette:
 ```kotlin
 dynamicColorScheme(
     seedColor = seedColor,
-    isDark = useDarkTheme,
+    isDark = isDark,
     style = PaletteStyle.Vibrant,
 )
 ```
@@ -160,12 +160,12 @@ Example:
 @Composable
 fun MyTheme(
     seedColor: Color,
-    useDarkTheme: Boolean = isSystemInDarkTheme(),
+    isDark: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
     DynamicMaterialTheme(
         seedColor = seedColor,
-        isDark = useDarkTheme,
+        isDark = isDark,
         animate = true,
         content = content,
     )

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,6 @@ org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\=
 
 # Kotlin
 kotlin.code.style=official
-org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
 
 # Android
 android.useAndroidX=true

--- a/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
+++ b/material-kolor/src/commonMain/kotlin/com/materialkolor/DynamicMaterialTheme.kt
@@ -21,7 +21,7 @@ import com.materialkolor.scheme.DynamicScheme
  * @see dynamicColorScheme
  * @see PaletteStyle
  * @param[seedColor] The seed color to use for generating the color scheme.
- * @param[useDarkTheme] Whether to use a dark theme or not.
+ * @param[isDark] Whether to use a dark theme or not.
  * @param[isAmoled] Whether the dark scheme is used with Amoled screen (Pure dark).
  * @param[primary] The custom primary color of the color scheme.
  * @param[secondary] The custom secondary color of the color scheme.
@@ -42,7 +42,7 @@ import com.materialkolor.scheme.DynamicScheme
 @Composable
 public fun DynamicMaterialTheme(
     seedColor: Color,
-    useDarkTheme: Boolean = isSystemInDarkTheme(),
+    isDark: Boolean = isSystemInDarkTheme(),
     isAmoled: Boolean = false,
     primary: Color? = null,
     secondary: Color? = null,
@@ -62,7 +62,7 @@ public fun DynamicMaterialTheme(
 ) {
     val state = rememberDynamicMaterialThemeState(
         seedColor = seedColor,
-        isDark = useDarkTheme,
+        isDark = isDark,
         isAmoled = isAmoled,
         primary = primary,
         secondary = secondary,
@@ -94,7 +94,7 @@ public fun DynamicMaterialTheme(
  * @see dynamicColorScheme
  * @see PaletteStyle
  * @param[primary] The primary color of the color scheme.
- * @param[useDarkTheme] Whether to use a dark theme or not.
+ * @param[isDark] Whether to use a dark theme or not.
  * @param[isAmoled] Whether the dark scheme is used with Amoled screen (Pure dark).
  * @param[secondary] The custom secondary color of the color scheme.
  * @param[tertiary] The custom tertiary color of the color scheme.
@@ -114,7 +114,7 @@ public fun DynamicMaterialTheme(
 @Composable
 public fun DynamicMaterialTheme(
     primary: Color,
-    useDarkTheme: Boolean = isSystemInDarkTheme(),
+    isDark: Boolean = isSystemInDarkTheme(),
     isAmoled: Boolean = false,
     secondary: Color? = null,
     tertiary: Color? = null,
@@ -133,7 +133,7 @@ public fun DynamicMaterialTheme(
 ) {
     val state = rememberDynamicMaterialThemeState(
         primary = primary,
-        isDark = useDarkTheme,
+        isDark = isDark,
         isAmoled = isAmoled,
         secondary = secondary,
         tertiary = tertiary,


### PR DESCRIPTION
In some places `useDarkTheme` was used instead of `isDark`, this PR changes all usages to `isDark`

**BREAKING CHANGES**

- DynamicMaterialTheme.kt:
    - `DynamicMaterialTheme()` now is `isDark`
