### PR TITLE
Add consumer ProGuard rules for top-level Kotlin API

### DIFF
--- a/material-kolor/build.gradle.kts
+++ b/material-kolor/build.gradle.kts
@@ -22,6 +22,10 @@ kotlin {
         minSdk = libs.versions.sdk.min.get().toInt()
         namespace = "com.materialkolor"
 
+        defaultConfig {
+            consumerProguardFiles("consumer-rules.pro")
+        }
+
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
         }

--- a/material-kolor/build.gradle.kts
+++ b/material-kolor/build.gradle.kts
@@ -22,8 +22,9 @@ kotlin {
         minSdk = libs.versions.sdk.min.get().toInt()
         namespace = "com.materialkolor"
 
-        defaultConfig {
-            consumerProguardFiles("consumer-rules.pro")
+        optimization {
+            consumerKeepRules.publish = true
+            consumerKeepRules.file("consumer-rules.pro")
         }
 
         compilerOptions {

--- a/material-kolor/consumer-rules.pro
+++ b/material-kolor/consumer-rules.pro
@@ -1,0 +1,5 @@
+# Keep all public top-level Kotlin functions (generated *Kt classes) so that
+# R8/ProGuard does not strip them in release builds of consumer apps.
+# See: https://github.com/jordond/MaterialKolor/issues/493
+-keep public class com.materialkolor.*Kt { public *; }
+-keep public class com.materialkolor.ktx.*Kt { public *; }

--- a/material-kolor/src/jvmMain/resources/META-INF/proguard/material-kolor.pro
+++ b/material-kolor/src/jvmMain/resources/META-INF/proguard/material-kolor.pro
@@ -1,0 +1,8 @@
+# Keep all public top-level Kotlin functions (generated *Kt classes) so that
+# R8/ProGuard does not strip them in release builds of consumer apps.
+# See: https://github.com/jordond/MaterialKolor/issues/493
+#
+# Auto-discovered by R8/ProGuard from META-INF/proguard/ in jvm jar deps.
+# Mirror of material-kolor/consumer-rules.pro (Android consumer rules).
+-keep public class com.materialkolor.*Kt { public *; }
+-keep public class com.materialkolor.ktx.*Kt { public *; }


### PR DESCRIPTION
Closes #493

## Problem

Kotlin top-level functions (e.g. `rememberDynamicColorScheme`, `dynamicColorScheme`) compile to a generated JVM class with a `Kt` suffix — `DynamicColorSchemeKt`, etc. R8/ProGuard can strip these classes in release builds when it cannot statically trace calls into them, resulting in `NoClassDefFoundError` at runtime.

## Fix

**`material-kolor/consumer-rules.pro`** — new file that keeps all public members of generated `*Kt` classes in the two public packages:

```proguard
-keep public class com.materialkolor.*Kt { public *; }
-keep public class com.materialkolor.ktx.*Kt { public *; }
```

**`material-kolor/build.gradle.kts`** — adds `consumerProguardFiles("consumer-rules.pro")` inside `androidLibrary { defaultConfig { … } }` so the rule is automatically bundled into the AAR and applied to any Android consumer's R8/ProGuard pass — no manual configuration needed.

> **Compose Desktop / JVM users** still need to add the rule manually to their app-level ProGuard config, as the `consumerProguardFiles` mechanism is Android-specific.