### PR TITLE
Stop overriding consumer Material3 version on Android

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ kotlin = "2.4.10"
 compose-multiplatform = "1.12.0"
 compose-material3 = "1.12.0-alpha03"
 androidx-annotation = "1.10.0"
+androidx-material3 = "1.5.0-alpha22"
 binaryCompatibility = "0.18.1"
 dokka = "2.2.0"
 publish = "0.37.0"
@@ -48,6 +49,7 @@ buildKonfig = "0.22.0"
 
 [libraries]
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidx-material3" }
 colormath = { module = "com.github.ajalt.colormath:colormath", version.ref = "colormath" }
 errorProneAnnotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "errorProneAnnotations" }
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }

--- a/material-kolor/build.gradle.kts
+++ b/material-kolor/build.gradle.kts
@@ -59,13 +59,19 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.compose.material3)
+            implementation(libs.compose.material3.get().toString()) {
+                exclude(group = "androidx.compose.material3")
+            }
             implementation(libs.compose.foundation)
             implementation(libs.compose.runtime)
             implementation(libs.compose.ui)
             implementation(libs.colormath)
 
             api(project(":material-color-utilities"))
+        }
+
+        androidMain.dependencies {
+            compileOnly(libs.androidx.compose.material3)
         }
 
         commonTest.dependencies {


### PR DESCRIPTION
Fixes #515