### PR TITLE
Port upstream fix: yellow hue tone-99 chroma handling

### DIFF
--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2025.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/dynamiccolor/ColorSpec2025.kt
@@ -1787,11 +1787,15 @@ public class ColorSpec2025 : ColorSpec2021() {
         // "recover" intended chroma as contrast increases.
         val palette: TonalPalette = color.palette(scheme)
         val tone = getTone(scheme, color)
-        val hue: Double = palette.hue
-        val chromaMultiplier = color.chromaMultiplier?.invoke(scheme) ?: 1
-        val chroma: Double = palette.chroma * chromaMultiplier.toDouble()
-
-        return Hct.from(hue, chroma, tone)
+        val chromaMultiplier = color.chromaMultiplier?.invoke(scheme) ?: 1.0
+        if (chromaMultiplier == 1.0) {
+            return palette.getHct(tone)
+        }
+        val chroma = palette.chroma * chromaMultiplier
+        if (tone == 99.0 && Hct.isYellow(palette.hue)) {
+            return TonalPalette.fromHueAndChroma(palette.hue, chroma).getHct(tone)
+        }
+        return Hct.from(palette.hue, chroma, tone)
     }
 
     public override fun getTone(

--- a/material-color-utilities/src/commonMain/kotlin/com/materialkolor/palettes/TonalPalette.kt
+++ b/material-color-utilities/src/commonMain/kotlin/com/materialkolor/palettes/TonalPalette.kt
@@ -61,7 +61,12 @@ public class TonalPalette private constructor(
      * @param[tone] HCT tone, measured from 0 to 100.
      * @return HCT representation of a color with that tone.
      */
-    public fun getHct(tone: Double): Hct = Hct.from(hue, chroma, tone)
+    public fun getHct(tone: Double): Hct {
+        if (tone == 99.0 && Hct.isYellow(hue)) {
+            return Hct.fromInt(tone(99))
+        }
+        return Hct.from(hue, chroma, tone)
+    }
 
     /**
      * Key color is a color that represents the hue and chroma of a tonal palette.

--- a/mcu-upstream/src/test/java/palettes/TonalPaletteTest.kt
+++ b/mcu-upstream/src/test/java/palettes/TonalPaletteTest.kt
@@ -60,6 +60,35 @@ class TonalPaletteTest {
         }
     }
 
+    // Regression: ports upstream fix 1a34bd2 from material-color-utilities.
+    // Yellow hues at T99 must route getHct through Hct.fromInt(tone(99)) so the averaged
+    // ARGB from tone(Int) drives the HCT result instead of a direct Hct.from(hue,chroma,99).
+    @Test
+    fun getHct_yellowTone99_matchesAveragedTone() {
+        val yellowHues = listOf(105.0, 110.0, 115.0, 120.0, 124.0)
+        for (hue in yellowHues) {
+            val palette = TonalPalette.fromHueAndChroma(hue, 50.0)
+            val expected = Hct.fromInt(palette.tone(99))
+            val actual = palette.getHct(99.0)
+            actual.hue shouldBe expected.hue
+            actual.chroma shouldBe expected.chroma
+            actual.tone shouldBe expected.tone
+        }
+    }
+
+    @Test
+    fun getHct_nonYellowTone99_unaffected() {
+        val nonYellowHues = listOf(0.0, 60.0, 104.999, 125.0, 240.0, 300.0)
+        for (hue in nonYellowHues) {
+            val palette = TonalPalette.fromHueAndChroma(hue, 50.0)
+            val direct = Hct.from(hue, palette.chroma, 99.0)
+            val viaPalette = palette.getHct(99.0)
+            viaPalette.hue shouldBe direct.hue
+            viaPalette.chroma shouldBe direct.chroma
+            viaPalette.tone shouldBe direct.tone
+        }
+    }
+
     private fun assertPalettesEqual(
         expected: palettes.TonalPalette,
         actual: TonalPalette,


### PR DESCRIPTION
Closes #492

Ports commit [`1a34bd2`](https://github.com/material-foundation/material-color-utilities/commit/1a34bd2) from `google/material-color-utilities`.

## Changes

### `TonalPalette.getHct`
Adds a yellow-hue guard at tone 99, mirroring the existing logic in `TonalPalette.tone(Int)`. Instead of calling `Hct.from` directly at tone 99 for yellow hues, it now delegates to `Hct.fromInt(tone(99))` — which uses the averaged ARGB value already computed by the cache-aware `tone()` function. This keeps both code paths consistent.

### `ColorSpec2025.getHct`
Two improvements:
1. **Short-circuit for the common path**: when `chromaMultiplier == 1.0`, delegate directly to `palette.getHct(tone)` (which now includes the yellow-hue guard) instead of unconditionally reconstructing from raw hue/chroma.
2. **Yellow-hue edge case under chroma scaling**: when a multiplier is applied at tone 99 on a yellow hue, construct a fresh `TonalPalette` with the scaled chroma and call `getHct(tone)` on it, so the averaged tone logic applies correctly.

## Why this matters
Yellow hues near tone 99 can produce slightly inconsistent colors depending on whether the color was computed via `TonalPalette.tone()` (int path, with averaging) or `Hct.from()` (direct path, no averaging). This fix unifies both paths and ensures `getHct` always agrees with `tone()` for yellow palettes at T99.