### PR TITLE
Build: Remove gradle validation step in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v3
-
       - name: Binary Compatibility Validation
         run: ./gradlew apiCheck --scan
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
-      - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v5
-
       - name: Generate documentation
         run: ./gradlew dokkaGenerate
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
-      - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v5
-
       - name: Deploy to Sonatype
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then


### PR DESCRIPTION
The 'setup-gradle' action now handles this by default

https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation